### PR TITLE
fix(server-swagger): support reading the embedded fields from an arra…

### DIFF
--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/HouseSearchResource.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/HouseSearchResource.java
@@ -1,0 +1,35 @@
+package org.sdase.commons.server.swagger;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+@ApiModel("HouseSearchResource")
+public class HouseSearchResource {
+
+  @ApiModelProperty(value = "A list of found houses", required = true)
+  private List<HouseResource> houses = new ArrayList<>();
+
+  @ApiModelProperty(value = "The total count of houses", required = true)
+  private int totalCount;
+
+  @JsonCreator
+  public HouseSearchResource(
+      @JsonProperty("houses") List<HouseResource> houses,
+      @JsonProperty("totalCount") int totalCount) {
+
+    this.houses.addAll(houses);
+    this.totalCount = totalCount;
+  }
+
+  public List<HouseResource> getHouses() {
+    return houses;
+  }
+
+  public int getTotalCount() {
+    return totalCount;
+  }
+}

--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleIT.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleIT.java
@@ -119,7 +119,10 @@ public class SwaggerBundleIT {
   public void shouldIncludePaths() {
     String response = getJsonRequest().get(String.class);
 
-    assertThatJson(response).inPath("$.paths").isObject().containsOnlyKeys("/jdoe", "/house");
+    assertThatJson(response)
+        .inPath("$.paths")
+        .isObject()
+        .containsOnlyKeys("/jdoe", "/house", "/houses");
 
     assertThatJson(response)
         .inPath("$.paths./jdoe")
@@ -127,6 +130,8 @@ public class SwaggerBundleIT {
         .containsOnlyKeys("get", "post", "delete");
 
     assertThatJson(response).inPath("$.paths./house").isObject().containsOnlyKeys("get");
+
+    assertThatJson(response).inPath("$.paths./houses").isObject().containsOnlyKeys("get");
   }
 
   @Test
@@ -184,6 +189,16 @@ public class SwaggerBundleIT {
 
     assertThatJson(response)
         .inPath("$.paths./house.get.parameters[0].items.enum")
+        .isArray()
+        .containsOnly("animals", "partners");
+  }
+
+  @Test
+  public void shouldIncludeEmbedParameterForNestedProperty() {
+    String response = getJsonRequest().get(String.class);
+
+    assertThatJson(response)
+        .inPath("$.paths./houses.get.parameters[0].items.enum")
         .isArray()
         .containsOnly("animals", "partners");
   }

--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleTestApp.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleTestApp.java
@@ -97,4 +97,12 @@ public class SwaggerBundleTestApp extends Application<Configuration> {
     return new HouseResource(
         Collections.emptyList(), Collections.emptyList(), new HALLink.Builder(self).build());
   }
+
+  @GET
+  @Path("/houses")
+  @Produces(APPLICATION_JSON)
+  @ApiResponses(@ApiResponse(code = 200, message = "get", response = HouseSearchResource.class))
+  public HouseSearchResource searchHouse() {
+    return new HouseSearchResource(Collections.emptyList(), 0);
+  }
 }


### PR DESCRIPTION
…y-property

This change is useful for endpoints that return a wrapper objects e.g. for paging but still want to have the embed parameter documentation generated correctly.