### PR TITLE
Keep the MacOS firewall silent when executing tests with MongoDB

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -77,12 +77,18 @@ public class MongoDbRule extends ExternalResource {
       static final MongodStarter INSTANCE = getMongoStarter();
 
       private static MongodStarter getMongoStarter() {
+         de.flapdoodle.embed.process.store.ExtractedArtifactStoreBuilder artifactStoreBuilder = new ExtractedArtifactStoreBuilder()
+               .defaults(Command.MongoD)
+               .download(createDownloadConfig());
+         // avoid recurring firewall requests on mac,
+         // see https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo/issues/40#issuecomment-14969151
+         if (SystemUtils.IS_OS_MAC_OSX) {
+            artifactStoreBuilder.executableNaming((prefix, postfix) -> "mongod");
+         }
          return MongodStarter
                .getInstance(new RuntimeConfigBuilder()
                      .defaults(Command.MongoD)
-                     .artifactStore(new ExtractedArtifactStoreBuilder()
-                           .defaults(Command.MongoD)
-                           .download(createDownloadConfig()))
+                     .artifactStore(artifactStoreBuilder)
                      .build());
       }
 


### PR DESCRIPTION
Since the latest update MacOS asks for every started MongoDB in test for
firewall access confirmation. When keeping the executable name fixed,
this confirmation request only annoys once.

- [ ] ~fix `FileAlreadyExistsException` when multiple tests are executed at the same time~