### PR TITLE
Provide `OpaJwtPrincipal` as injectable bean

### DIFF
--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
@@ -110,10 +110,13 @@ public class AuthAndOpaIT {
 
     assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
     PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+    assertThat(principalInfo.getName()).isEqualTo("OpaJwtPrincipal");
     assertThat(principalInfo.getJwt()).isNotNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isTrue();
     assertThat(principalInfo.getConstraints().getConstraint())
         .contains(entry("customer_ids", newArrayList("1")));
+    assertThat(principalInfo.getConstraintsJson()).contains("\"customer_ids\":").contains("\"1\"");
+    assertThat(principalInfo.getSub()).isEqualTo("test");
   }
 
   @Test

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
@@ -1,0 +1,137 @@
+package org.sdase.commons.server.opa.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.Collections;
+import javax.ws.rs.ForbiddenException;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.auth.testing.AuthRule;
+import org.sdase.commons.server.opa.config.OpaConfig;
+import org.sdase.commons.server.opa.testing.test.OpaJwtPrincipalInjectApp;
+import org.sdase.commons.server.testing.DropwizardRuleHelper;
+import org.sdase.commons.server.testing.LazyRule;
+
+public class OpaJwtPrincipalInjectIT {
+
+  private static AuthRule AUTH = AuthRule.builder().build();
+  private static OpaRule OPA = new OpaRule();
+
+  private static LazyRule<DropwizardAppRule<OpaJwtPrincipalInjectApp.Config>> DW =
+      new LazyRule<>(
+          () ->
+              DropwizardRuleHelper.dropwizardTestAppFrom(OpaJwtPrincipalInjectApp.class)
+                  .withConfigFrom(OpaJwtPrincipalInjectApp.Config::new)
+                  .withRandomPorts()
+                  .withConfigurationModifier(
+                      c -> c.setOpa(new OpaConfig().setBaseUrl(OPA.getUrl())))
+                  .withConfigurationModifier(
+                      AUTH.applyConfig(OpaJwtPrincipalInjectApp.Config::setAuth))
+                  .build());
+
+  @ClassRule public static RuleChain CHAIN = RuleChain.outerRule(AUTH).around(OPA).around(DW);
+
+  @Before
+  public void setUp() {
+    OPA.reset();
+  }
+
+  @Test
+  public void shouldInjectPrincipalWithConstraints() {
+
+    String token = AUTH.auth().buildToken();
+    OPA.mock(
+        OpaRule.onAnyRequest()
+            .allow()
+            .withConstraint(Collections.singletonMap("allowedOwners", new String[] {"ownerId"})));
+
+    OpaJwtPrincipalInjectApp.Constraints constraints =
+        client()
+            .path("principal")
+            .path("constraints")
+            .request(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .get(OpaJwtPrincipalInjectApp.Constraints.class);
+
+    assertThat(constraints).isNotNull();
+    assertThat(constraints.getAllowedOwners()).contains("ownerId");
+    assertThat(constraints.isAllow()).isTrue();
+  }
+
+  @Test
+  public void shouldProvideConstraintsWithoutUserContext() {
+
+    OPA.mock(
+        OpaRule.onAnyRequest()
+            .allow()
+            .withConstraint(Collections.singletonMap("allowedOwners", new String[] {})));
+
+    OpaJwtPrincipalInjectApp.Constraints constraints =
+        client()
+            .path("principal")
+            .path("constraints")
+            .request(MediaType.APPLICATION_JSON)
+            .get(OpaJwtPrincipalInjectApp.Constraints.class);
+
+    assertThat(constraints).isNotNull();
+    assertThat(constraints.getAllowedOwners()).isEmpty();
+    assertThat(constraints.isAllow()).isTrue();
+  }
+
+  @Test
+  public void shouldRejectWithForbiddenWithoutUserContext() {
+
+    OPA.mock(OpaRule.onAnyRequest().deny());
+
+    assertThatExceptionOfType(ForbiddenException.class)
+        .isThrownBy(
+            () ->
+                client()
+                    .path("principal")
+                    .path("constraints")
+                    .request(MediaType.APPLICATION_JSON)
+                    .get(OpaJwtPrincipalInjectApp.Constraints.class));
+  }
+
+  @Test
+  public void shouldCreateSeparateContextForEachRequest() {
+
+    String token1 = AUTH.auth().addClaim("foo", "bar").buildToken();
+    String token2 = AUTH.auth().addClaim("bar", "foo").buildToken();
+    OPA.mock(
+        OpaRule.onAnyRequest()
+            .allow()
+            .withConstraint(Collections.singletonMap("allowedOwners", new String[] {"ownerId"})));
+
+    String actualToken1 =
+        client()
+            .path("principal")
+            .path("token")
+            .request(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token1)
+            .get(String.class);
+
+    String actualToken2 =
+        client()
+            .path("principal")
+            .path("token")
+            .request(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token2)
+            .get(String.class);
+
+    assertThat(actualToken1).isEqualTo(token1);
+    assertThat(actualToken2).isEqualTo(token2);
+    assertThat(token1).isNotEqualTo(token2);
+  }
+
+  private WebTarget client() {
+    return DW.getRule().client().target("http://localhost:" + DW.getRule().getLocalPort());
+  }
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/AuthAndOpaBundleTestApp.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/AuthAndOpaBundleTestApp.java
@@ -3,7 +3,6 @@ package org.sdase.commons.server.opa.testing.test;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Context;
@@ -43,14 +42,19 @@ public class AuthAndOpaBundleTestApp extends Application<AuthAndOpaBundeTestAppC
 
     @GET
     @Path("resources")
-    public Response get() throws IOException {
+    public Response get() {
       OpaJwtPrincipal principal = (OpaJwtPrincipal) securityContext.getUserPrincipal();
 
       PrincipalInfo result =
           new PrincipalInfo()
               .setName(principal.getName())
               .setJwt(principal.getJwt())
-              .setConstraints(principal.getConstraintsAsEntity(ConstraintModel.class));
+              .setSub(
+                  principal.getClaims() == null
+                      ? null
+                      : principal.getClaims().get("sub").asString())
+              .setConstraints(principal.getConstraintsAsEntity(ConstraintModel.class))
+              .setConstraintsJson(principal.getConstraints());
 
       return Response.ok(result, MediaType.APPLICATION_JSON_TYPE).build();
     }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalEndpoint.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalEndpoint.java
@@ -1,0 +1,35 @@
+package org.sdase.commons.server.opa.testing.test;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import org.sdase.commons.server.opa.OpaJwtPrincipal;
+
+@Path("/principal")
+@Produces(APPLICATION_JSON)
+public class OpaJwtPrincipalEndpoint implements Feature {
+
+  @Context private OpaJwtPrincipal opaJwtPrincipal;
+
+  @GET
+  @Path("/constraints")
+  public OpaJwtPrincipalInjectApp.Constraints getOpaJwtPrincipalConstraints() {
+    return opaJwtPrincipal.getConstraintsAsEntity(OpaJwtPrincipalInjectApp.Constraints.class);
+  }
+
+  @GET
+  @Path("/token")
+  public String getOpaJwtPrincipalToken() {
+    return opaJwtPrincipal.getJwt();
+  }
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    return true;
+  }
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalInjectApp.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalInjectApp.java
@@ -1,0 +1,75 @@
+package org.sdase.commons.server.opa.testing.test;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import java.util.List;
+import org.sdase.commons.server.auth.AuthBundle;
+import org.sdase.commons.server.auth.config.AuthConfig;
+import org.sdase.commons.server.opa.OpaBundle;
+import org.sdase.commons.server.opa.config.OpaConfig;
+
+public class OpaJwtPrincipalInjectApp extends Application<OpaJwtPrincipalInjectApp.Config> {
+
+  @Override
+  public void initialize(Bootstrap<Config> bootstrap) {
+    bootstrap.addBundle(
+        AuthBundle.builder()
+            .withAuthConfigProvider(Config::getAuth)
+            .withExternalAuthorization()
+            .build());
+    bootstrap.addBundle(OpaBundle.builder().withOpaConfigProvider(Config::getOpa).build());
+  }
+
+  @Override
+  public void run(Config configuration, Environment environment) {
+    environment.jersey().register(new OpaJwtPrincipalEndpoint());
+  }
+
+  public static class Constraints {
+    private boolean allow;
+    private List<String> allowedOwners;
+
+    public boolean isAllow() {
+      return allow;
+    }
+
+    public Constraints setAllow(boolean allow) {
+      this.allow = allow;
+      return this;
+    }
+
+    public List<String> getAllowedOwners() {
+      return allowedOwners;
+    }
+
+    public Constraints setAllowedOwners(List<String> allowedOwners) {
+      this.allowedOwners = allowedOwners;
+      return this;
+    }
+  }
+
+  public static class Config extends Configuration {
+    private AuthConfig auth;
+    private OpaConfig opa;
+
+    public AuthConfig getAuth() {
+      return auth;
+    }
+
+    public Config setAuth(AuthConfig auth) {
+      this.auth = auth;
+      return this;
+    }
+
+    public OpaConfig getOpa() {
+      return opa;
+    }
+
+    public Config setOpa(OpaConfig opa) {
+      this.opa = opa;
+      return this;
+    }
+  }
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/PrincipalInfo.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/PrincipalInfo.java
@@ -6,6 +6,8 @@ public class PrincipalInfo {
   private String name;
   private String jwt;
   private ConstraintModel constraints;
+  private String constraintsJson;
+  private String sub;
 
   public String getName() {
     return name;
@@ -31,6 +33,24 @@ public class PrincipalInfo {
 
   public PrincipalInfo setConstraints(ConstraintModel constraints) {
     this.constraints = constraints;
+    return this;
+  }
+
+  public String getConstraintsJson() {
+    return constraintsJson;
+  }
+
+  public PrincipalInfo setConstraintsJson(String constraintsJson) {
+    this.constraintsJson = constraintsJson;
+    return this;
+  }
+
+  public String getSub() {
+    return sub;
+  }
+
+  public PrincipalInfo setSub(String sub) {
+    this.sub = sub;
     return this;
   }
 }

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -211,10 +211,16 @@ with a list of string values.
 }
 ```
 
-The bundle creates a [`OpaJwtPrincipal`](./src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java) for each 
-request. Data from an [`JwtPrincipal`](./src/main/java/org/sdase/commons/server/auth/JwtPrincipal.java) is copied to the new principal if existing.
-Beside the JWT, the constraints are included in this principal. The `OpaJwtPrincipal` includes a method to parse the constraints JSON string to
-a Java object.
+The bundle creates a [`OpaJwtPrincipal`](./src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java) 
+for each request.
+Data from an [`JwtPrincipal`](./src/main/java/org/sdase/commons/server/auth/JwtPrincipal.java) is 
+copied to the new principal if existing.
+Beside the JWT, the constraints are included in this principal. The `OpaJwtPrincipal` includes a 
+method to parse the constraints JSON string to a Java object.
+The [`OpaJwtPrincipal`](./src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java) can be 
+injected as field using `@Context` in 
+[request scoped beans like endpoint implementations](../sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalEndpoint.java).
+
 
 The following listing shows a corresponding model class to the example above.
 ```java

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
@@ -23,7 +23,9 @@ import java.util.List;
 import java.util.Map;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.WebTarget;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.process.internal.RequestScoped;
 import org.sdase.commons.server.opa.config.OpaConfig;
 import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.server.opa.extension.OpaInputExtension;
@@ -31,6 +33,7 @@ import org.sdase.commons.server.opa.extension.OpaInputHeadersExtension;
 import org.sdase.commons.server.opa.filter.OpaAuthFilter;
 import org.sdase.commons.server.opa.filter.model.OpaInput;
 import org.sdase.commons.server.opa.health.PolicyExistsHealthCheck;
+import org.sdase.commons.server.opa.internal.OpaJwtPrincipalFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -144,6 +147,20 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
           .register(
               PolicyExistsHealthCheck.DEFAULT_NAME, new PolicyExistsHealthCheck(policyTarget));
     }
+
+    environment
+        .jersey()
+        .register(
+            new AbstractBinder() {
+              @Override
+              protected void configure() {
+                bindFactory(OpaJwtPrincipalFactory.class)
+                    .to(OpaJwtPrincipal.class)
+                    .proxy(true)
+                    .proxyForSameScope(true)
+                    .in(RequestScoped.class);
+              }
+            });
   }
 
   private Client createClient(

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.security.Principal;
 import java.util.Map;
+import org.sdase.commons.server.opa.internal.OpaJwtPrincipalImpl;
 
 /**
  * Principal for @{@link javax.ws.rs.core.SecurityContext} that optionally contains a JWT and a set
@@ -14,29 +15,7 @@ import java.util.Map;
  * javax.ws.rs.core.Context} when the {@link OpaBundle} is used to setup the open policy agent
  * configuration.
  */
-public class OpaJwtPrincipal implements Principal {
-
-  private static final String DEFAULT_NAME = OpaJwtPrincipal.class.getSimpleName();
-
-  private String name;
-  private String jwt;
-  private Map<String, Claim> claims;
-  private JsonNode constraints;
-  private ObjectMapper om;
-
-  @SuppressWarnings("unused")
-  OpaJwtPrincipal() {
-    // for proxy
-  }
-
-  private OpaJwtPrincipal(
-      String name, String jwt, Map<String, Claim> claims, JsonNode constraints, ObjectMapper om) {
-    this.name = name;
-    this.jwt = jwt;
-    this.claims = claims;
-    this.constraints = constraints;
-    this.om = om;
-  }
+public interface OpaJwtPrincipal extends Principal {
 
   /**
    * @param jwt The token this Principal is created from. May be required to pass it to other
@@ -46,30 +25,20 @@ public class OpaJwtPrincipal implements Principal {
    * @param constraints Authorization details used within the service for limiting result data
    * @return the principal that contains a jwt token, claims, and constraints that can be decoded
    */
-  public static OpaJwtPrincipal create(
+  static OpaJwtPrincipalImpl create(
       String jwt, Map<String, Claim> claims, JsonNode constraints, ObjectMapper om) {
-    return new OpaJwtPrincipal(DEFAULT_NAME, jwt, claims, constraints, om);
-  }
-
-  @Override
-  public String getName() {
-    return name;
+    String defaultName = OpaJwtPrincipal.class.getSimpleName();
+    return new OpaJwtPrincipalImpl(defaultName, jwt, claims, constraints, om);
   }
 
   /** @return the JWT as string */
-  public String getJwt() {
-    return jwt;
-  }
+  String getJwt();
 
   /** @return map with the claims decoded from the JWT */
-  public Map<String, Claim> getClaims() {
-    return claims;
-  }
+  Map<String, Claim> getClaims();
 
   /** @return the constraint object as JSON String */
-  public String getConstraints() {
-    return constraints.toString();
-  }
+  String getConstraints();
 
   /**
    * returns the constraint as Object. The object type must match the response from OPA sidecar
@@ -78,11 +47,5 @@ public class OpaJwtPrincipal implements Principal {
    * @param <T> type for correct casting
    * @return the object or null if no constraint exists
    */
-  public <T> T getConstraintsAsEntity(Class<T> resultType) {
-    if (constraints != null) {
-      return om.convertValue(constraints, resultType);
-    } else {
-      return null;
-    }
-  }
+  <T> T getConstraintsAsEntity(Class<T> resultType);
 }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaJwtPrincipal.java
@@ -9,6 +9,10 @@ import java.util.Map;
 /**
  * Principal for @{@link javax.ws.rs.core.SecurityContext} that optionally contains a JWT and a set
  * of constraints as JSON object string.
+ *
+ * <p>The {@code OpaJwtPrincipal} can be injected as field in endpoint implementations using {@link
+ * javax.ws.rs.core.Context} when the {@link OpaBundle} is used to setup the open policy agent
+ * configuration.
  */
 public class OpaJwtPrincipal implements Principal {
 
@@ -19,6 +23,11 @@ public class OpaJwtPrincipal implements Principal {
   private Map<String, Claim> claims;
   private JsonNode constraints;
   private ObjectMapper om;
+
+  @SuppressWarnings("unused")
+  OpaJwtPrincipal() {
+    // for proxy
+  }
 
   private OpaJwtPrincipal(
       String name, String jwt, Map<String, Claim> claims, JsonNode constraints, ObjectMapper om) {

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalFactory.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalFactory.java
@@ -1,0 +1,32 @@
+package org.sdase.commons.server.opa.internal;
+
+import java.security.Principal;
+import javax.inject.Inject;
+import javax.ws.rs.core.SecurityContext;
+import org.glassfish.hk2.api.Factory;
+import org.sdase.commons.server.opa.OpaJwtPrincipal;
+
+/** A factory that is able to provide the {@link OpaJwtPrincipal} in the request context. */
+public class OpaJwtPrincipalFactory implements Factory<OpaJwtPrincipal> {
+
+  private SecurityContext securityContext;
+
+  @Inject
+  public OpaJwtPrincipalFactory(SecurityContext securityContext) {
+    this.securityContext = securityContext;
+  }
+
+  @Override
+  public OpaJwtPrincipal provide() {
+    Principal userPrincipal = securityContext.getUserPrincipal();
+    if (userPrincipal instanceof OpaJwtPrincipal) {
+      return (OpaJwtPrincipal) userPrincipal;
+    }
+    return null;
+  }
+
+  @Override
+  public void dispose(OpaJwtPrincipal instance) {
+    // ignored
+  }
+}

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalImpl.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalImpl.java
@@ -1,0 +1,63 @@
+package org.sdase.commons.server.opa.internal;
+
+import com.auth0.jwt.interfaces.Claim;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.sdase.commons.server.opa.OpaBundle;
+import org.sdase.commons.server.opa.OpaJwtPrincipal;
+
+/**
+ * Principal for @{@link javax.ws.rs.core.SecurityContext} that optionally contains a JWT and a set
+ * of constraints as JSON object string.
+ *
+ * <p>The {@code OpaJwtPrincipal} can be injected as field in endpoint implementations using {@link
+ * javax.ws.rs.core.Context} when the {@link OpaBundle} is used to setup the open policy agent
+ * configuration.
+ */
+public class OpaJwtPrincipalImpl implements OpaJwtPrincipal {
+
+  private String name;
+  private String jwt;
+  private Map<String, Claim> claims;
+  private JsonNode constraints;
+  private ObjectMapper om;
+
+  public OpaJwtPrincipalImpl(
+      String name, String jwt, Map<String, Claim> claims, JsonNode constraints, ObjectMapper om) {
+    this.name = name;
+    this.jwt = jwt;
+    this.claims = claims;
+    this.constraints = constraints;
+    this.om = om;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getJwt() {
+    return jwt;
+  }
+
+  @Override
+  public Map<String, Claim> getClaims() {
+    return claims;
+  }
+
+  @Override
+  public String getConstraints() {
+    return constraints.toString();
+  }
+
+  @Override
+  public <T> T getConstraintsAsEntity(Class<T> resultType) {
+    if (constraints != null) {
+      return om.convertValue(constraints, resultType);
+    } else {
+      return null;
+    }
+  }
+}

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalFactoryTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/internal/OpaJwtPrincipalFactoryTest.java
@@ -1,0 +1,84 @@
+package org.sdase.commons.server.opa.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.interfaces.Claim;
+import java.security.Principal;
+import java.util.Map;
+import javax.ws.rs.core.SecurityContext;
+import org.junit.Test;
+import org.sdase.commons.server.opa.OpaJwtPrincipal;
+
+public class OpaJwtPrincipalFactoryTest {
+
+  private SecurityContext securityContextMock = mock(SecurityContext.class);
+  private OpaJwtPrincipalFactory opaJwtPrincipalFactory =
+      new OpaJwtPrincipalFactory(securityContextMock);
+
+  @Test
+  public void shouldProvideOpaJwtPrincipalFromSecurityContext() {
+
+    Principal given = emptyOpaJwtPrincipal();
+    when(securityContextMock.getUserPrincipal()).thenReturn(given);
+
+    OpaJwtPrincipal actual = opaJwtPrincipalFactory.provide();
+
+    assertThat(actual).isSameAs(given);
+  }
+
+  @Test
+  public void shouldSkipOtherTypeOfPrincipal() {
+
+    Principal given = emptyGenericPrincipal();
+    when(securityContextMock.getUserPrincipal()).thenReturn(given);
+
+    OpaJwtPrincipal actual = opaJwtPrincipalFactory.provide();
+
+    assertThat(actual).isNull();
+  }
+
+  @Test
+  public void shouldReturnNullIfNoPrincipal() {
+
+    when(securityContextMock.getUserPrincipal()).thenReturn(null);
+
+    OpaJwtPrincipal actual = opaJwtPrincipalFactory.provide();
+
+    assertThat(actual).isNull();
+  }
+
+  private Principal emptyGenericPrincipal() {
+    return () -> null;
+  }
+
+  private OpaJwtPrincipal emptyOpaJwtPrincipal() {
+    return new OpaJwtPrincipal() {
+      @Override
+      public String getJwt() {
+        return null;
+      }
+
+      @Override
+      public Map<String, Claim> getClaims() {
+        return null;
+      }
+
+      @Override
+      public String getConstraints() {
+        return null;
+      }
+
+      @Override
+      public <T> T getConstraintsAsEntity(Class<T> resultType) {
+        return null;
+      }
+
+      @Override
+      public String getName() {
+        return null;
+      }
+    };
+  }
+}


### PR DESCRIPTION
In many of our services we add a dedicated class or method that extracts and casts the principal from the injected `SecurityContext`.

To avoid the repeated block of code that always has to be tested, we can inject the `OpaJwtPrincipal` directly to read the constraints defined by the OPA.

Unfortunately there seems to be no option to provide constraints in the context as they depend on the project.