### PR TITLE
Fix validation response in case of inheritance

### DIFF
--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/JacksonConfigurationTestApp.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/JacksonConfigurationTestApp.java
@@ -167,4 +167,20 @@ public class JacksonConfigurationTestApp extends Application<Configuration> {
                 .build())
         .build();
   }
+
+  @POST
+  @Valid
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON) // in case of validation error
+  @Path("/searchValidation")
+  public Response createExtendedValidationResource(@Valid SearchFilterResource searchFilter) {
+    return Response.created(
+            uriInfo
+                .getBaseUriBuilder()
+                .path(JacksonConfigurationTestApp.class)
+                .path(JacksonConfigurationTestApp.class, "searchValidation")
+                .path("1")
+                .build())
+        .build();
+  }
 }

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameSearchFilterResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameSearchFilterResource.java
@@ -1,0 +1,23 @@
+package org.sdase.commons.server.jackson.test;
+
+import javax.validation.constraints.NotNull;
+
+public class NameSearchFilterResource extends SearchFilterResource {
+
+  static final String TYPE = "NAME";
+
+  @NotNull private String name;
+
+  public NameSearchFilterResource() {
+    super(TYPE);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public NameSearchFilterResource setName(String name) {
+    this.name = name;
+    return this;
+  }
+}

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/SearchFilterResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/SearchFilterResource.java
@@ -1,0 +1,25 @@
+package org.sdase.commons.server.jackson.test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    include = JsonTypeInfo.As.EXISTING_PROPERTY,
+    property = "type",
+    visible = true)
+@JsonSubTypes({
+  @JsonSubTypes.Type(value = NameSearchFilterResource.class, name = NameSearchFilterResource.TYPE)
+})
+public abstract class SearchFilterResource {
+
+  private String type;
+
+  protected SearchFilterResource(String type) {
+    this.type = type;
+  }
+
+  public String getType() {
+    return type;
+  }
+}


### PR DESCRIPTION
When using inheritance with `@JsonTypeInfo` like in APIs with complex search filters, we are not able to identify the path of an invalid field to respond with appropriate `invalidParams`.

The invalid path is set to _N/A_ instead of the correct path. This happens because the `JerseyValidationExceptionMapper` only knowns about the superclass defined in the param list of the API method and not about the subclasses.

At the moment we have no solution for this but added a test case in this PR that constructs such a situation and fails.