### PR TITLE
Add custom converter to store LocalDate without time part

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -205,6 +205,11 @@ public class MongoDbRule extends ExternalResource {
     return mongodConfig.net().getBindIp() + ":" + mongodConfig.net().getPort();
   }
 
+  /** @return the initialized database */
+  public String getDatabase() {
+    return database;
+  }
+
   /** @return the version of the MongoDB instance which is associated with this MongoDbRule */
   public IFeatureAwareVersion getVersion() {
     return version;

--- a/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/converter/LocalDateConverter.java
+++ b/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/converter/LocalDateConverter.java
@@ -1,0 +1,71 @@
+package org.sdase.commons.server.morphia.converter;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE;
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
+
+import dev.morphia.converters.SimpleValueConverter;
+import dev.morphia.converters.TypeConverter;
+import dev.morphia.mapping.MappedField;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+
+public class LocalDateConverter extends TypeConverter implements SimpleValueConverter {
+
+  // we use this for parsing to be backward compatible with the default
+  private static final DateTimeFormatter ISO_LOCAL_DATE_WITH_OPTIONAL_TIME =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .append(ISO_LOCAL_DATE)
+          .optionalStart()
+          .appendLiteral('T')
+          .append(ISO_LOCAL_TIME)
+          .optionalEnd()
+          .optionalStart()
+          .appendOffsetId()
+          .toFormatter();
+
+  public LocalDateConverter() {
+    super(LocalDate.class);
+  }
+
+  @Override
+  public Object decode(
+      Class<?> targetClass,
+      Object fromDBObject,
+      @SuppressWarnings("deprecation")
+          MappedField optionalExtraInfo) { // NOSONAR deprecation inherited
+    if (fromDBObject == null) {
+      return null;
+    }
+
+    if (fromDBObject instanceof String) {
+      return LocalDate.parse((String) fromDBObject, ISO_LOCAL_DATE_WITH_OPTIONAL_TIME);
+    }
+
+    // If this exception arises for java.util.Date, it is most likely that the collection has been
+    // set up with an older version of SDA Commons which is not compatible with this converter.
+    // The LocalDateConverter causing this breaking change has been introduced by PR #185. It should
+    // help to initialize the MorphiaBundle 'withoutLocalDateConverter()' if upgrading the content
+    // of the database is not an option.
+    throw new IllegalArgumentException(
+        String.format("Cannot decode object of class: %s", fromDBObject.getClass().getName()));
+  }
+
+  @Override
+  public Object encode(
+      Object value,
+      @SuppressWarnings("deprecation")
+          MappedField optionalExtraInfo) { // NOSONAR deprecation inherited
+    if (value == null) {
+      return null;
+    }
+
+    if (value instanceof LocalDate) {
+      return ((LocalDate) value).format(ISO_LOCAL_DATE);
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Cannot encode object of class: %s", value.getClass().getName()));
+  }
+}

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
@@ -39,7 +39,10 @@ public class MorphiaBundleCustomConverterIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
@@ -35,7 +35,7 @@ public class MorphiaBundleDefinedClassIT {
                       c ->
                           c.getMongo()
                               .setHosts(MONGODB.getHost())
-                              .setDatabase(MongoDbRule.Builder.DEFAULT_DATABASE))
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDisableLocalDateConvertersIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDisableLocalDateConvertersIT.java
@@ -1,0 +1,92 @@
+package org.sdase.commons.server.morphia;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.morphia.Datastore;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.mongo.testing.MongoDbRule;
+import org.sdase.commons.server.morphia.test.Config;
+import org.sdase.commons.server.morphia.test.model.Person;
+import org.sdase.commons.server.testing.DropwizardRuleHelper;
+import org.sdase.commons.server.testing.LazyRule;
+
+/** Tests if entities can be added by exact definition. */
+public class MorphiaBundleDisableLocalDateConvertersIT {
+
+  private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
+
+  private static final LazyRule<DropwizardAppRule<Config>> DW =
+      new LazyRule<>(
+          () ->
+              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
+                  .withConfigFrom(Config::new)
+                  .withRandomPorts()
+                  .withConfigurationModifier(
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
+                  .build());
+
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
+
+  @Before
+  public void cleanCollection() {
+    MONGODB.clearCollections();
+  }
+
+  @Test
+  public void supportLocalDateAndLocalDateTime() {
+    Datastore datastore = getDatastore();
+    LocalDate birthday = LocalDate.of(1979, 2, 8);
+    LocalDateTime lastLogin = LocalDateTime.now().withNano(0); // Mongo precision
+    datastore.save(
+        new Person().setName("Peter Parker").setBirthday(birthday).setLastLogin(lastLogin));
+
+    Person foundPerson =
+        datastore.createQuery(Person.class).field("name").equal("Peter Parker").first();
+
+    assertThat(foundPerson).isNotNull();
+    assertThat(foundPerson.getName()).isEqualTo("Peter Parker");
+    assertThat(foundPerson.getBirthday()).isEqualTo(birthday);
+    assertThat(foundPerson.getLastLogin()).isEqualTo(lastLogin);
+  }
+
+  private Datastore getDatastore() {
+    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+  }
+
+  public static class MorphiaTestApp extends Application<Config> {
+
+    @SuppressWarnings("deprecation")
+    private MorphiaBundle<Config> morphiaBundle =
+        MorphiaBundle.builder()
+            .withConfigurationProvider(Config::getMongo)
+            .withEntity(Person.class)
+            .withoutLocalDateConverter()
+            .build();
+
+    @Override
+    public void initialize(Bootstrap<Config> bootstrap) {
+      bootstrap.addBundle(morphiaBundle);
+    }
+
+    @Override
+    public void run(Config configuration, Environment environment) {
+      // nothing to run
+    }
+
+    MorphiaBundle<Config> getMorphiaBundle() {
+      return morphiaBundle;
+    }
+  }
+}

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
@@ -37,7 +37,10 @@ public class MorphiaBundleEnsureIndexesIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
@@ -29,7 +29,10 @@ public class MorphiaBundleHealthCheckIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testHC"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
@@ -32,7 +32,10 @@ public class MorphiaBundleNoEntityDefinedIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
@@ -33,7 +33,10 @@ public class MorphiaBundleScanPackageByMarkerClassIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
@@ -32,7 +32,10 @@ public class MorphiaBundleTracingIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
@@ -28,7 +28,10 @@ public class MorphiaBundleValidationDisabledIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
@@ -29,7 +29,10 @@ public class MorphiaBundleValidationIT {
                   .withConfigFrom(Config::new)
                   .withRandomPorts()
                   .withConfigurationModifier(
-                      c -> c.getMongo().setHosts(MONGODB.getHost()).setDatabase("testPeople"))
+                      c ->
+                          c.getMongo()
+                              .setHosts(MONGODB.getHost())
+                              .setDatabase(MONGODB.getDatabase()))
                   .build());
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/converter/LocalDateConverterTest.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/converter/LocalDateConverterTest.java
@@ -1,0 +1,81 @@
+package org.sdase.commons.server.morphia.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+
+public class LocalDateConverterTest {
+
+  private LocalDateConverter localDateConverter = new LocalDateConverter();
+
+  @Test
+  public void shouldEncodeAsIsoLocalDateString() {
+
+    LocalDate given = LocalDate.parse("2020-03-15");
+
+    Object actual = localDateConverter.encode(given, null);
+
+    assertThat(actual).isInstanceOf(String.class).isEqualTo("2020-03-15");
+  }
+
+  @Test
+  public void shouldEncodeNullAsNull() {
+
+    LocalDate given = null;
+
+    Object actual = localDateConverter.encode(given, null);
+
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  public void allowEncodeFailureForBadDataType() {
+
+    ZonedDateTime given = ZonedDateTime.now();
+
+    assertThatIllegalArgumentException().isThrownBy(() -> localDateConverter.encode(given, null));
+  }
+
+  @Test
+  public void shouldDecodeIsoLocalDateString() {
+
+    String given = "2020-03-15";
+
+    Object actual = localDateConverter.decode(LocalDate.class, given, null);
+
+    assertThat(actual).isInstanceOf(LocalDate.class).isEqualTo(LocalDate.parse("2020-03-15"));
+  }
+
+  @Test
+  public void shouldDecodeIsoLocalDateTimeStringForBackwardCompatibility() {
+
+    String given = "1979-02-08T00:00:00.000"; // this format has been used by Morphia for local date
+
+    Object actual = localDateConverter.decode(LocalDate.class, given, null);
+
+    assertThat(actual).isInstanceOf(LocalDate.class).isEqualTo(LocalDate.parse("1979-02-08"));
+  }
+
+  @Test
+  public void shouldDecodeNullAsNull() {
+
+    String given = null;
+
+    Object actual = localDateConverter.decode(LocalDate.class, given, null);
+
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  public void allowDecodeFailureForBadDataType() {
+
+    long given = Instant.now().toEpochMilli();
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> localDateConverter.decode(LocalDate.class, given, null));
+  }
+}


### PR DESCRIPTION
This PR will break services that use `java.time.LocalDate` in their Morphia entity classes. A configuration option for backward compatibility has been added. We need to add the following announcement to the release notes manually after the release has been created:

> Add custom converter to store LocalDate without time part
> 
> This way there is no timezone hassle when storing dates without time.
>
> This might break existing services that already use `java.time.LocalDate` in any of their Morphia entity classes.
> 
> - Only `java.time.LocalDate` in entity classes is affected.
> - Only Morphia/MongoDB is affected.
> - Everything is safe with PostgreSQL/JDBC, the REST model, the Jackson mappings.
>
> If your service uses `java.time.LocalDate` in any entity class that is managed with the `MorphiaBundle`, the bundle can be initialized using `withoutLocalDateConverter()` in the fluent builder to keep any custom or default converters for `java.time.LocalDate` and the service will not break.
> All new services and all services that add fields of type `java.time.LocalDate` to their Morphia entity classes after this release have no problem.