### PR TITLE
chore: read the staging profile id from the outputs context

### DIFF
--- a/.github/workflows/upload-release-maven-central.yml
+++ b/.github/workflows/upload-release-maven-central.yml
@@ -46,4 +46,4 @@ jobs:
         env:
           SDA_SONATYPE_USER: ${{ secrets.SDA_SONATYPE_USER }}
           SDA_SONATYPE_PASSWORD: ${{ secrets.SDA_SONATYPE_PASSWORD }}
-          SONATYPE_STAGING_REPOSITORY_ID: ${{ steps.create-staging-repo.output.STAGING_PROFILE_ID }}
+          SONATYPE_STAGING_REPOSITORY_ID: ${{ steps.create-staging-repo.outputs.STAGING_PROFILE_ID }}


### PR DESCRIPTION
A typo that didn't provide the id of the created staging profile to the upload step.