### PR TITLE
chore: set lower build timeout

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -8,6 +8,7 @@ jobs:
     # do not execute for PRs that origin from forks since we are missing the secrets for the scan
     if: "!(github.event.pull_request && github.event.pull_request.head.repo.fork)"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,7 @@ jobs:
           - os: windows-latest
             java_version: '11'
 
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
 
@@ -55,6 +56,7 @@ jobs:
   # create release and publish the artifacts
   semantic-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pull-request-snapshots.yml
+++ b/.github/workflows/pull-request-snapshots.yml
@@ -8,6 +8,7 @@ jobs:
     # do not execute for PRs that origin from forks since we are missing the secrets for the push
     if: "!(github.event.pull_request && github.event.pull_request.head.repo.fork)"
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK 1.8


### PR DESCRIPTION
Sometimes, especially on Windows runners, the process hangs and we just have an idle build runner. We can fail much early and try to restart the process.