### PR TITLE
test(server-kafka): increase timeout of createTopic

### DIFF
--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaTopicIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaTopicIT.java
@@ -286,7 +286,7 @@ public class KafkaTopicIT {
     try (AdminClient admin = KAFKA.getKafkaTestUtils().getAdminClient()) {
       NewTopic newTopic = new NewTopic(topicName, 2, (short) 2).configs(properties);
       KafkaFuture<Void> result = admin.createTopics(Collections.singletonList(newTopic)).all();
-      await().atMost(5, TimeUnit.SECONDS).until(result::isDone);
+      await().until(result::isDone);
     }
   }
 


### PR DESCRIPTION
Now uses the default timeout of 10s.