### PR TITLE
feat: add tracing to admin port

### DIFF
--- a/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/OpenTracingBundle.java
+++ b/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/OpenTracingBundle.java
@@ -23,6 +23,7 @@ import javax.servlet.FilterRegistration.Dynamic;
 import org.sdase.commons.server.opentracing.jaxrs.CustomServerSpanDecorator;
 import org.sdase.commons.server.opentracing.jaxrs.ExceptionListener;
 import org.sdase.commons.server.opentracing.logging.SpanLogsAppender;
+import org.sdase.commons.server.opentracing.servlet.AdminServletSpanDecorator;
 import org.sdase.commons.server.opentracing.servlet.CustomServletSpanDecorator;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,6 @@ public class OpenTracingBundle implements Bundle {
   private void registerServletFilter(Tracer currentTracer, Environment environment) {
     List<ServletFilterSpanDecorator> decorators =
         asList(ServletFilterSpanDecorator.STANDARD_TAGS, new CustomServletSpanDecorator());
-
     TracingFilter filter = new TracingFilter(currentTracer, decorators, null);
     FilterRegistration.Dynamic filterRegistration =
         environment.servlets().addFilter("TracingFilter", filter);
@@ -69,7 +69,12 @@ public class OpenTracingBundle implements Bundle {
 
     // The admin endpoint only has servlet support. Tracing this allows to filter health checks and
     // metrics.
-    TracingFilter adminFilter = new TracingFilter(currentTracer, decorators, null);
+    List<ServletFilterSpanDecorator> adminDecorators =
+        asList(
+            ServletFilterSpanDecorator.STANDARD_TAGS,
+            new CustomServletSpanDecorator(),
+            new AdminServletSpanDecorator());
+    TracingFilter adminFilter = new TracingFilter(currentTracer, adminDecorators, null);
     FilterRegistration.Dynamic adminFilterRegistration =
         environment.admin().addFilter("AdminTracingFilter", adminFilter);
     adminFilterRegistration.addMappingForUrlPatterns(

--- a/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/servlet/AdminServletSpanDecorator.java
+++ b/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/servlet/AdminServletSpanDecorator.java
@@ -1,0 +1,47 @@
+package org.sdase.commons.server.opentracing.servlet;
+
+import static io.opentracing.tag.Tags.SAMPLING_PRIORITY;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.web.servlet.filter.ServletFilterSpanDecorator;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AdminServletSpanDecorator implements ServletFilterSpanDecorator {
+
+  private static final String JAEGER_DEBUG_ID = "jaeger-debug-id";
+
+  @Override
+  public void onRequest(HttpServletRequest httpServletRequest, Span span) {
+    // Avoid that the admin endpoint's spans are sampled. This is implementation specific and not
+    // guaranteed, but Jaeger avoids sampling them and their children.
+    // However, still keep the option to sample if the Jaeger debug id is present.
+    if (httpServletRequest.getHeader(JAEGER_DEBUG_ID) == null) {
+      span.setTag(SAMPLING_PRIORITY, 0);
+    }
+  }
+
+  @Override
+  public void onResponse(
+      HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, Span span) {
+    // No special tags
+  }
+
+  @Override
+  public void onError(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      Throwable exception,
+      Span span) {
+    // No special tags
+  }
+
+  @Override
+  public void onTimeout(
+      HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse,
+      long timeout,
+      Span span) {
+    // No special tags
+  }
+}

--- a/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
+++ b/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
@@ -62,9 +62,10 @@ public class OpenTracingBundleTest {
 
     await()
         .untilAsserted(
-            () -> {
-              assertThat(tracer.finishedSpans()).flatExtracting(MockSpan::parentId).contains(1337L);
-            });
+            () ->
+                assertThat(tracer.finishedSpans())
+                    .flatExtracting(MockSpan::parentId)
+                    .contains(1337L));
   }
 
   @Test
@@ -78,12 +79,11 @@ public class OpenTracingBundleTest {
 
     await()
         .untilAsserted(
-            () -> {
-              assertThat(tracer.finishedSpans())
-                  .flatExtracting(MockSpan::tags)
-                  .extracting(COMPONENT.getKey())
-                  .contains("java-web-servlet");
-            });
+            () ->
+                assertThat(tracer.finishedSpans())
+                    .flatExtracting(MockSpan::tags)
+                    .extracting(COMPONENT.getKey())
+                    .contains("java-web-servlet"));
   }
 
   @Test
@@ -97,12 +97,11 @@ public class OpenTracingBundleTest {
 
     await()
         .untilAsserted(
-            () -> {
-              assertThat(tracer.finishedSpans())
-                  .flatExtracting(MockSpan::tags)
-                  .extracting(COMPONENT.getKey())
-                  .contains("jaxrs");
-            });
+            () ->
+                assertThat(tracer.finishedSpans())
+                    .flatExtracting(MockSpan::tags)
+                    .extracting(COMPONENT.getKey())
+                    .contains("jaxrs"));
   }
 
   @Test
@@ -259,7 +258,29 @@ public class OpenTracingBundleTest {
             });
   }
 
+  @Test
+  public void shouldInstrumentAdminServlets() {
+    Response r = createAdminClient().path("healthcheck").request().get();
+
+    // Make sure to wait till the request is completed:
+    r.readEntity(String.class);
+
+    assertThat(r.getStatus()).isEqualTo(SC_OK);
+
+    await()
+        .untilAsserted(
+            () ->
+                assertThat(tracer.finishedSpans())
+                    .flatExtracting(MockSpan::tags)
+                    .extracting(COMPONENT.getKey())
+                    .contains("java-web-servlet"));
+  }
+
   private WebTarget createClient() {
     return dw.client().target("http://localhost:" + dw.getLocalPort());
+  }
+
+  private WebTarget createAdminClient() {
+    return dw.client().target("http://localhost:" + dw.getAdminPort());
   }
 }


### PR DESCRIPTION
While one normally don't want to trace the admin port, this allows to group the spans that are currently emitted by health checks. Later on we can disable tracing for these spans and their child spans.