### PR TITLE
fix(deps): Use same Jetty version as Dropwizard 9.4.18.v20190429

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -16,16 +16,12 @@ ext {
   scalaVersion = '2.12.11'
   kafkaVersion = '2.2.1' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
   confluentVersion = '5.2.3' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
-  jettyVersion = '9.4.29.v20200521' // '9.4.30.v20200611' does not work!
+  jettyVersion = '9.4.18.v20190429' // Same version as Dropwizard!
   hk2Version = '2.5.0-b42'
   scalaVersion = '2.12.8'
 }
 
 dependencies {
-  api enforcedPlatform("org.eclipse.jetty:jetty-bom:$jettyVersion") {
-    because "Import jetty-bom before dropwizard-bom to enforce our jettyVersion! We need to add " +
-        "jetty-bom because dropwizard only defines version of some jetty components"
-  }
   api enforcedPlatform("org.glassfish.hk2:hk2-bom:$hk2Version") {
     because "Jersey uses different versions of hk2. Jersey is managed by Dropwizard. " +
         "Update hk2 manually according to greatest transitive dependency from Jersey."
@@ -33,6 +29,9 @@ dependencies {
   api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:1.3.50") // override version from dropwizard-bom
   api enforcedPlatform("io.dropwizard:dropwizard-bom:1.3.23")
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.11.800")
+  api enforcedPlatform("org.eclipse.jetty:jetty-bom:$jettyVersion") {
+    because "Add jetty-bom because dropwizard-bom is missing some jetty components"
+  }
   // add dropwizard-dependencies for Dropwizard 2.x.y
 
   constraints {

--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/test/SwaggerAssertions.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/test/SwaggerAssertions.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.load.configuration.LoadingConfiguration;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import com.github.fge.jsonschema.main.JsonValidator;
@@ -66,7 +67,15 @@ public final class SwaggerAssertions {
     static final JsonValidator jsonValidator = createJsonValidator();
 
     private static JsonValidator createJsonValidator() {
-      return JsonSchemaFactory.byDefault().getValidator();
+      // Preload the Swagger schema. By default, the validator tries to download it from the id
+      // field of the schema file (=http://swagger.io/v2/schema.json).
+      return JsonSchemaFactory.newBuilder()
+          .setLoadingConfiguration(
+              LoadingConfiguration.newBuilder()
+                  .preloadSchema(SwaggerSchemaHolder.swagger2Schema)
+                  .freeze())
+          .freeze()
+          .getValidator();
     }
   }
 


### PR DESCRIPTION
This fixes getting mixed versions from several Jetty components like jetty-http which caused 'NoSuchFieldError's when running the application.