### PR TITLE
feat: add support for JSON logging

### DIFF
--- a/sda-commons-server-dropwizard/README.md
+++ b/sda-commons-server-dropwizard/README.md
@@ -77,3 +77,7 @@ public void initialize(Bootstrap<Configuration> bootstrap) {
     bootstrap.addBundle(DefaultLoggingConfigurationBundle.builder().build());
 }
 ```
+
+To enable [JSON logging](https://www.dropwizard.io/en/latest/manual/core.html#logging), set the environment variable `ENABLE_JSON_LOGGING` to `"true"`.
+We recommend JSON logging in production as they are better parsable by tools.
+However they are hard to read for human beings, so better deactivate them when working with a service locally.

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -1,10 +1,12 @@
 dependencies {
   compile 'io.dropwizard:dropwizard-core'
+  compile 'io.dropwizard:dropwizard-json-logging'
 
   // should not be needed in Dropwizard 2 (https://github.com/dropwizard/dropwizard/issues/2318#issuecomment-485385183)
   compile 'javax.activation:javax.activation-api'
   compile 'javax.xml.bind:jaxb-api'
 
+  testCompile project(':sda-commons-server-testing')
   testCompile 'junit:junit'
   testCompile 'org.assertj:assertj-core'
   testCompile 'io.dropwizard:dropwizard-testing'

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundle.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundle.java
@@ -7,7 +7,8 @@ import org.sdase.commons.server.dropwizard.logging.ConsoleAppenderInjectorSource
 
 /**
  * The {@code DefaultLoggingConfigurationBundle} allows to configure the console logger with the
- * settings desired by the SDA.
+ * settings desired by the SDA. Requires that the environment variable {@code ENABLE_JSON_LOGGING}
+ * is set to {@code "true"}.
  */
 public class DefaultLoggingConfigurationBundle implements Bundle {
   public static Builder builder() {

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.dropwizard.logging;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
 import io.dropwizard.configuration.ConfigurationSourceProvider;
@@ -49,6 +51,7 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
         }
 
         applyLogging(root);
+        applyServer(root);
       } catch (ClassCastException ex) {
         LOG.error("Unable to inject console appender config, invalid config format");
       }
@@ -62,17 +65,17 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
     root.putIfAbsent("logging", new HashMap<String, Object>());
     @SuppressWarnings("unchecked")
     Map<String, Object> logging = (Map<String, Object>) root.get("logging");
-    applyAppenders(logging);
+    applyLoggingAppenders(logging);
   }
 
-  private void applyAppenders(Map<String, Object> logging) {
+  private void applyLoggingAppenders(Map<String, Object> logging) {
     logging.putIfAbsent("appenders", new ArrayList<>());
     @SuppressWarnings("unchecked")
     List<Object> appenders = (List<Object>) logging.get("appenders");
-    applyConsoleAppender(appenders);
+    applyLoggingConsoleAppender(appenders);
   }
 
-  private void applyConsoleAppender(List<Object> appenders) {
+  private void applyLoggingConsoleAppender(List<Object> appenders) {
     AtomicBoolean foundConsoleAppender = new AtomicBoolean();
     appenders.forEach(
         a -> {
@@ -81,33 +84,106 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
             Map<String, Object> appender = (Map<String, Object>) a;
 
             if ("console".equals((appender).get("type"))) {
-              applyConsoleAppenderDefaults(appender);
+              applyLoggingConsoleAppenderDefaults(appender);
               foundConsoleAppender.set(true);
             }
           }
         });
 
     if (!foundConsoleAppender.get()) {
-      Map<String, Object> consoleAppender = createConsoleAppender();
-      applyConsoleAppenderDefaults(consoleAppender);
+      Map<String, Object> consoleAppender = createLoggingConsoleAppender();
+      applyLoggingConsoleAppenderDefaults(consoleAppender);
       appenders.add(consoleAppender);
     }
   }
 
-  private Map<String, Object> createConsoleAppender() {
+  private Map<String, Object> createLoggingConsoleAppender() {
     Map<String, Object> consoleAppender = new HashMap<>();
     consoleAppender.put("type", "console");
     return consoleAppender;
   }
 
-  private void applyConsoleAppenderDefaults(Map<String, Object> consoleAppender) {
+  private void applyLoggingConsoleAppenderDefaults(Map<String, Object> consoleAppender) {
     consoleAppender.putIfAbsent("threshold", DEFAULT_THRESHOLD);
     consoleAppender.putIfAbsent("logFormat", DEFAULT_LOG_FORMAT);
+
+    if ("true".equals(System.getenv("ENABLE_JSON_LOGGING"))) {
+      consoleAppender.putIfAbsent("layout", createLoggingConsoleAppenderLayout());
+    }
 
     if (!DEFAULT_LOG_FORMAT.equals(consoleAppender.get("logFormat"))) {
       LOG.warn(
           "The current console appender log format does not comply to the format expected "
               + "by our logging pipeline. This might cause unexpected behavior.");
     }
+  }
+
+  private Map<String, Object> createLoggingConsoleAppenderLayout() {
+    Map<String, Object> consoleAppenderLayout = new HashMap<>();
+    consoleAppenderLayout.put("type", "json");
+    return consoleAppenderLayout;
+  }
+
+  private void applyServer(Map<String, Object> root) {
+    root.putIfAbsent("server", new HashMap<String, Object>());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> server = (Map<String, Object>) root.get("server");
+    applyRequestLog(server);
+  }
+
+  private void applyRequestLog(Map<String, Object> server) {
+    server.putIfAbsent("requestLog", new HashMap<String, Object>());
+    @SuppressWarnings("unchecked")
+    Map<String, Object> requestLog = (Map<String, Object>) server.get("requestLog");
+    applyRequestLogAppenders(requestLog);
+  }
+
+  private void applyRequestLogAppenders(Map<String, Object> requestLog) {
+    requestLog.putIfAbsent("appenders", new ArrayList<>());
+    @SuppressWarnings("unchecked")
+    List<Object> appenders = (List<Object>) requestLog.get("appenders");
+    applyRequestLogConsoleAppender(appenders);
+  }
+
+  private void applyRequestLogConsoleAppender(List<Object> appenders) {
+    AtomicBoolean foundConsoleAppender = new AtomicBoolean();
+    appenders.forEach(
+        a -> {
+          if (a instanceof Map) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> appender = (Map<String, Object>) a;
+
+            if ("console".equals((appender).get("type"))) {
+              applyRequestLogConsoleAppenderDefaults(appender);
+              foundConsoleAppender.set(true);
+            }
+          }
+        });
+
+    if (!foundConsoleAppender.get()) {
+      Map<String, Object> consoleAppender = createRequestLogConsoleAppender();
+      applyRequestLogConsoleAppenderDefaults(consoleAppender);
+      appenders.add(consoleAppender);
+    }
+  }
+
+  private Map<String, Object> createRequestLogConsoleAppender() {
+    Map<String, Object> consoleAppender = new HashMap<>();
+    consoleAppender.put("type", "console");
+    return consoleAppender;
+  }
+
+  private void applyRequestLogConsoleAppenderDefaults(Map<String, Object> consoleAppender) {
+    if ("true".equals(System.getenv("ENABLE_JSON_LOGGING"))) {
+      consoleAppender.putIfAbsent("layout", createRequestLogConsoleAppenderLayout());
+    }
+  }
+
+  private Map<String, Object> createRequestLogConsoleAppenderLayout() {
+    Map<String, Object> consoleAppenderLayout = new HashMap<>();
+    consoleAppenderLayout.put("type", "access-json");
+    consoleAppenderLayout.put("requestHeaders", asList("Trace-Token", "Consumer-Token"));
+    consoleAppenderLayout.put("responseHeaders", singletonList("Trace-Token"));
+    return consoleAppenderLayout;
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithConsoleAppenderTest.java
@@ -40,5 +40,6 @@ public class DefaultLoggingConfigurationBundleWithConsoleAppenderTest {
 
     assertThat(consoleAppenderFactory.getLogFormat()).isEqualTo("%-5level %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("DEBUG");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
@@ -40,5 +40,6 @@ public class DefaultLoggingConfigurationBundleWithEmptyConfigTest {
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
@@ -1,0 +1,81 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import io.dropwizard.Configuration;
+import io.dropwizard.logging.AppenderFactory;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.DefaultLoggingFactory;
+import io.dropwizard.logging.json.AccessJsonLayoutBaseFactory;
+import io.dropwizard.logging.json.EventJsonLayoutBaseFactory;
+import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
+import io.dropwizard.server.DefaultServerFactory;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
+import org.sdase.commons.server.testing.EnvironmentRule;
+
+public class DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest {
+
+  public static final EnvironmentRule ENV =
+      new EnvironmentRule().setEnv("ENABLE_JSON_LOGGING", "true");
+
+  public static final DropwizardAppRule<Configuration> DW =
+      new DropwizardAppRule<>(
+          LoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
+
+  @ClassRule public static final RuleChain RULE = RuleChain.outerRule(ENV).around(DW);
+
+  @Test()
+  public void shouldApplyConsoleAppender() {
+    LoggingTestApp app = DW.getApplication();
+    DefaultLoggingFactory defaultLoggingFactory =
+        (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
+
+    List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
+        defaultLoggingFactory.getAppenders().stream()
+            .filter(a -> a instanceof ConsoleAppenderFactory)
+            .collect(Collectors.toList());
+
+    assertThat(consoleAppenderFactories.size()).isEqualTo(1);
+
+    ConsoleAppenderFactory<ILoggingEvent> consoleAppenderFactory =
+        (ConsoleAppenderFactory<ILoggingEvent>) consoleAppenderFactories.get(0);
+
+    assertThat(consoleAppenderFactory.getLogFormat())
+        .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isInstanceOf(EventJsonLayoutBaseFactory.class);
+
+    EventJsonLayoutBaseFactory layout =
+        (EventJsonLayoutBaseFactory) consoleAppenderFactory.getLayout();
+
+    assertThat(layout.isFlattenMdc()).isFalse();
+  }
+
+  @Test()
+  public void shouldApplyRequestLogConsoleAppender() {
+    LoggingTestApp app = DW.getApplication();
+
+    DefaultServerFactory serverFactory =
+        (DefaultServerFactory) app.getConfiguration().getServerFactory();
+    LogbackAccessRequestLogFactory requestLogFactory =
+        (LogbackAccessRequestLogFactory) serverFactory.getRequestLogFactory();
+    ConsoleAppenderFactory consoleAppenderFactory =
+        (ConsoleAppenderFactory) requestLogFactory.getAppenders().asList().get(0);
+
+    assertThat(consoleAppenderFactory.getLayout()).isInstanceOf(AccessJsonLayoutBaseFactory.class);
+    AccessJsonLayoutBaseFactory accessJsonLayoutBaseFactory =
+        (AccessJsonLayoutBaseFactory) consoleAppenderFactory.getLayout();
+
+    assertThat(accessJsonLayoutBaseFactory.getRequestHeaders())
+        .containsExactly("Trace-Token", "Consumer-Token");
+    assertThat(accessJsonLayoutBaseFactory.getResponseHeaders()).containsExactly("Trace-Token");
+  }
+}

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
@@ -41,5 +41,6 @@ public class DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTes
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
@@ -41,5 +41,6 @@ public class DefaultLoggingConfigurationBundleWithoutAppendersKeyTest {
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
@@ -41,5 +41,6 @@ public class DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest {
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
@@ -41,5 +41,6 @@ public class DefaultLoggingConfigurationBundleWithoutLoggingKeyTest {
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
     assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }


### PR DESCRIPTION
You can activate JSON logging for normal log messages and request log via the ENABLE_JSON_LOGGING environment variable.