### PR TITLE
fix(deps): prefer using jakarta.* over javax.* dependencies that are provided by dropwizard-dependencies

### DIFF
--- a/sda-commons-client-jersey-wiremock-testing/build.gradle
+++ b/sda-commons-client-jersey-wiremock-testing/build.gradle
@@ -1,6 +1,10 @@
 dependencies {
 
   compile "com.github.tomakehurst:wiremock-jre8", {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
 

--- a/sda-commons-client-jersey-wiremock-testing/build.gradle
+++ b/sda-commons-client-jersey-wiremock-testing/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
 
-  compile "com.github.tomakehurst:wiremock-jre8"
+  compile "com.github.tomakehurst:wiremock-jre8", {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
 
   compile 'org.glassfish.jersey.core:jersey-client'
   compile 'org.glassfish.jersey.ext:jersey-proxy-client'
+  compile 'jakarta.servlet:jakarta.servlet-api'
 }

--- a/sda-commons-client-jersey/build.gradle
+++ b/sda-commons-client-jersey/build.gradle
@@ -4,7 +4,10 @@ dependencies {
   compile project(':sda-commons-shared-tracing')
   compile project(':sda-commons-shared-error')
 
-  compile 'io.dropwizard:dropwizard-client'
+  compile 'io.dropwizard:dropwizard-client', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+  compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'org.glassfish.jersey.core:jersey-client'
   compile 'org.glassfish.jersey.ext:jersey-proxy-client'
   compile 'org.codefetti.proxy:proxy-handler:1.0.0'

--- a/sda-commons-client-jersey/build.gradle
+++ b/sda-commons-client-jersey/build.gradle
@@ -5,6 +5,10 @@ dependencies {
   compile project(':sda-commons-shared-error')
 
   compile 'io.dropwizard:dropwizard-client', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     api "io.jaegertracing:jaeger-client:1.3.1"
 
     // sda-commons-server-mongo-testing
-    api "org.mongodb:mongo-java-driver:3.10.1"
     api "de.flapdoodle.embed:de.flapdoodle.embed.mongo:2.2.0"
 
     // sda-commons-server-morphia

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -35,9 +35,6 @@ dependencies {
     api "net.sf.jopt-simple:jopt-simple:5.0.4", {
       because "conflict between org.apache.kafka:kafka_2.12 and com.github.tomakehurst:wiremock-jre8"
     }
-    api "javax.annotation:javax.annotation-api:1.3.2", {
-      because "conflict between io.jaegertracing:jaeger-client and org.eclipse.jetty:jetty-annotations"
-    }
     api "org.jboss.logging:jboss-logging:3.4.1.Final", {
       because "conflict between org.hibernate.validator:hibernate-validator and org.jboss.weld.se:weld-se-core"
     }
@@ -86,6 +83,9 @@ dependencies {
     api "dev.morphia.morphia:core:$morphiaVersion"
     api "dev.morphia.morphia:validation:$morphiaVersion"
     api "org.bouncycastle:bcpkix-jdk15on:1.66"
+    api "jakarta.inject:jakarta.inject-api:1.0", {
+      because "the jakarta.inject-api comes with dropwizard but seems not to be managed by dropwizard-dependencies"
+    }
 
     // sda-commons-server-swagger
     api "io.openapitools.hal:swagger-hal:1.0.4"
@@ -113,7 +113,6 @@ dependencies {
     api "io.findify:s3mock_2.12:0.2.6"
 
     // sda-commons-server-swagger
-    api "javax.ws.rs:javax.ws.rs-api:2.1.1"
     api "com.github.java-json-tools:json-schema-validator:2.2.10"
     api "net.javacrumbs.json-unit:json-unit-assertj:2.18.1"
 
@@ -131,8 +130,6 @@ dependencies {
     }
 
     // sda-commons-server-weld
-    api "javax.el:javax.el-api:3.0.0"
-    api "javax.enterprise:cdi-api:2.0"
     api "org.jboss.weld.se:weld-se-core:$weldVersion"
     api "org.jboss.weld.servlet:weld-servlet-core:$weldVersion"
 

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -83,9 +83,6 @@ dependencies {
     api "dev.morphia.morphia:core:$morphiaVersion"
     api "dev.morphia.morphia:validation:$morphiaVersion"
     api "org.bouncycastle:bcpkix-jdk15on:1.66"
-    api "jakarta.inject:jakarta.inject-api:1.0", {
-      because "the jakarta.inject-api comes with dropwizard but seems not to be managed by dropwizard-dependencies"
-    }
 
     // sda-commons-server-swagger
     api "io.openapitools.hal:swagger-hal:1.0.4"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -132,6 +132,9 @@ dependencies {
     // sda-commons-server-weld
     api "org.jboss.weld.se:weld-se-core:$weldVersion"
     api "org.jboss.weld.servlet:weld-servlet-core:$weldVersion"
+    api "javax.transaction:javax.transaction-api:1.3", {
+      because "Dropwizard does not use the jakarta version yet so we replace it in weld with the javax version that comes as transitive dependency without explicit version."
+    }
 
     // sda-commons-shared-*
     api 'commons-io:commons-io:2.7'

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -17,7 +17,7 @@ public class DuplicateClassesTest {
    * Number of duplicates seen in the GitHub action build. This number may be lower in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 432;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 109;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 
@@ -37,7 +37,10 @@ public class DuplicateClassesTest {
   public void checkForDuplicateClasses() {
     int numberOfDuplicates = 0;
     ResourceList allResourcesInClasspath = new ClassGraph().scan().getAllResources();
-    ResourceList classFilesInClasspath = allResourcesInClasspath.classFilesOnly();
+    ResourceList classFilesInClasspath =
+        allResourcesInClasspath
+            .filter(resource -> !resource.getURL().toString().contains("/.gradle/wrapper/"))
+            .classFilesOnly();
     for (Map.Entry<String, ResourceList> duplicate : classFilesInClasspath.findDuplicatePaths()) {
       LOG.warn("Class files path: {}", duplicate.getKey()); // Classfile path
       numberOfDuplicates++;
@@ -45,6 +48,7 @@ public class DuplicateClassesTest {
         LOG.warn(" -> {}", res.getURL()); // Resource URL, showing classpath element
       }
     }
+    LOG.warn("Found {} duplicates.", numberOfDuplicates);
     assertThat(numberOfDuplicates)
         .describedAs(
             "already saw only %s duplicate classes but now there are %s",

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -1,0 +1,57 @@
+package org.sdase.commons.dependency.check;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.Resource;
+import io.github.classgraph.ResourceList;
+import java.util.Map;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DuplicateClassesTest {
+
+  /**
+   * Number of duplicates seen in the GitHub action build. This number may be lower in other
+   * environments for unknown reasons.
+   */
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 432;
+
+  private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
+
+  /**
+   * This test finds and logs duplicate classes in the classpath. Such duplicates appear for example
+   * when some libraries repackage standard functionality or APIs like javax.* or jakarta.* or when
+   * providers change their Maven GAV without changing the internal package structure. In both cases
+   * the dependency management can't identify the duplication.
+   *
+   * <p>When this test is not ignored any more by the assumption, the assumption can be turned into
+   * an assertion.
+   *
+   * <p>This approach of finding duplicates is inspired by <a
+   * href="https://stackoverflow.com/a/52639079">Stackoverflow</a>
+   */
+  @Test
+  public void checkForDuplicateClasses() {
+    int numberOfDuplicates = 0;
+    ResourceList allResourcesInClasspath = new ClassGraph().scan().getAllResources();
+    ResourceList classFilesInClasspath = allResourcesInClasspath.classFilesOnly();
+    for (Map.Entry<String, ResourceList> duplicate : classFilesInClasspath.findDuplicatePaths()) {
+      LOG.warn("Class files path: {}", duplicate.getKey()); // Classfile path
+      numberOfDuplicates++;
+      for (Resource res : duplicate.getValue()) {
+        LOG.warn(" -> {}", res.getURL()); // Resource URL, showing classpath element
+      }
+    }
+    assertThat(numberOfDuplicates)
+        .describedAs(
+            "already saw only %s duplicate classes but now there are %s",
+            LAST_SEEN_NUMBER_OF_DUPLICATES, numberOfDuplicates)
+        .isLessThanOrEqualTo(LAST_SEEN_NUMBER_OF_DUPLICATES);
+    assumeThat(numberOfDuplicates)
+        .describedAs("expecting no duplicate classes but found %s", numberOfDuplicates)
+        .isZero();
+  }
+}

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -17,7 +17,7 @@ public class DuplicateClassesTest {
    * Number of duplicates seen in the GitHub action build. This number may be different in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 108;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 44;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -17,7 +17,7 @@ public class DuplicateClassesTest {
    * Number of duplicates seen in the GitHub action build. This number may be different in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 15;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 0;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -14,10 +14,10 @@ import org.slf4j.LoggerFactory;
 public class DuplicateClassesTest {
 
   /**
-   * Number of duplicates seen in the GitHub action build. This number may be lower in other
+   * Number of duplicates seen in the GitHub action build. This number may be different in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 109;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 108;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 
@@ -42,6 +42,9 @@ public class DuplicateClassesTest {
             .filter(resource -> !resource.getURL().toString().contains("/.gradle/wrapper/"))
             .classFilesOnly();
     for (Map.Entry<String, ResourceList> duplicate : classFilesInClasspath.findDuplicatePaths()) {
+      if ("module-info.class".equals(duplicate.getKey())) {
+        continue;
+      }
       LOG.warn("Class files path: {}", duplicate.getKey()); // Classfile path
       numberOfDuplicates++;
       for (Resource res : duplicate.getValue()) {

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -17,7 +17,7 @@ public class DuplicateClassesTest {
    * Number of duplicates seen in the GitHub action build. This number may be different in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 44;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 34;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 

--- a/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
+++ b/sda-commons-dependency-check/src/test/java/org/sdase/commons/dependency/check/DuplicateClassesTest.java
@@ -17,7 +17,7 @@ public class DuplicateClassesTest {
    * Number of duplicates seen in the GitHub action build. This number may be different in other
    * environments for unknown reasons.
    */
-  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 34;
+  private static final int LAST_SEEN_NUMBER_OF_DUPLICATES = 15;
 
   private static final Logger LOG = LoggerFactory.getLogger(DuplicateClassesTest.class);
 

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -5,6 +5,10 @@ dependencies {
   compile project(':sda-commons-shared-tracing')
   compile 'io.dropwizard:dropwizard-auth'
   compile 'io.dropwizard:dropwizard-client', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -4,7 +4,11 @@ dependencies {
   compile project(':sda-commons-server-opentracing')
   compile project(':sda-commons-shared-tracing')
   compile 'io.dropwizard:dropwizard-auth'
-  compile 'io.dropwizard:dropwizard-client'
+  compile 'io.dropwizard:dropwizard-client', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+  compile 'jakarta.servlet:jakarta.servlet-api'
+
   compile 'com.auth0:java-jwt'
 
   testCompile project(':sda-commons-server-testing')

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
-  compile 'io.dropwizard:dropwizard-core'
+  compile 'io.dropwizard:dropwizard-core', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+  compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'io.dropwizard:dropwizard-json-logging'
 
   testCompile project(':sda-commons-server-testing')

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -1,5 +1,9 @@
 dependencies {
   compile 'io.dropwizard:dropwizard-core', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'

--- a/sda-commons-server-hibernate/build.gradle
+++ b/sda-commons-server-hibernate/build.gradle
@@ -1,8 +1,13 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
   compile 'io.dropwizard:dropwizard-hibernate', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
+  compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'org.postgresql:postgresql'
   compile 'org.flywaydb:flyway-core'
 

--- a/sda-commons-server-hibernate/build.gradle
+++ b/sda-commons-server-hibernate/build.gradle
@@ -6,6 +6,14 @@ dependencies {
      * Both contain the same classes.
      */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
+    /**
+     * dropwizard-hibernate provides javax.transaction:javax.transaction-api through
+     * jackson-datatype-hibernate5 and
+     * org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec through hibernate-core.
+     * Both bring the same classes but javax.transaction provides serialVersionUID which is
+     * documented as 'for backward compatibility'. So we keep the javax dependency.
+     */
+    exclude group: 'org.jboss.spec.javax.transaction', module: 'jboss-transaction-api_1.2_spec'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'org.postgresql:postgresql'

--- a/sda-commons-server-hibernate/build.gradle
+++ b/sda-commons-server-hibernate/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
-  compile 'io.dropwizard:dropwizard-hibernate'
+  compile 'io.dropwizard:dropwizard-hibernate', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
   compile 'org.postgresql:postgresql'
   compile 'org.flywaydb:flyway-core'
 

--- a/sda-commons-server-jaeger/build.gradle
+++ b/sda-commons-server-jaeger/build.gradle
@@ -1,7 +1,15 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
 
-  compile 'io.jaegertracing:jaeger-client'
+  compile 'io.jaegertracing:jaeger-client', {
+    /**
+     * Dropwizard comes with jakarta.annotation-api instead of javax.annotation-api.
+     * Both contain the same classes.
+     */
+    exclude group: "javax.annotation", module: "javax.annotation-api"
+  }
+  compile 'jakarta.annotation:jakarta.annotation-api'
+
 
   // Sadly the required code is in a test dependency, but as an alternative we could also copy the class here.
   compile group: 'io.opentracing', name: 'opentracing-util', classifier: 'tests'

--- a/sda-commons-server-mongo-testing/build.gradle
+++ b/sda-commons-server-mongo-testing/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
   compile project(':sda-commons-server-testing')
 
-  compile 'org.mongodb:mongo-java-driver'
+  // This dependency and version is used by Morphia in sda-commons-server-morphia.
+  // Only upgrade here when there is a version or GAV conflict with the artifact provided by
+  // Morphia.
+  compile 'org.mongodb:mongodb-driver-legacy:4.0.3'
   compile 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
 }

--- a/sda-commons-server-morphia/build.gradle
+++ b/sda-commons-server-morphia/build.gradle
@@ -4,7 +4,8 @@ dependencies {
   compile 'dev.morphia.morphia:core'
   compile 'dev.morphia.morphia:validation', {
     /**
-     * Dropwizard comes with jakarta.inject-api instead of javax.inject.
+     * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
+     * javax.inject.
      * Both contain the same classes.
      */
     exclude group: 'javax.inject', module: 'javax.inject'
@@ -15,7 +16,7 @@ dependencies {
      */
     exclude group: 'javax.validation', module: 'validation-api'
   }
-  compile 'jakarta.inject:jakarta.inject-api'
+  compile 'org.glassfish.hk2.external:jakarta.inject'
   compile 'jakarta.validation:jakarta.validation-api'
 
   compile 'org.bouncycastle:bcpkix-jdk15on'

--- a/sda-commons-server-morphia/build.gradle
+++ b/sda-commons-server-morphia/build.gradle
@@ -15,9 +15,15 @@ dependencies {
      * Both contain the same classes.
      */
     exclude group: 'javax.validation', module: 'validation-api'
+
+    /**
+     * Dropwizard comes with the repackaged version from Glassfish.
+     */
+    exclude group: 'aopalliance', module: 'aopalliance'
   }
   compile 'org.glassfish.hk2.external:jakarta.inject'
   compile 'jakarta.validation:jakarta.validation-api'
+  compile 'org.glassfish.hk2.external:aopalliance-repackaged'
 
   compile 'org.bouncycastle:bcpkix-jdk15on'
   compile 'io.opentracing.contrib:opentracing-mongo-driver'

--- a/sda-commons-server-morphia/build.gradle
+++ b/sda-commons-server-morphia/build.gradle
@@ -4,11 +4,18 @@ dependencies {
   compile 'dev.morphia.morphia:core'
   compile 'dev.morphia.morphia:validation', {
     /**
+     * Dropwizard comes with jakarta.inject-api instead of javax.inject.
+     * Both contain the same classes.
+     */
+    exclude group: 'javax.inject', module: 'javax.inject'
+
+    /**
      * Dropwizard comes with jakarta.validation instead of javax-validation.
      * Both contain the same classes.
      */
     exclude group: 'javax.validation', module: 'validation-api'
   }
+  compile 'jakarta.inject:jakarta.inject-api'
   compile 'jakarta.validation:jakarta.validation-api'
 
   compile 'org.bouncycastle:bcpkix-jdk15on'

--- a/sda-commons-server-prometheus/build.gradle
+++ b/sda-commons-server-prometheus/build.gradle
@@ -3,6 +3,10 @@ dependencies {
   compile project(':sda-commons-server-dropwizard')
   compile project(':sda-commons-shared-tracing')
   compile 'io.dropwizard:dropwizard-client', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'

--- a/sda-commons-server-prometheus/build.gradle
+++ b/sda-commons-server-prometheus/build.gradle
@@ -2,7 +2,11 @@ dependencies {
 
   compile project(':sda-commons-server-dropwizard')
   compile project(':sda-commons-shared-tracing')
-  compile 'io.dropwizard:dropwizard-client'
+  compile 'io.dropwizard:dropwizard-client', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+  compile 'jakarta.servlet:jakarta.servlet-api'
+
 
   compile 'io.prometheus:simpleclient'
   compile 'io.prometheus:simpleclient_dropwizard'

--- a/sda-commons-server-s3-testing/build.gradle
+++ b/sda-commons-server-s3-testing/build.gradle
@@ -1,5 +1,19 @@
 dependencies {
   compile project(':sda-commons-server-testing')
 
-  compile 'io.findify:s3mock_2.12'
+  compile 'io.findify:s3mock_2.12', {
+    /**
+     * Dropwizard comes with jakarta.activation-api instead of javax.activation-api.
+     * Both contain the same classes.
+     */
+    exclude group: "javax.activation", module: "javax.activation-api"
+
+    /**
+     * Dropwizard comes with jakarta.xml.bind-api instead of jaxb-api.
+     * Both contain the same classes.
+     */
+    exclude group: "javax.xml.bind", module: "jaxb-api"
+  }
+  compile 'jakarta.activation:jakarta.activation-api'
+  compile 'jakarta.xml.bind:jakarta.xml.bind-api'
 }

--- a/sda-commons-server-s3/build.gradle
+++ b/sda-commons-server-s3/build.gradle
@@ -1,6 +1,12 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
-  compile 'com.amazonaws:aws-java-sdk-s3'
+  compile 'com.amazonaws:aws-java-sdk-s3', {
+    /**
+     * As we use SLF4J for logging, we need the Bridge, not commons-logging itself
+     */
+    exclude group: 'commons-logging', module: 'commons-logging'
+  }
+  compile 'org.slf4j:jcl-over-slf4j'
   compile 'io.opentracing.contrib:opentracing-aws-sdk-1'
   compile 'io.opentracing:opentracing-util'
 

--- a/sda-commons-server-swagger/build.gradle
+++ b/sda-commons-server-swagger/build.gradle
@@ -20,7 +20,7 @@ dependencies {
      */
     exclude group: 'javax.validation', module: 'validation-api'
   }
-  compile 'javax.ws.rs:javax.ws.rs-api'
+  compile 'jakarta.ws.rs:jakarta.ws.rs-api'
   compile 'jakarta.validation:jakarta.validation-api'
 
   compile 'io.openapitools.hal:swagger-hal', {

--- a/sda-commons-server-swagger/build.gradle
+++ b/sda-commons-server-swagger/build.gradle
@@ -34,7 +34,14 @@ dependencies {
   testCompile 'net.javacrumbs.json-unit:json-unit-assertj', {
     exclude group: 'org.hamcrest',  module: 'hamcrest-core'
   }
-  testCompile 'com.github.java-json-tools:json-schema-validator'
+  testCompile 'com.github.java-json-tools:json-schema-validator', {
+    /**
+     * Dropwizard comes with jakarta.activation instead of javax.activation.
+     * Both contain the same classes.
+     */
+    exclude group: 'javax.activation', module: 'activation'
+  }
+  testCompile 'jakarta.activation:jakarta.activation-api'
 }
 
 test {

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
 
-  compile 'io.dropwizard:dropwizard-testing'
+  compile 'io.dropwizard:dropwizard-testing', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+  compile 'jakarta.servlet:jakarta.servlet-api'
+
   compile 'junit:junit'
   compile 'org.hamcrest:hamcrest'
   compile 'org.mockito:mockito-core'

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -2,6 +2,10 @@ dependencies {
   compile project(':sda-commons-server-dropwizard')
 
   compile 'io.dropwizard:dropwizard-testing', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
   compile 'jakarta.servlet:jakarta.servlet-api'

--- a/sda-commons-server-weld-testing/build.gradle
+++ b/sda-commons-server-weld-testing/build.gradle
@@ -3,5 +3,7 @@ dependencies {
   compile project(':sda-commons-server-weld')
 
   testCompile project(':sda-commons-server-jackson')
-  testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0'
+  testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0', {
+    exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
 }

--- a/sda-commons-server-weld-testing/build.gradle
+++ b/sda-commons-server-weld-testing/build.gradle
@@ -4,6 +4,11 @@ dependencies {
 
   testCompile project(':sda-commons-server-jackson')
   testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0', {
+    /**
+     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
+     * Both contain the same classes.
+     */
     exclude group: 'javax.servlet', module: 'javax.servlet-api'
   }
+  testCompile 'jakarta.servlet:jakarta.servlet-api'
 }

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -4,17 +4,36 @@ dependencies {
   compile 'org.jboss.weld.se:weld-se-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
+    /**
+     * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
+     * javax.inject.
+     * Both contain the same classes.
+     */
+    exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
   }
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
+    /**
+     * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
+     * javax.inject.
+     * Both contain the same classes.
+     */
+    exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
   }
+  compile 'org.glassfish.hk2.external:jakarta.inject'
   compile 'jakarta.el:jakarta.el-api', {
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
   }
 
   compile 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
+    /**
+     * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
+     * javax.inject.
+     * Both contain the same classes.
+     */
+    exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
   }
   compile 'javax.transaction:javax.transaction-api'
   compile 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -3,12 +3,19 @@ dependencies {
 
   compile 'org.jboss.weld.se:weld-se-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
+    exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
   }
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
+    exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
   }
-  compile 'jakarta.el:jakarta.el-api'
+  compile 'jakarta.el:jakarta.el-api', {
+    exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
+  }
 
-  compile 'jakarta.enterprise:jakarta.enterprise.cdi-api'
+  compile 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
+    exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
+  }
+  compile 'javax.transaction:javax.transaction-api'
   compile 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'
 }

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -7,8 +7,8 @@ dependencies {
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
   }
-  compile 'javax.el:javax.el-api'
+  compile 'jakarta.el:jakarta.el-api'
 
-  compile 'javax.enterprise:cdi-api'
+  compile 'jakarta.enterprise:jakarta.enterprise.cdi-api'
   compile 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'
 }

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -25,6 +25,12 @@ dependencies {
      * still in place.
      */
     exclude group: 'org.jboss.spec.javax.interceptor', module: 'jboss-interceptors-api_1.2_spec'
+    /**
+     * Dropwizard manages jakarta.annotation:jakarta.annotation-api while Weld brings
+     * org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec. Both have identical contents.
+     * We keep the version managed by Dropwizard.
+     */
+    exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
   }
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
     /**
@@ -49,9 +55,16 @@ dependencies {
      * still in place.
      */
     exclude group: 'org.jboss.spec.javax.interceptor', module: 'jboss-interceptors-api_1.2_spec'
+    /**
+     * Dropwizard manages jakarta.annotation:jakarta.annotation-api while Weld brings
+     * org.jboss.spec.javax.annotation:jboss-annotations-api_1.3_spec. Both have identical contents.
+     * We keep the version managed by Dropwizard.
+     */
+    exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
   }
   compile 'org.glassfish.hk2.external:jakarta.inject'
   compile 'org.glassfish:jakarta.el'
+  compile 'jakarta.annotation:jakarta.annotation-api'
 
   compile 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -10,9 +10,19 @@ dependencies {
      * Both contain the same classes.
      */
     exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
+    /**
+     * Dropwizard manages jakarta.el from Glassfish
+     */
+    exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
+    exclude group: 'jakarta.el', module: 'jakarta.el-api'
   }
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
+    /**
+     * Dropwizard manages jakarta.el from Glassfish
+     */
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
+    exclude group: 'jakarta.el', module: 'jakarta.el-api'
+
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
     /**
      * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
@@ -22,9 +32,7 @@ dependencies {
     exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
   }
   compile 'org.glassfish.hk2.external:jakarta.inject'
-  compile 'jakarta.el:jakarta.el-api', {
-    exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
-  }
+  compile 'org.glassfish:jakarta.el'
 
   compile 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
@@ -34,6 +42,10 @@ dependencies {
      * Both contain the same classes.
      */
     exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
+    /**
+     * Dropwizard manages jakarta.el from Glassfish
+     */
+    exclude group: 'jakarta.el', module: 'jakarta.el-api'
   }
   compile 'javax.transaction:javax.transaction-api'
   compile 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -15,6 +15,16 @@ dependencies {
      */
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
     exclude group: 'jakarta.el', module: 'jakarta.el-api'
+
+    /**
+     * Weld itself has concurrent transitive dependencies:
+     * jakarta.interceptor:jakarta.interceptor-api:1.2.5 and
+     * org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec:2.0.0.Final with identical
+     * classes. This causes duplicate classes in the application. We keep the official dependency.
+     * When Weld is upgraded we need to check if jakarta.interceptor:jakarta.interceptor-api is
+     * still in place.
+     */
+    exclude group: 'org.jboss.spec.javax.interceptor', module: 'jboss-interceptors-api_1.2_spec'
   }
   compile 'org.jboss.weld.servlet:weld-servlet-core', {
     /**
@@ -30,6 +40,15 @@ dependencies {
      * Both contain the same classes.
      */
     exclude group: 'jakarta.inject', module: 'jakarta.inject-api'
+    /**
+     * Weld itself has concurrent transitive dependencies:
+     * jakarta.interceptor:jakarta.interceptor-api:1.2.5 and
+     * org.jboss.spec.javax.interceptor:jboss-interceptors-api_1.2_spec:2.0.0.Final with identical
+     * classes. This causes duplicate classes in the application. We keep the official dependency.
+     * When Weld is upgraded we need to check if jakarta.interceptor:jakarta.interceptor-api is
+     * still in place.
+     */
+    exclude group: 'org.jboss.spec.javax.interceptor', module: 'jboss-interceptors-api_1.2_spec'
   }
   compile 'org.glassfish.hk2.external:jakarta.inject'
   compile 'org.glassfish:jakarta.el'


### PR DESCRIPTION
There are still some `javax.*` dependencies that are brought in by dropwizard. I guess we want to ignore those for now?
* javax.transaction:javax.transaction-api (by dropwizard-hibernate)
* javax.servlet:javax.servlet-api (by jetty ➡️ by nearly alle dropwizard modules)
