### PR TITLE
fix(server-jaeger): shutdown jaeger tracer on application exit

### DIFF
--- a/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
+++ b/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
@@ -79,6 +79,7 @@ public class JaegerBundle implements Bundle {
     // It's not perfect that GlobalTracerTestUtil comes from a test-jar, but
     // we could also copy the code into this project.
     environment.lifecycle().manage(onShutdown(GlobalTracerTestUtil::resetGlobalTracer));
+    environment.lifecycle().manage(onShutdown(tracer::close));
     environment.lifecycle().manage(prometheusMetricsFactory);
   }
 


### PR DESCRIPTION
Jaeger automatically shuts down on JVM exit. However, we are running mutliple Drowpizard applications during testing without shutting down the Jaeger tracer. This can cause memory leaks.