### PR TITLE
fix(deps): upgrade hamcrest and stop managing test dependencies manag…

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -129,12 +129,17 @@ dependencies {
     api "net.javacrumbs.json-unit:json-unit-assertj:2.18.1"
 
     // sda-commons-server-testing
-    api "org.hamcrest:hamcrest:2.2"
-    // hamcrest-core is deprecated and overlaps with hamcrest, in hamcrest-core 2.2 is only one
-    // class named HamcrestCoreIsDeprecated. We force this version to avoid complex exclude and
-    // dependency substitution configuration as there is no conflict with hamcrest in the code base.
-    // Please do not upgrade hamcrest-core.
-    api "org.hamcrest:hamcrest-core:2.2"
+    api "org.hamcrest:hamcrest:2.2", {
+      because "hamcrest is the successor of hamcrest-core."
+    }
+    api "org.hamcrest:hamcrest-core:2.2", {
+      because '''\
+          hamcrest-core is deprecated and overlaps with hamcrest, in hamcrest-core 2.2 is
+          only one class named HamcrestCoreIsDeprecated. We force this version to avoid complex
+          exclude and dependency substitution configuration as there is no conflict with
+          hamcrest in the code base. Please do not upgrade hamcrest-core.
+          '''
+    }
 
     // sda-commons-server-weld
     api "javax.el:javax.el-api:3.0.0"


### PR DESCRIPTION
…ed by dropwizard

hamcrest (2.x) and hamcrest-core (1.x) have mostly similar classes
but are not compatible in all details the later version of hamcrest
comes with Awaitility, so we use that in favour of the older one
served with junit. It is assumed that junit does not use it itself
and therefore has no conflicts due to the changes.

As junit by default provides hamcrest, we still ship it. But it is
not used any more here in favour of AssertJ. All usages of hamcrest
are replaced with AssertJ.

We need to manage the deprecated dependency hamcrest-core to
overwrite transitive dependencies. Version 2.2 of hamcrest-core
contains deprecation notices only and has no conflicts with the new
artifact.