### PR TITLE
feat(server-auth): forward all http headers to OPA

### DIFF
--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
@@ -1,0 +1,173 @@
+package org.sdase.commons.server.opa.testing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.IOException;
+import java.util.Map;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.auth.testing.AuthRule;
+import org.sdase.commons.server.opa.testing.test.OpaBundeTestAppConfiguration;
+import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
+import org.sdase.commons.server.testing.DropwizardRuleHelper;
+import org.sdase.commons.server.testing.LazyRule;
+import org.sdase.commons.server.testing.Retry;
+import org.sdase.commons.server.testing.RetryRule;
+
+public class OpaRequestsIT {
+
+  private static final WireMockClassRule WIRE = new WireMockClassRule(
+      wireMockConfig().dynamicPort());
+
+  private static final AuthRule AUTH = AuthRule.builder().build();
+
+  private static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW = new LazyRule<>(
+      () -> DropwizardRuleHelper
+          .dropwizardTestAppFrom(OpaBundleTestApp.class)
+          .withConfigFrom(OpaBundeTestAppConfiguration::new)
+          .withRandomPorts()
+          .withConfigurationModifier(
+              c -> c.getOpa().setBaseUrl(WIRE.baseUrl()).setPolicyPackage("my.policy")) // NOSONAR
+          .withConfigurationModifier(AUTH.applyConfig(OpaBundeTestAppConfiguration::setAuth))
+          .build());
+
+  @ClassRule
+  public static final RuleChain chain = RuleChain.outerRule(WIRE).around(AUTH).around(DW);
+  @Rule
+  public RetryRule retryRule = new RetryRule();
+
+  @BeforeClass
+  public static void start() {
+    WIRE.start();
+  }
+
+
+  private void mock() {
+    WIRE.stubFor(post("/v1/data/my/policy")
+        .willReturn(aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withStatus(200)
+            .withBody("{\n"
+                + "  \"result\": {\n" // NOSONAR
+                + "    \"allow\": true\n"
+                + "  }\n"
+                + "}")
+        )
+    );
+  }
+
+  @Before
+  public void before() {
+    WIRE.resetAll();
+    mock();
+  }
+
+  @Test
+  @Retry(5)
+  public void shouldSerializePathAndMethodCorrectly() throws IOException {
+    // when
+    doGetRequest(null);
+
+    // then
+    String body = WIRE.getAllServeEvents().get(0).getRequest().getBodyAsString();
+    Map<String, Object> opaInput = new ObjectMapper()
+        .readValue(body, new TypeReference<Map<String, Object>>() {
+        });
+
+    basicAssertions(opaInput);
+    assertThat(opaInput).extracting("input").extracting("trace").isNull(); // NOSONAR
+    assertThat(opaInput).extracting("input").extracting("jwt").isNull();
+  }
+
+
+
+  @Test
+  @Retry(5)
+  public void shouldSerializeJwtCorrectly() throws IOException {
+    // when
+    MultivaluedMap<String, Object> headers = AUTH.auth().buildAuthHeader();
+    doGetRequest(headers);
+
+    // then
+    String body = WIRE.getAllServeEvents().get(0).getRequest().getBodyAsString();
+    Map<String, Object> opaInput = new ObjectMapper()
+        .readValue(body, new TypeReference<Map<String, Object>>() {
+        });
+
+    basicAssertions(opaInput);
+    assertThat(opaInput).extracting("input").extracting("trace").isNull();
+    assertThat(opaInput).extracting("input").extracting("jwt")
+        .isEqualTo(((String) headers.getFirst("Authorization")).substring("Bearer ".length()));
+  }
+
+  @Test
+  @Retry(5)
+  public void shouldSerializeTraceTokenCorrectly() throws IOException {
+    // when
+    MultivaluedMap<String, Object> headers = AUTH.auth().buildAuthHeader();
+    headers.add("Trace-Token", "myTrace");
+    doGetRequest(headers);
+
+    // then
+    String body = WIRE.getAllServeEvents().get(0).getRequest().getBodyAsString();
+    Map<String, Object> opaInput = new ObjectMapper()
+        .readValue(body, new TypeReference<Map<String, Object>>() {
+        });
+
+    basicAssertions(opaInput);
+    assertThat(opaInput).extracting("input").extracting("trace").isEqualTo("myTrace");
+  }
+
+
+  @Test
+  @Retry(5)
+  public void shouldSerializeAdditionalHeaderCorrectly() throws IOException {
+    // when
+    MultivaluedMap<String, Object> headers = AUTH.auth().buildAuthHeader();
+    headers.add("Simple", "SimpleValue");
+    headers.add("Complex", "1");
+    headers.add("Complex", "2");
+    doGetRequest(headers);
+
+    // then
+    String body = WIRE.getAllServeEvents().get(0).getRequest().getBodyAsString();
+    Map<String, Object> opaInput = new ObjectMapper()
+        .readValue(body, new TypeReference<Map<String, Object>>() {
+        });
+
+    basicAssertions(opaInput);
+    //noinspection unchecked,ConstantConditions
+    Map<String, Object> extractedHeaders = (Map<String, Object>) ((Map<String, Object>) opaInput
+        .get("input")).get("headers");
+    assertThat(extractedHeaders).extracting("simple").asList().containsExactly("SimpleValue");
+    assertThat(extractedHeaders).extracting("complex").asList().containsExactly("1,2");
+  }
+
+  private void doGetRequest(MultivaluedMap<String, Object> headers) {
+    Response response = DW.getRule().client()
+        .target("http://localhost:" + DW.getRule().getLocalPort()).path("resources").request()
+        .headers(headers).get();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  private void basicAssertions(Map<String, Object> opaInput) {
+    assertThat(opaInput).extracting("input").extracting("httpMethod").isEqualTo("GET");
+    assertThat(opaInput).extracting("input").extracting("path").asList()
+        .containsExactly("resources");
+  }
+
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
@@ -64,7 +64,7 @@ public class OpaResponsesIT {
               + "    \"path\": [\"resources\"],\n"
               + "    \"httpMethod\":\"GET\"\n"
               + "  }\n" // NOSONAR
-              + "}"))
+              + "}", true, true))
           .willReturn(aResponse()
               .withHeader("Content-Type", "application/json")
               .withStatus(status)

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRuleIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRuleIT.java
@@ -1,15 +1,6 @@
 package org.sdase.commons.server.opa.testing;
 
-import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
-import static org.apache.http.HttpStatus.SC_OK;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.sdase.commons.server.opa.testing.OpaRule.onAnyRequest;
-import static org.sdase.commons.server.opa.testing.OpaRule.onRequest;
-
 import com.github.tomakehurst.wiremock.client.VerificationException;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import org.glassfish.jersey.client.JerseyClientBuilder;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -21,6 +12,16 @@ import org.sdase.commons.server.opa.filter.model.OpaResponse;
 import org.sdase.commons.server.opa.testing.test.ConstraintModel;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sdase.commons.server.opa.testing.OpaRule.onAnyRequest;
+import static org.sdase.commons.server.opa.testing.OpaRule.onRequest;
 
 public class OpaRuleIT {
 
@@ -137,7 +138,11 @@ public class OpaRuleIT {
    }
 
    private OpaRequest request(String method, String... path) {
-      return new OpaRequest().setInput(new OpaInput().setHttpMethod(method).setPath(path));
+      return new OpaRequest().setInput(new OpaInput()
+          .setJwt(null)
+          .setHttpMethod(method)
+          .setPath(path)
+          .setHeaders(null)
+      );
    }
-
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaBundeTestAppConfiguration.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaBundeTestAppConfiguration.java
@@ -1,9 +1,12 @@
 package org.sdase.commons.server.opa.testing.test;
 
 import io.dropwizard.Configuration;
+import org.sdase.commons.server.auth.config.AuthConfig;
 import org.sdase.commons.server.opa.config.OpaConfig;
 
 public class OpaBundeTestAppConfiguration extends Configuration {
+
+  private AuthConfig auth = new AuthConfig();
 
   private OpaConfig opa = new OpaConfig();
 
@@ -11,9 +14,17 @@ public class OpaBundeTestAppConfiguration extends Configuration {
     return opa;
   }
 
-  public OpaBundeTestAppConfiguration setOpa(
-      OpaConfig opa) {
+  public OpaBundeTestAppConfiguration setOpa(OpaConfig opa) {
     this.opa = opa;
+    return this;
+  }
+
+  public AuthConfig getAuth() {
+    return auth;
+  }
+
+  public OpaBundeTestAppConfiguration setAuth(AuthConfig auth) {
+    this.auth = auth;
     return this;
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaBundleTestApp.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaBundleTestApp.java
@@ -3,6 +3,7 @@ package org.sdase.commons.server.opa.testing.test;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import org.sdase.commons.server.auth.AuthBundle;
 import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
 import org.sdase.commons.server.opa.OpaBundle;
 import org.sdase.commons.server.swagger.SwaggerBundle;
@@ -12,6 +13,7 @@ public class OpaBundleTestApp extends Application<OpaBundeTestAppConfiguration> 
   @Override
   public void initialize(Bootstrap<OpaBundeTestAppConfiguration> bootstrap) {
     bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build());
+    bootstrap.addBundle(AuthBundle.builder().withAuthConfigProvider(OpaBundeTestAppConfiguration::getAuth).withExternalAuthorization().build());
     bootstrap.addBundle(SwaggerBundle.builder().withTitle("Test").addResourcePackageClass(OpaBundleTestApp.class).build());
     bootstrap.addBundle(OpaBundle.builder().withOpaConfigProvider(OpaBundeTestAppConfiguration::getOpa).build());
   }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaInput.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaInput.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.opa.filter.model;
 
+import javax.ws.rs.core.MultivaluedMap;
+
 public class OpaInput {
 
   /**
@@ -22,15 +24,21 @@ public class OpaInput {
    */
   private String httpMethod;
 
+  /**
+   * Additional, optional headers that get passed to the OPA service.
+   */
+  private MultivaluedMap<String, String> headers;
+
   public OpaInput() {
     // nothing here, just for Jackson
   }
 
-  OpaInput(String jwt, String[] path, String httpMethod, String traceToken) {
+  OpaInput(String jwt, String[] path, String httpMethod, String traceToken, MultivaluedMap<String, String> headers) {
     this.jwt = jwt;
     this.path = path;
     this.httpMethod = httpMethod;
     this.trace = traceToken;
+    this.headers = headers;
   }
 
   public String getJwt() {
@@ -66,6 +74,15 @@ public class OpaInput {
 
   public OpaInput setTrace(String trace) {
     this.trace = trace;
+    return this;
+  }
+
+  public MultivaluedMap<String, String> getHeaders() {
+    return headers;
+  }
+
+  public OpaInput setHeaders(MultivaluedMap<String, String> headers) {
+    this.headers = headers;
     return this;
   }
 }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaRequest.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaRequest.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.opa.filter.model;
 
+import javax.ws.rs.core.MultivaluedMap;
 
 public class OpaRequest {
 
@@ -23,8 +24,9 @@ public class OpaRequest {
     return this;
   }
 
-  public static OpaRequest request(String jwt, String[] path, String method, String traceToken) {
-    return new OpaRequest(new OpaInput(jwt, path, method, traceToken));
+  public static OpaRequest request(String jwt, String[] path, String method, String traceToken,
+                                   MultivaluedMap<String, String> headers) {
+    return new OpaRequest(new OpaInput(jwt, path, method, traceToken, headers));
   }
 
 }


### PR DESCRIPTION
This change forwards all incoming HTTP headers to the OPA-Input. They are available as input.headers.<header-name>. We implement this in the scope of KAP-1149 to introduce a way to pass information from the service to the OPA.