### PR TITLE
feat(client-jersey): add transferRequestContext to use the Jersey cli…

### DIFF
--- a/sda-commons-client-jersey/README.md
+++ b/sda-commons-client-jersey/README.md
@@ -152,6 +152,20 @@ To support sending multipart requests like file uploads, `sda-commons-shared-for
 
 The client is the configured automatically to support multipart.
 
+
+## Concurrency
+
+If you plan to use the Jersey client from another thread, note that the authorization from the request context and the trace token are missing.
+This can cause issues.
+You can use `ContainerRequestContextHolder.transferRequestContext` to transfer the request context and `MDC` to another thread.
+
+```java
+executorService.submit(transferRequestContext(() -> {
+  // MDC.get("Trace-Token") returns the same value as the parent thread
+})).get();
+```
+
+
 ## Tips and Tricks
 
 ### 3rd Party `javax.ws.rs-api` Client Implementations in Classpath

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/filter/ContainerRequestContextHolderTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/filter/ContainerRequestContextHolderTest.java
@@ -1,0 +1,90 @@
+package org.sdase.commons.client.jersey.filter;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.sdase.commons.client.jersey.filter.ContainerRequestContextHolder.transferRequestContext;
+
+import java.net.URI;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.glassfish.jersey.internal.MapPropertiesDelegate;
+import org.glassfish.jersey.server.ContainerRequest;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+public class ContainerRequestContextHolderTest {
+
+  @Test
+  public void shouldTransferRequestContextToThreadForRunnable()
+      throws InterruptedException, ExecutionException {
+    initializeContext();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    executorService.submit(transferRequestContext(() -> {
+      assertThat(MDC.get("Trace-Token")).isEqualTo("a-trace-token");
+      assertThat(new AuthHeaderClientFilter().getHeaderValue().orElse(null)).isEqualTo("an-access-token");
+    })).get();
+
+    executorService.shutdown();
+  }
+
+  @Test
+  public void shouldTransferRequestContextToThreadForCallable()
+      throws ExecutionException, InterruptedException {
+    initializeContext();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    int result = executorService.submit(transferRequestContext(() -> {
+      assertThat(MDC.get("Trace-Token")).isEqualTo("a-trace-token");
+      assertThat(new AuthHeaderClientFilter().getHeaderValue().orElse(null)).isEqualTo("an-access-token");
+      return 42;
+    })).get();
+
+    assertThat(result).isEqualTo(42);
+
+    executorService.shutdown();
+  }
+
+  @Test
+  public void shouldCleanupAfterTransferRequestContextToThreadForRunnable()
+      throws InterruptedException, ExecutionException {
+    initializeContext();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    executorService.submit(transferRequestContext(() -> {})).get();
+    executorService.submit(() -> {
+      // As the thread is reused, we expect it to be cleaned.
+      assertThat(MDC.get("Trace-Token")).isNull();
+      assertThat(new AuthHeaderClientFilter().getHeaderValue().isPresent()).isFalse();
+    }).get();
+
+    executorService.shutdown();
+  }
+
+  @Test
+  public void shouldCleanupAfterTransferRequestContextToThreadForCallable()
+      throws ExecutionException, InterruptedException {
+    initializeContext();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    executorService.submit(transferRequestContext(() -> {})).get();
+    executorService.submit(() -> {
+      // As the thread is reused, we expect it to be cleaned.
+      assertThat(MDC.get("Trace-Token")).isNull();
+      assertThat(new AuthHeaderClientFilter().getHeaderValue().isPresent()).isFalse();
+      return 42;
+    }).get();
+
+    executorService.shutdown();
+  }
+
+  private void initializeContext() {
+    MDC.put("Trace-Token", "a-trace-token");
+    ContainerRequest containerRequest = new ContainerRequest(
+        URI.create("http://example.com"), URI.create("http://example.com/path"), "PUT", null,
+        new MapPropertiesDelegate());
+    containerRequest.header(AUTHORIZATION, "an-access-token");
+    new ContainerRequestContextHolder().filter(containerRequest);
+  }
+}

--- a/sda-commons-server-trace/README.md
+++ b/sda-commons-server-trace/README.md
@@ -15,6 +15,7 @@ The calls can be correlated in logs and metrics using this trace token that is a
 
 When using new threads for clients to invoke another service, the trace token is not transferred out-of-the-box. 
 The same holds for mentioning the trace token in log entries of new threads.
+See the documentation about [concurrency](../sda-commons-client-jersey/README.md#concurrency) on how to transfer this context into another thread.
 
 
 ## Usage


### PR DESCRIPTION
…ent in different threads

transferRequestContext transfers the request context and MDC to provide access to the Authorization and Trace-Token in another thread by the Jersey client.