### PR TITLE
chore: remove OWASP dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'jacoco'
-    id 'org.owasp.dependencycheck' version '4.0.2'
     id 'org.sonarqube' version '2.8'
 }
 
@@ -63,7 +62,6 @@ subprojects {
 configure(subprojects.findAll {it.name != 'sda-commons-bom' && it.name != 'sda-commons-dependencies'}) {
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'org.owasp.dependencycheck'
 
     sourceCompatibility = 1.8
 

--- a/sda-commons-server-kafka-confluent-testing/build.gradle
+++ b/sda-commons-server-kafka-confluent-testing/build.gradle
@@ -1,8 +1,3 @@
-dependencyCheck {
-    skip=true
-}
-
-
 dependencies {
 
     compile project(':sda-commons-server-kafka-testing')


### PR DESCRIPTION
For now we have to remove the OWASP dependency check as it doesn't work. The current referenced version 4.0.2 doesn't work with our project setup. The latest version 5.3.0 does, however has a version conflict with the current version of the AVRO code generator plugin (velocity templates dependency). This is fixed in the latest version of the AVRO code generator plugin, however this is only compatible to the latest Confluent, Avro and Kafka versions. We still have a Kafka (and related components) upgrade on our roadmap.
However, as we also expect our downstream project to scan for dependency issues using OWASP dependency check, we should still stay alerted about dependency issues. In addition dependabot is configured to provide use with security updates.