### PR TITLE
chore: run sonarcloud in the Java 11 build

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Sonarcloud
         # do not execute for PRs that origin from forks since we are missing the secrets for the scan
-        if: "always() && matrix.java_version == '1.8' && matrix.os == 'ubuntu-latest' && !(github.event.pull_request && github.event.pull_request.head.repo.fork)"
+        if: "always() && matrix.java_version == '11' && matrix.os == 'ubuntu-latest' && !(github.event.pull_request && github.event.pull_request.head.repo.fork)"
         run: ./gradlew -x test codeCoverageReport sonarqube
         env:
           SONAR_LOGIN_TOKEN: ${{ secrets.SONAR_LOGIN_TOKEN }}


### PR DESCRIPTION
Sonarcloud issues a warning that Java 8 will not be supported anymore soon.