### PR TITLE
feat(server-auth): make the input extensible for different use cases

### DIFF
--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRuleIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRuleIT.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.sdase.commons.server.opa.testing.OpaRule.onAnyRequest;
 import static org.sdase.commons.server.opa.testing.OpaRule.onRequest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.VerificationException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -183,7 +184,10 @@ public class OpaRuleIT {
   }
 
   private OpaRequest requestWithJwt(String jwt, String method, String... path) {
+    ObjectMapper objectMapper = new ObjectMapper();
     return new OpaRequest()
-        .setInput(new OpaInput().setJwt(jwt).setHttpMethod(method).setPath(path).setHeaders(null));
+        .setInput(
+            objectMapper.valueToTree(
+                new OpaInput().setJwt(jwt).setHttpMethod(method).setPath(path)));
   }
 }

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -156,7 +156,7 @@ The OPA bundle requests the policy decision providing the following inputs
  * HTTP path as Array
  * HTTP method as String
  * validated JWT (if available) 
- * all request headers 
+ * all request headers (can be disabled in the [`OpaBundle`](./src/main/java/org/sdase/commons/server/opa/OpaBundle.java) builder)
 
 _Remark to HTTP request headers:_  
 The bundle normalizes  header names to lower case to simplify handling in OPA since HTTP specification defines header names as case insensitive.

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -8,4 +8,5 @@ dependencies {
   compile 'com.auth0:java-jwt'
 
   testCompile project(':sda-commons-server-testing')
+  testCompile project(':sda-commons-client-jersey-wiremock-testing')
 }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
@@ -207,6 +207,12 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
     }
 
     @Override
+    public <T extends Configuration> OpaBuilder<T> withOpaConfigProvider(
+        OpaConfigProvider<T> opaConfigProvider) {
+      return new Builder<>(opaConfigProvider);
+    }
+
+    @Override
     public OpaBuilder<C> withTracer(Tracer tracer) {
       this.tracer = tracer;
       return this;
@@ -215,12 +221,6 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
     @Override
     public OpaBundle<C> build() {
       return new OpaBundle<>(opaConfigProvider, tracer);
-    }
-
-    @Override
-    public <T extends Configuration> OpaBuilder<T> withOpaConfigProvider(
-        OpaConfigProvider<T> opaConfigProvider) {
-      return new Builder<>(opaConfigProvider);
     }
   }
 }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/extension/OpaInputExtension.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/extension/OpaInputExtension.java
@@ -1,0 +1,79 @@
+package org.sdase.commons.server.opa.extension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import javax.ws.rs.container.ContainerRequestContext;
+
+/**
+ * An extension to provide additional data to the {@link
+ * org.sdase.commons.server.opa.filter.model.OpaInput} before sending it to the Open Policy Agent.
+ *
+ * <p>Implementing this class should be the <i>last resort</i>. It is more favourable to depend on
+ * the existing {@link org.sdase.commons.server.opa.extension extensions} and instead use the
+ * constraint feature of the {@link
+ * org.sdase.commons.server.opa.OpaJwtPrincipal#getConstraintsAsEntity(Class)} to receive data from
+ * the policy decider and use it to decide based on it in your service.
+ *
+ * <p>Each extension is added in an own namespace, that means that it's data is accessible in a
+ * single sub-property. This contents can be represented by any object that is serializable by an
+ * {@link ObjectMapper}.
+ *
+ * <p>Example that returns a boolean:
+ *
+ * <pre>
+ *   {
+ *     "jwt": "…",
+ *     "path": ["…", "…"],
+ *     "httpMethod": "GET",
+ *     "myExtension": true
+ *   }
+ * </pre>
+ *
+ * <p>Example that returns an object:
+ *
+ * <pre>
+ *   {
+ *     "jwt": "…",
+ *     "path": ["…", "…"],
+ *     "httpMethod": "GET",
+ *     "myExtension": {
+ *       "myBoolean": true,
+ *       "myString": "asdf",
+ *       "myArray": ["…", "…", "…"]
+ *     }
+ *   }
+ * </pre>
+ *
+ * The property name in the input is defined during registration in {@link
+ * org.sdase.commons.server.opa.OpaBundle.Builder#withInputExtension(String, OpaInputExtension)}.
+ */
+public interface OpaInputExtension<T> {
+  /**
+   * When registered, it is called in {@link
+   * org.sdase.commons.server.opa.filter.OpaAuthFilter#filter(ContainerRequestContext)}. The return
+   * value is added as child of the property name defined during the {@link
+   * org.sdase.commons.server.opa.OpaBundle.Builder#withInputExtension(String, OpaInputExtension)
+   * registration}.
+   *
+   * <p>Example that adds the property {@code "myExtension": true}:
+   *
+   * <pre>
+   *   public class OpaInputHeadersExtension implements OpaInputExtension&lt;Boolean&gt; {
+   *     &#64;Override
+   *     public Boolean createAdditionalInputContent(ContainerRequestContext requestContext) {
+   *       return true;
+   *     }
+   *   }
+   *
+   *   // ... in your application
+   *   OpaBundle.builder()
+   *       // ...
+   *       .withInputExtension("myExtension", new MyOpaExtension())
+   *       .build();
+   *   // ...
+   * </pre>
+   *
+   * @param requestContext the request context
+   * @return the JsonNode that should be added as child of the extension's namespace property.
+   */
+  T createAdditionalInputContent(ContainerRequestContext requestContext);
+}

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/extension/OpaInputHeadersExtension.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/extension/OpaInputHeadersExtension.java
@@ -1,0 +1,76 @@
+package org.sdase.commons.server.opa.extension;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+
+/**
+ * An input extension that adds the request headers to the {@link
+ * org.sdase.commons.server.opa.filter.model.OpaInput}.
+ *
+ * <p>Header names are defined as case-insensitive by the HTTP RFC (<a
+ * href="https://tools.ietf.org/html/rfc7230#section-3.2">RFC 7230 Sec. 3.2</a>). This filter
+ * normalizes all headers to lowercase and included as:
+ *
+ * <pre>
+ *   …,
+ *   "headers": {
+ *     "my-header": ["value0", "value1", "value2"],
+ *     "another-header": ["value0,value1", "value2,value3"]
+ *   }
+ * </pre>
+ *
+ * <p>Headers are currently passed to OPA as read by the framework. There might be an issue with
+ * multivalued headers. The representation differs depending on how the client sends the headers. It
+ * might be a list with values, or one entry separated with a separator, for example ',' or a
+ * combination of both.
+ */
+public class OpaInputHeadersExtension implements OpaInputExtension<MultivaluedMap<String, String>> {
+
+  //
+  // Builder
+  //
+  public static ExtensionBuilder builder() {
+    return new OpaInputHeadersExtension.Builder();
+  }
+
+  private OpaInputHeadersExtension() {
+    // private method to prevent external instantiation
+  }
+
+  @Override
+  public MultivaluedMap<String, String> createAdditionalInputContent(
+      ContainerRequestContext requestContext) {
+    return lowercaseHeaderNames(requestContext.getHeaders());
+  }
+
+  /**
+   * Lowercase header names. In HTTP RFC, the header names are defined as case-insensitive, so a
+   * normalization is needed to define how the headers are named in OPA.
+   *
+   * @param headers request headers
+   * @return Map with normalized header names
+   */
+  private MultivaluedMap<String, String> lowercaseHeaderNames(
+      MultivaluedMap<String, String> headers) {
+    MultivaluedMap<String, String> result = new MultivaluedHashMap<>();
+    headers.forEach((key, value) -> result.addAll(key.toLowerCase(), value));
+    return result;
+  }
+
+  public interface ExtensionBuilder {
+    OpaInputHeadersExtension build();
+  }
+
+  public static class Builder implements ExtensionBuilder {
+
+    private Builder() {
+      // private method to prevent external instantiation
+    }
+
+    @Override
+    public OpaInputHeadersExtension build() {
+      return new OpaInputHeadersExtension();
+    }
+  }
+}

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaInput.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaInput.java
@@ -1,7 +1,5 @@
 package org.sdase.commons.server.opa.filter.model;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 public class OpaInput {
 
   /** trace token to be able to find opa debug */
@@ -16,24 +14,15 @@ public class OpaInput {
   /** HTTP Method */
   private String httpMethod;
 
-  /** Additional, optional headers that get passed to the OPA service. */
-  private MultivaluedMap<String, String> headers;
-
   public OpaInput() {
     // nothing here, just for Jackson
   }
 
-  OpaInput(
-      String jwt,
-      String[] path,
-      String httpMethod,
-      String traceToken,
-      MultivaluedMap<String, String> headers) {
+  public OpaInput(String jwt, String[] path, String httpMethod, String traceToken) {
     this.jwt = jwt;
     this.path = path;
     this.httpMethod = httpMethod;
     this.trace = traceToken;
-    this.headers = headers;
   }
 
   public String getJwt() {
@@ -69,15 +58,6 @@ public class OpaInput {
 
   public OpaInput setTrace(String trace) {
     this.trace = trace;
-    return this;
-  }
-
-  public MultivaluedMap<String, String> getHeaders() {
-    return headers;
-  }
-
-  public OpaInput setHeaders(MultivaluedMap<String, String> headers) {
-    this.headers = headers;
     return this;
   }
 }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaRequest.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/filter/model/OpaRequest.java
@@ -1,34 +1,29 @@
 package org.sdase.commons.server.opa.filter.model;
 
-import javax.ws.rs.core.MultivaluedMap;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class OpaRequest {
 
-  private OpaInput input;
+  private JsonNode input;
 
   public OpaRequest() {
     // nothing here
   }
 
-  private OpaRequest(OpaInput input) {
+  private OpaRequest(JsonNode input) {
     this.input = input;
   }
 
-  public OpaInput getInput() {
+  public JsonNode getInput() {
     return input;
   }
 
-  public OpaRequest setInput(OpaInput input) {
+  public OpaRequest setInput(JsonNode input) {
     this.input = input;
     return this;
   }
 
-  public static OpaRequest request(
-      String jwt,
-      String[] path,
-      String method,
-      String traceToken,
-      MultivaluedMap<String, String> headers) {
-    return new OpaRequest(new OpaInput(jwt, path, method, traceToken, headers));
+  public static OpaRequest request(JsonNode input) {
+    return new OpaRequest(input);
   }
 }

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
@@ -1,0 +1,212 @@
+package org.sdase.commons.server.opa;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.opa.config.OpaConfig;
+import org.sdase.commons.server.opa.extension.OpaInputExtension;
+import org.sdase.commons.server.testing.DropwizardRuleHelper;
+import org.sdase.commons.server.testing.LazyRule;
+
+public class OpaBundleBodyInputExtensionTest {
+  private static final WireMockClassRule WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  private static final LazyRule<DropwizardAppRule<TestConfiguration>> DW_WITH_EXTENSION =
+      new LazyRule<>(
+          () ->
+              DropwizardRuleHelper.dropwizardTestAppFrom(TestApplicationWithExtension.class)
+                  .withConfigFrom(TestConfiguration::new)
+                  .withRandomPorts()
+                  .withConfigurationModifier(c -> c.getOpa().setPolicyPackage("with"))
+                  .build());
+
+  private static final LazyRule<DropwizardAppRule<TestConfiguration>> DW_WITHOUT_EXTENSION =
+      new LazyRule<>(
+          () ->
+              DropwizardRuleHelper.dropwizardTestAppFrom(TestApplicationWithoutExtension.class)
+                  .withConfigFrom(TestConfiguration::new)
+                  .withRandomPorts()
+                  .withConfigurationModifier(c -> c.getOpa().setPolicyPackage("without"))
+                  .build());
+
+  @ClassRule
+  public static RuleChain CHAIN =
+      RuleChain.outerRule(WIRE).around(DW_WITH_EXTENSION).around(DW_WITHOUT_EXTENSION);
+
+  @Before
+  public void before() {
+    WIRE.resetAll();
+
+    WIRE.stubFor(
+        post("/v1/data/with")
+            .withRequestBody(matchingJsonPath("$.input.body.key", equalTo("value")))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{\"result\": {\"allow\": true}}")));
+
+    WIRE.stubFor(
+        post("/v1/data/without")
+            .withRequestBody(matchingJsonPath("$.input.body.key", WireMock.absent()))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{\"result\": {\"allow\": true}}")));
+  }
+
+  @Test
+  public void testFailureWhenExtensionIsActivated() {
+    // given
+    // when
+    Response response =
+        DW_WITH_EXTENSION
+            .getRule()
+            .client()
+            .target("http://localhost:" + DW_WITH_EXTENSION.getRule().getLocalPort())
+            .request()
+            .post(Entity.json(Collections.singletonMap("key", "value")));
+
+    // then
+    assertThat(WIRE.getAllServeEvents()).hasSize(1);
+    assertThat(response.getStatus()).isEqualTo(400);
+    assertThat(response.readEntity(String.class)).contains("Received null input.");
+  }
+
+  @Test
+  public void testSuccessWhenExtensionIsNotActivated() {
+    // given
+    // when
+    Response response =
+        DW_WITHOUT_EXTENSION
+            .getRule()
+            .client()
+            .target("http://localhost:" + DW_WITHOUT_EXTENSION.getRule().getLocalPort())
+            .request()
+            .post(Entity.json(Collections.singletonMap("key", "value")));
+
+    // then
+    assertThat(WIRE.getAllServeEvents()).hasSize(1);
+    assertThat(response.getStatus()).isEqualTo(200);
+    assertThat(response.readEntity(String.class)).isEqualTo("value");
+  }
+
+  /**
+   * An extension that reads the body properties and sends them as-is to the OPA (not recommended!).
+   * This consumes the input entity such that it can _not_ be accessed in the actual endpoint later.
+   */
+  static class BodyInputExtension implements OpaInputExtension<Map<String, Object>> {
+    private final ObjectMapper objectMapper;
+
+    BodyInputExtension(ObjectMapper objectMapper) {
+      this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Map<String, Object> createAdditionalInputContent(
+        ContainerRequestContext requestContext) {
+      try {
+        // caution! this causes problems.
+        return objectMapper.readValue(
+            requestContext.getEntityStream(), new TypeReference<Map<String, Object>>() {});
+      } catch (IOException ignored) {
+        return null;
+      }
+    }
+  }
+
+  /** A test application without any additional extension. */
+  public static class TestApplicationWithoutExtension extends TestApplication {
+    public TestApplicationWithoutExtension() {
+      super(false);
+    }
+  }
+
+  /** A test application with the BodyInputExtension extension. */
+  public static class TestApplicationWithExtension extends TestApplication {
+    public TestApplicationWithExtension() {
+      super(true);
+    }
+  }
+
+  abstract static class TestApplication extends Application<TestConfiguration> {
+    private final boolean withExtension;
+
+    public TestApplication(boolean withExtension) {
+      this.withExtension = withExtension;
+    }
+
+    @Override
+    public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+      OpaBundle<TestConfiguration> bundle;
+      if (withExtension) {
+        bundle =
+            OpaBundle.builder()
+                .withOpaConfigProvider(TestConfiguration::getOpa)
+                .withInputExtension("body", new BodyInputExtension(bootstrap.getObjectMapper()))
+                .build();
+      } else {
+        bundle = OpaBundle.builder().withOpaConfigProvider(TestConfiguration::getOpa).build();
+      }
+
+      bootstrap.addBundle(bundle);
+    }
+
+    @Override
+    public void run(TestConfiguration configuration, Environment environment) {
+      environment.jersey().register(Endpoint.class);
+    }
+  }
+
+  @Path("")
+  public static class Endpoint {
+    @Path("/")
+    @POST
+    public String ping(Map<String, String> input) {
+      // throws NullPointerException since body has already been consumed in the BodyInputExtension
+      if (input == null) {
+        throw new BadRequestException("Received null input.");
+      }
+
+      return input.get("key");
+    }
+  }
+
+  public static class TestConfiguration extends Configuration {
+    private final OpaConfig opa = new OpaConfig().setBaseUrl(WIRE.baseUrl());
+
+    public OpaConfig getOpa() {
+      return opa;
+    }
+  }
+}

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleTest.java
@@ -1,0 +1,64 @@
+package org.sdase.commons.server.opa;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.dropwizard.Configuration;
+import javax.ws.rs.container.ContainerRequestContext;
+import org.junit.Test;
+import org.sdase.commons.server.opa.OpaBundle.DuplicatePropertyException;
+import org.sdase.commons.server.opa.OpaBundle.HiddenOriginalPropertyException;
+import org.sdase.commons.server.opa.config.OpaConfig;
+import org.sdase.commons.server.opa.extension.OpaInputExtension;
+import org.sdase.commons.server.opa.extension.OpaInputHeadersExtension;
+
+public class OpaBundleTest {
+  @Test
+  public void shouldThrowExceptionIfNamespaceCollidesWithOriginalProperty() {
+    assertThatThrownBy(
+            () ->
+                OpaBundle.builder()
+                    .withOpaConfigProvider(TestConfiguration::getOpa)
+                    .withInputExtension("path", new NullInputExtension()))
+        .isInstanceOf(HiddenOriginalPropertyException.class)
+        .hasMessageContaining("NullInputExtension")
+        .hasMessageContaining("\"path\"");
+  }
+
+  @Test
+  public void shouldThrowExceptionIfNamespaceCollidesWithOtherExtension() {
+    assertThatThrownBy(
+            () ->
+                OpaBundle.builder()
+                    .withOpaConfigProvider(TestConfiguration::getOpa)
+                    .withInputExtension("myExtension", OpaInputHeadersExtension.builder().build())
+                    .withInputExtension("myExtension", new NullInputExtension()))
+        .isInstanceOf(DuplicatePropertyException.class)
+        .hasMessageContaining("OpaInputHeadersExtension")
+        .hasMessageContaining("NullInputExtension")
+        .hasMessageContaining("\"myExtension\"");
+  }
+
+  @Test
+  public void shouldActivateHeadersExtensionByDefault() {
+    OpaBundle<TestConfiguration> bundle =
+        OpaBundle.builder().withOpaConfigProvider(TestConfiguration::getOpa).build();
+
+    assertThat(bundle.getInputExtensions())
+        .hasEntrySatisfying(
+            "headers", ex -> assertThat(ex).isOfAnyClassIn(OpaInputHeadersExtension.class));
+  }
+
+  static class NullInputExtension implements OpaInputExtension<Boolean> {
+    @Override
+    public Boolean createAdditionalInputContent(ContainerRequestContext requestContext) {
+      return null;
+    }
+  }
+
+  static class TestConfiguration extends Configuration {
+    public OpaConfig getOpa() {
+      return null;
+    }
+  }
+}

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleTest.java
@@ -49,6 +49,18 @@ public class OpaBundleTest {
             "headers", ex -> assertThat(ex).isOfAnyClassIn(OpaInputHeadersExtension.class));
   }
 
+  @Test
+  public void shouldNotActivateHeadersExtensionWhenDisabled() {
+    OpaBundle<TestConfiguration> bundle =
+        OpaBundle.builder()
+            .withOpaConfigProvider(TestConfiguration::getOpa)
+            .withoutHeadersExtension()
+            .build();
+
+    assertThat(bundle.getInputExtensions().values())
+        .noneMatch(ex -> OpaInputHeadersExtension.class.equals(ex.getClass()));
+  }
+
   static class NullInputExtension implements OpaInputExtension<Boolean> {
     @Override
     public Boolean createAdditionalInputContent(ContainerRequestContext requestContext) {


### PR DESCRIPTION
This PR adds the possibility to add extensions for the `OPAInput` and moves the implementation of the headers to an extension that is enabled by default. It also adds an option to disable this default extension.