### PR TITLE
Remove management of depencies that are defined by dropwizard-dependencies

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     api "org.dbunit:dbunit:2.7.0", {
       because "rider in 1.2.9 only provides 2.5.3 from 2016, see http://dbunit.sourceforge.net/changes-report.html"
     }
-    api "com.h2database:h2:1.4.200"
 
     // sda-commons-server-jaeger
     api "io.jaegertracing:jaeger-client:1.3.1"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -70,7 +70,6 @@ dependencies {
 
     // sda-commons-server-circuitbreaker
     api "org.objenesis:objenesis:3.1"
-    api "org.javassist:javassist:3.27.0-GA"
 
     // sda-commons-server-hibernate
     api "org.postgresql:postgresql:42.2.5"


### PR DESCRIPTION
This PR does not include javax.*-Dependencies that are replaced by jakarta.* in Dropwizard. We will update them when confluent/avro is removed.