### PR TITLE
fix(deps): fix overriding the kotlin dependecy (and downgrade to 1.3.50)

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     because "Jersey uses different versions of hk2. Jersey is managed by Dropwizard. " +
         "Update hk2 manually according to greatest transitive dependency from Jersey."
   }
+  api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:1.3.50") // override version from dropwizard-bom
   api enforcedPlatform("io.dropwizard:dropwizard-bom:1.3.23")
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.11.800")
   // add dropwizard-dependencies for Dropwizard 2.x.y
@@ -94,7 +95,6 @@ dependencies {
     api "io.opentracing.contrib:opentracing-jaxrs2:1.0.0"
     api "io.opentracing.contrib:opentracing-concurrent:0.4.0"
     api "io.opentracing.contrib:opentracing-web-servlet-filter:0.4.1"
-    api "org.jetbrains.kotlin:kotlin-stdlib:1.3.72" // override version from dropwizard-bom
 
     api "javax.activation:activation:1.1.1"
     api "javax.activation:javax.activation-api:1.2.0"


### PR DESCRIPTION
Constraints are evaluated before included BOMs which means that we can't override dependencies included by BOMs with a constraint later. The previous comment said that, but didn't worked and caused mixed versions and a downgrade to a very old version that contains CVEs. This can be fixed by including the kotlin-bom, that also makes sure that all depending modules stay on the same version.
However this doesn't work with 1.3.72 for some reason, so we downgrade to 1.3.50 for now.