### PR TITLE
fix(deps): upgrade hamcrest

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -135,6 +135,12 @@ dependencies {
 
     // sda-commons-server-testing
     api "junit:junit:4.13"
+    api "org.hamcrest:hamcrest:2.2"
+    // hamcrest-core is deprecated and overlaps with hamcrest, in hamcrest-core 2.2 is only one
+    // class named HamcrestCoreIsDeprecated. We force this version to avoid complex exclude and
+    // dependency substitution configuration as there is no conflict with hamcrest in the code base.
+    // Please do not upgrade hamcrest-core.
+    api "org.hamcrest:hamcrest-core:2.2"
     api "org.assertj:assertj-core:3.16.1"
     api "org.mockito:mockito-core:3.3.3"
 

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -134,15 +134,12 @@ dependencies {
     api "net.javacrumbs.json-unit:json-unit-assertj:2.18.1"
 
     // sda-commons-server-testing
-    api "junit:junit:4.13"
     api "org.hamcrest:hamcrest:2.2"
     // hamcrest-core is deprecated and overlaps with hamcrest, in hamcrest-core 2.2 is only one
     // class named HamcrestCoreIsDeprecated. We force this version to avoid complex exclude and
     // dependency substitution configuration as there is no conflict with hamcrest in the code base.
     // Please do not upgrade hamcrest-core.
     api "org.hamcrest:hamcrest-core:2.2"
-    api "org.assertj:assertj-core:3.16.1"
-    api "org.mockito:mockito-core:3.3.3"
 
     // sda-commons-server-weld
     api "javax.el:javax.el-api:3.0.0"

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -3,7 +3,4 @@ dependencies {
   compile 'io.dropwizard:dropwizard-json-logging'
 
   testCompile project(':sda-commons-server-testing')
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'io.dropwizard:dropwizard-testing'
 }

--- a/sda-commons-server-kafka-confluent/src/test/java/org/sdase/commons/server/kafka/confluent/WrapperKafkaDeserializerIT.java
+++ b/sda-commons-server-kafka-confluent/src/test/java/org/sdase/commons/server/kafka/confluent/WrapperKafkaDeserializerIT.java
@@ -1,9 +1,7 @@
 package org.sdase.commons.server.kafka.confluent;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
@@ -66,7 +64,6 @@ public class WrapperKafkaDeserializerIT {
   @Before
   public void setup() {
     KafkaTestApplication application = DROPWIZARD_APP_RULE.getApplication();
-    //noinspection unchecked
     bundle = application.kafkaBundle();
     results.clear();
   }
@@ -106,7 +103,7 @@ public class WrapperKafkaDeserializerIT {
                 .withErrorHandler(new IgnoreAndProceedErrorHandler<>())
                 .build());
 
-    assertThat(stringStringMessageListener, is(notNullValue()));
+    assertThat(stringStringMessageListener).isNotNull();
 
     ProducerConfig pConfigAvro = new ProducerConfig();
     pConfigAvro

--- a/sda-commons-server-kafka-confluent/src/test/java/org/sdase/commons/server/kafka/confluent/dropwizard/KafkaAvroIT.java
+++ b/sda-commons-server-kafka-confluent/src/test/java/org/sdase/commons/server/kafka/confluent/dropwizard/KafkaAvroIT.java
@@ -1,9 +1,7 @@
-package org.sdase.commons.server.kafka.confluent;
+package org.sdase.commons.server.kafka.confluent.dropwizard;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
@@ -28,8 +26,6 @@ import org.sdase.commons.server.kafka.builder.ProducerRegistration;
 import org.sdase.commons.server.kafka.config.ConsumerConfig;
 import org.sdase.commons.server.kafka.config.ProducerConfig;
 import org.sdase.commons.server.kafka.config.ProtocolType;
-import org.sdase.commons.server.kafka.confluent.dropwizard.KafkaTestApplication;
-import org.sdase.commons.server.kafka.confluent.dropwizard.KafkaTestConfiguration;
 import org.sdase.commons.server.kafka.confluent.testing.ConfluentSchemaRegistryRule;
 import org.sdase.commons.server.kafka.confluent.testing.KafkaBrokerEnvironmentRule;
 import org.sdase.commons.server.kafka.consumer.IgnoreAndProceedErrorHandler;
@@ -64,7 +60,6 @@ public class KafkaAvroIT {
   @Before
   public void setup() {
     KafkaTestApplication application = DROPWIZARD_APP_RULE.getApplication();
-    //noinspection unchecked
     bundle = application.kafkaBundle();
     results.clear();
   }
@@ -97,7 +92,7 @@ public class KafkaAvroIT {
                 .withErrorHandler(new IgnoreAndProceedErrorHandler<>())
                 .build());
 
-    assertThat(stringStringMessageListener, is(notNullValue()));
+    assertThat(stringStringMessageListener).isNotNull();
 
     ProducerConfig pConfig = new ProducerConfig();
     pConfig

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -1,7 +1,9 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
+
+  compile 'io.dropwizard:dropwizard-testing'
   compile 'junit:junit'
+  compile 'org.hamcrest:hamcrest'
   compile 'org.mockito:mockito-core'
   compile 'org.assertj:assertj-core'
-  compile 'io.dropwizard:dropwizard-testing'
 }


### PR DESCRIPTION
hamcrest (2.x) and hamcrest-core (1.x) have mostly similar classes 
but are not compatible in all details the later version of hamcrest
comes with Awaitility, so we use that in favour of the older one
served with junit. It is assumed that junit does not use it itself
and therefore has no conflicts due to the changes.

As junit by default provides hamcrest, we still ship it. But it is
not used any more here in favour of AssertJ. All usages of hamcrest 
are replaced with AssertJ.

We need to manage the deprecated dependency hamcrest-core to 
overwrite transitive dependencies. Version 2.2 of hamcrest-core
contains deprecation notices only and has no conflicts with the new
artifact.