### PR TITLE
Feat/asyncapi with victools

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -15,6 +15,7 @@ ext {
   openTracingUtilVersion = '0.33.0'
   scalaVersion = '2.12.8' // Always prefer the version from kafka_2.12. Make sure that the major version is always aligned with kafka, s3mock, and mbknor-jackson-jsonschema.
   kafkaVersion = '2.2.1' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
+  victoolsJsonSchemaGeneratorVersion = '4.13.0'
 }
 
 dependencies {
@@ -55,7 +56,9 @@ dependencies {
     }
 
     // sda-commons-server-asyncapi
-    api "com.kjetland:mbknor-jackson-jsonschema_2.12:1.0.39"
+    api "com.github.victools:jsonschema-generator:$victoolsJsonSchemaGeneratorVersion"
+    api "com.github.victools:jsonschema-module-jackson:$victoolsJsonSchemaGeneratorVersion"
+    api "com.github.victools:jsonschema-module-javax-validation:$victoolsJsonSchemaGeneratorVersion"
 
     // sda-commons-server-auth
     api "com.auth0:java-jwt:3.10.3"

--- a/sda-commons-shared-asyncapi/README.md
+++ b/sda-commons-shared-asyncapi/README.md
@@ -125,6 +125,8 @@ String expected = JsonSchemaGenerator
 
 ## Document Models
 
+// TODO: Update docs! mention new annotations and reference the library!
+
 You can document the models using annotations like `JsonPropertyDescription` from Jackson or
 `JsonSchemaExamples` from [`mbknor-jackson-jsonSchema`](https://github.com/mbknor/mbknor-jackson-jsonSchema).
 See the tests of this module for [example model classes](./src/test/java/org/sdase/commons/shared/asyncapi/models).

--- a/sda-commons-shared-asyncapi/build.gradle
+++ b/sda-commons-shared-asyncapi/build.gradle
@@ -1,11 +1,9 @@
 dependencies {
   compile project(':sda-commons-server-jackson')
   compile project(':sda-commons-shared-yaml')
-  compile 'com.kjetland:mbknor-jackson-jsonschema_2.12', {
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-    exclude group: 'javax.validation', module: 'validation-api'
-    exclude group: 'org.slf4j', module: 'slf4j-api'
-  }
+  compile "com.github.victools:jsonschema-generator"
+  compile "com.github.victools:jsonschema-module-jackson"
+  compile "com.github.victools:jsonschema-module-javax-validation"
 
   testCompile project(':sda-commons-server-testing')
 }

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/JsonSchemaGenerator.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/JsonSchemaGenerator.java
@@ -1,10 +1,33 @@
 package org.sdase.commons.shared.asyncapi;
 
+import static com.github.victools.jsonschema.generator.Option.ALLOF_CLEANUP_AT_THE_END;
+import static com.github.victools.jsonschema.generator.Option.DEFINITIONS_FOR_ALL_OBJECTS;
+import static com.github.victools.jsonschema.generator.Option.DEFINITION_FOR_MAIN_SCHEMA;
+import static com.github.victools.jsonschema.generator.Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT;
+import static com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON;
+import static com.github.victools.jsonschema.generator.SchemaVersion.DRAFT_7;
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY;
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.IGNORE_TYPE_INFO_TRANSFORM;
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.RESPECT_JSONPROPERTY_ORDER;
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.SKIP_SUBTYPE_LOOKUP;
+import static com.github.victools.jsonschema.module.javax.validation.JavaxValidationOption.INCLUDE_PATTERN_EXPRESSIONS;
+import static com.github.victools.jsonschema.module.javax.validation.JavaxValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.kjetland.jackson.jsonSchema.JsonSchemaConfig;
-import com.kjetland.jackson.jsonSchema.JsonSchemaDraft;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.naming.CleanSchemaDefinitionNamingStrategy;
+import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy;
+import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.javax.validation.JavaxValidationModule;
 import org.sdase.commons.server.jackson.ObjectMapperConfigurationUtil;
+import org.sdase.commons.shared.asyncapi.schema.CleanupSuffixSchemaDefinitioNamingStrategy;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamplesModule;
+import org.sdase.commons.shared.asyncapi.schema.TemporalFormatModule;
 import org.sdase.commons.shared.yaml.YamlUtil;
 
 /** Generator for JSON schemas from Jackson and mbknor-jackson-jsonSchema annotated Java classes. */
@@ -77,17 +100,61 @@ public class JsonSchemaGenerator {
     @Override
     public JsonNode generate() {
       ObjectMapper objectMapper = ObjectMapperConfigurationUtil.configureMapper().build();
-      com.kjetland.jackson.jsonSchema.JsonSchemaGenerator jsonSchemaGenerator =
-          new com.kjetland.jackson.jsonSchema.JsonSchemaGenerator(
-              objectMapper,
-              JsonSchemaConfig.vanillaJsonSchemaDraft4()
-                  // We use JSON schema draft 07 here explicitly and not the latest version, as
-                  // AsyncAPI uses DRAFT 07:
-                  // https://www.asyncapi.com/docs/specifications/2.0.0/#a-name-messageobjectschemaformattable-a-schema-formats-table
-                  .withJsonSchemaDraft(JsonSchemaDraft.DRAFT_07)
-                  .withFailOnUnknownProperties(!allowAdditionalPropertiesEnabled));
+      JacksonModule jacksonModule =
+          new JacksonModule(
+              RESPECT_JSONPROPERTY_ORDER,
+              //IGNORE_TYPE_INFO_TRANSFORM,
+              //SKIP_SUBTYPE_LOOKUP,
+              FLATTENED_ENUMS_FROM_JSONPROPERTY);
+      JavaxValidationModule javaxValidationModule =
+          new JavaxValidationModule(INCLUDE_PATTERN_EXPRESSIONS, NOT_NULLABLE_FIELD_IS_REQUIRED);
+      JsonSchemaExamplesModule jsonSchemaExamplesModule = new JsonSchemaExamplesModule();
+      TemporalFormatModule temporalFormatModule = new TemporalFormatModule();
+      // We use JSON schema draft 07 here explicitly and not the latest version, as
+      // AsyncAPI uses DRAFT 07:
+      // https://www.asyncapi.com/docs/specifications/2.0.0/#a-name-messageobjectschemaformattable-a-schema-formats-table
+      SchemaGeneratorConfigBuilder configBuilder =
+          new SchemaGeneratorConfigBuilder(objectMapper, DRAFT_7, PLAIN_JSON)
+              .with(DEFINITIONS_FOR_ALL_OBJECTS)
+              .with(DEFINITION_FOR_MAIN_SCHEMA)
+              .with(ALLOF_CLEANUP_AT_THE_END)
+              .with(jacksonModule)
+              .with(javaxValidationModule)
+              .with(jsonSchemaExamplesModule)
+              .with(temporalFormatModule);
 
-      return jsonSchemaGenerator.generateJsonSchema(clazz);
+      // TODO: While this workaround generates a schema that we can use with the AsyncAPIGenerator,
+      //  the generated schema with the allOf definition doesn't look useful in the asyncapi docs...
+      configBuilder
+          .forTypesInGeneral()
+          .withDefinitionNamingStrategy(new CleanupSuffixSchemaDefinitioNamingStrategy());
+
+      // TODO: This is behavior I would expect from the JacksonModule, should we contribute it?
+      configBuilder
+          .forFields()
+          .withRequiredCheck(
+              member -> {
+                JsonProperty jsonProperty =
+                    member.getAnnotationConsideringFieldAndGetter(JsonProperty.class);
+
+                return jsonProperty != null && jsonProperty.required();
+              });
+
+      // TODO: Support defaultImpl? (NEW FEATURE, SEPARATE COMMIT once we finished the rest)
+      //  This is the main reason for evaluating if victools is easier to extend, it's possible with
+      //  the existing one, but not "nice". defaultImpl is not supported by victools out of the box.
+      //  defaultImpl means, that there is another type that the JSON can be parsed into, if it
+      // lacks
+      //  a known type annotation. This can be handled using an anyOf and including only fields of
+      //  defaultImpl (without sub types).
+
+      if (!allowAdditionalPropertiesEnabled) {
+        configBuilder.with(FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT);
+      }
+
+      SchemaGeneratorConfig config = configBuilder.build();
+      SchemaGenerator generator = new SchemaGenerator(config);
+      return generator.generateSchema(clazz);
     }
 
     @Override

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/CleanupSuffixSchemaDefinitioNamingStrategy.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/CleanupSuffixSchemaDefinitioNamingStrategy.java
@@ -1,0 +1,25 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.impl.DefinitionKey;
+import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy;
+import java.util.Map;
+
+public class CleanupSuffixSchemaDefinitioNamingStrategy
+    extends DefaultSchemaDefinitionNamingStrategy {
+
+  @Override
+  public void adjustDuplicateNames(
+      Map<DefinitionKey, String> subschemasWithDuplicateNames,
+      SchemaGenerationContext generationContext) {
+    int index = subschemasWithDuplicateNames.entrySet().size() - 1;
+    for (Map.Entry<DefinitionKey, String> singleEntry : subschemasWithDuplicateNames.entrySet()) {
+      if (index == 0) {
+        singleEntry.setValue(singleEntry.getValue());
+      } else {
+        singleEntry.setValue(singleEntry.getValue() + "-" + index);
+      }
+      --index;
+    }
+  }
+}

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamples.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamples.java
@@ -1,0 +1,31 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+// TODO: This annotation should better be in an own package to import less dependencies in streaming
+//  models
+
+/**
+ * Annotation to describe example values in a JSON schema.
+ *
+ * <pre>
+ *   &#64;JsonSchemaExamples(value = {"Tesla Roadster", "Hummer H1"})
+ *   private String name;
+ * </pre>
+ */
+@Target({METHOD, FIELD, PARAMETER, TYPE})
+@Retention(RUNTIME)
+public @interface JsonSchemaExamples {
+
+  /**
+   * @return An array of example values, where each value can either be a string or a JSON value.
+   */
+  String[] value();
+}

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamplesModule.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamplesModule.java
@@ -1,0 +1,59 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGenerationContext;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO: Should we contribute this? This would be a good default behavior for victools.
+
+/**
+ * Module that transforms <code>JsonSchemaExamples</code> annotations into examples in the JSON
+ * schema.
+ */
+public class JsonSchemaExamplesModule implements Module {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonSchemaExamplesModule.class);
+
+  @Override
+  public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+    builder.forFields().withInstanceAttributeOverride(this::resolveExampleAttribute);
+  }
+
+  private void resolveExampleAttribute(
+      ObjectNode collectedMemberAttributes, FieldScope member, SchemaGenerationContext context) {
+    // Do not provide examples for items in fake containers, as the examples are already
+    // applied to the field itself
+    if (!member.isFakeContainerItemScope()) {
+      JsonSchemaExamples jsonSchemaExamples =
+          member.getAnnotationConsideringFieldAndGetter(JsonSchemaExamples.class);
+
+      if (jsonSchemaExamples != null) {
+        ArrayNode examples = context.getGeneratorConfig().createArrayNode();
+
+        for (String json : jsonSchemaExamples.value()) {
+          try {
+            examples.add(
+                context.getGeneratorConfig().getObjectMapper().readValue(json, JsonNode.class));
+          } catch (JsonProcessingException e) {
+            LOGGER.debug(
+                "Unable to parse example value as JSON, using it as string instead: {}",
+                e.getMessage());
+            // Unable to parse the JSON, in that case we handle it as a raw string, this
+            // also makes it easier to pass string examples (without using multiple
+            // quotes).
+            examples.add(json);
+          }
+        }
+
+        collectedMemberAttributes.set("examples", examples);
+      }
+    }
+  }
+}

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/TemporalFormatModule.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/schema/TemporalFormatModule.java
@@ -1,0 +1,38 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import com.github.victools.jsonschema.generator.FieldScope;
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+/** A module that adds the correct <code>format</code> to properties of time related types. */
+public class TemporalFormatModule implements Module {
+
+  @Override
+  public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+    // Configure the format based on our object mapper configuration (see
+    // ObjectMapperConfigurationUtil and DateFormatObjectMapperTest)
+    builder.forFields().withStringFormatResolver(this::stringFormatResolver);
+  }
+
+  private String stringFormatResolver(FieldScope target) {
+    if (target.getDeclaredType().isInstanceOf(OffsetDateTime.class)
+        || target.getDeclaredType().isInstanceOf(Instant.class)
+        || target.getDeclaredType().isInstanceOf(ZonedDateTime.class)
+        || target.getDeclaredType().isInstanceOf(Date.class)) {
+      return "date-time";
+    } else if (target.getDeclaredType().isInstanceOf(LocalDate.class)) {
+      return "date";
+    } else if (target.getDeclaredType().isInstanceOf(Duration.class)
+        || target.getDeclaredType().isInstanceOf(Period.class)) {
+      return "duration";
+    }
+    return null;
+  }
+}

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/AsyncApiGeneratorTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/AsyncApiGeneratorTest.java
@@ -26,6 +26,6 @@ public class AsyncApiGeneratorTest {
     Map<String, Object> actualJson =
         YamlUtil.load(actual, new TypeReference<Map<String, Object>>() {});
 
-    assertThat(actualJson).isEqualToComparingFieldByFieldRecursively(expectedJson);
+    assertThat(actualJson).usingRecursiveComparison().isEqualTo(expectedJson);
   }
 }

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/JsonSchemaGeneratorTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/JsonSchemaGeneratorTest.java
@@ -22,6 +22,6 @@ public class JsonSchemaGeneratorTest {
     Map<String, Object> actualJson =
         YamlUtil.load(actual, new TypeReference<Map<String, Object>>() {});
 
-    assertThat(actualJson).isEqualToComparingFieldByFieldRecursively(expectedJson);
+    assertThat(actualJson).usingRecursiveComparison().isEqualTo(expectedJson);
   }
 }

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/BaseEvent.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/BaseEvent.java
@@ -5,14 +5,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
 @JsonTypeInfo(
     use = Id.NAME,
     property = "type",
     visible = true,
-    include = JsonTypeInfo.As.EXISTING_PROPERTY)
+    include = As.EXISTING_PROPERTY)
 @JsonSubTypes({
   @Type(value = CarManufactured.class, name = "CAR_MANUFACTURED"),
   @Type(value = CarScrapped.class, name = "CAR_SCRAPPED"),

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarManufactured.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarManufactured.java
@@ -1,15 +1,13 @@
 package org.sdase.commons.shared.asyncapi.models;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import java.time.Instant;
 import javax.validation.constraints.NotNull;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
-@JsonSchemaTitle("Car manufactured")
-@JsonSchemaDescription("A new car was manufactured")
+@JsonClassDescription("A new car was manufactured")
 public class CarManufactured extends BaseEvent {
 
   @JsonProperty(required = true)

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarModel.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarModel.java
@@ -4,14 +4,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
 @JsonTypeInfo(
     use = Id.NAME,
     property = "engineType",
     visible = true,
-    include = JsonTypeInfo.As.EXISTING_PROPERTY)
+    include = As.EXISTING_PROPERTY)
 @JsonSubTypes({
   @Type(value = Electrical.class, name = "ELECTRICAL"),
   @Type(value = Combustion.class, name = "COMBUSTION"),

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarScrapped.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/CarScrapped.java
@@ -1,15 +1,13 @@
 package org.sdase.commons.shared.asyncapi.models;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import java.time.Instant;
 import javax.validation.constraints.NotNull;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
-@JsonSchemaTitle("Car scrapped")
-@JsonSchemaDescription("A car was scrapped")
+@JsonClassDescription("A car was scrapped")
 public class CarScrapped extends BaseEvent {
 
   @JsonProperty(required = true)

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/Combustion.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/Combustion.java
@@ -1,13 +1,11 @@
 package org.sdase.commons.shared.asyncapi.models;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import javax.validation.constraints.NotNull;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
-@JsonSchemaTitle("Combustion engine")
-@JsonSchemaDescription("An car model with a combustion engine")
+@JsonClassDescription("An car model with a combustion engine")
 public class Combustion extends CarModel {
 
   @JsonPropertyDescription("The capacity of the tank in liter")

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/Electrical.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/models/Electrical.java
@@ -1,13 +1,11 @@
 package org.sdase.commons.shared.asyncapi.models;
 
+import com.fasterxml.jackson.annotation.JsonClassDescription;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaExamples;
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import javax.validation.constraints.NotNull;
+import org.sdase.commons.shared.asyncapi.schema.JsonSchemaExamples;
 
-@JsonSchemaTitle("Electrical engine")
-@JsonSchemaDescription("An car model with an electrical engine")
+@JsonClassDescription("An car model with an electrical engine")
 public class Electrical extends CarModel {
 
   @JsonPropertyDescription("The capacity of the battery in kwH")

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamplesModuleTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/schema/JsonSchemaExamplesModuleTest.java
@@ -1,0 +1,60 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import static com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON;
+import static com.github.victools.jsonschema.generator.SchemaVersion.DRAFT_7;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class JsonSchemaExamplesModuleTest {
+
+  @Test()
+  public void shouldGenerateExamplesFromAnnotations() {
+    SchemaGeneratorConfig config =
+        new SchemaGeneratorConfigBuilder(DRAFT_7, PLAIN_JSON)
+            .with(new JsonSchemaExamplesModule())
+            .build();
+    SchemaGenerator generator = new SchemaGenerator(config);
+    ObjectNode schemaNode = generator.generateSchema(ExampleModel.class);
+    Map<String, Object> schema =
+        config
+            .getObjectMapper()
+            .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
+
+    assertThat(schema).extracting("properties.name.examples").isEqualTo(asList("Chantal", "Kevin"));
+    assertThat(schema).extracting("properties.age.examples").isEqualTo(asList(25, 34));
+    assertThat(schema).extracting("properties.income.examples").isEqualTo(singletonList(45.3));
+    assertThat(schema)
+        .extracting("properties.interests.examples")
+        .isEqualTo(singletonList(asList("soccer", "makeup")));
+    assertThat(schema)
+        .extracting("properties.interests.items.examples")
+        .as("No not include the examples for each list item")
+        .isNull();
+  }
+
+  public static class ExampleModel {
+
+    @JsonSchemaExamples({"Chantal", "Kevin"})
+    private String name;
+
+    @JsonSchemaExamples({"25", "34"})
+    private int age;
+
+    @JsonSchemaExamples({"45.3"})
+    private BigDecimal income;
+
+    @JsonSchemaExamples({"[\"soccer\", \"makeup\"]"})
+    private List<String> interests;
+  }
+}

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/schema/TemporalFormatModuleTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/schema/TemporalFormatModuleTest.java
@@ -1,0 +1,60 @@
+package org.sdase.commons.shared.asyncapi.schema;
+
+import static com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON;
+import static com.github.victools.jsonschema.generator.SchemaVersion.DRAFT_7;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.victools.jsonschema.generator.SchemaGenerator;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Map;
+import org.junit.Test;
+
+public class TemporalFormatModuleTest {
+
+  @Test()
+  public void shouldGenerateFormatFromType() {
+    SchemaGeneratorConfig config =
+        new SchemaGeneratorConfigBuilder(DRAFT_7, PLAIN_JSON)
+            .with(new TemporalFormatModule())
+            .build();
+    SchemaGenerator generator = new SchemaGenerator(config);
+    ObjectNode schemaNode = generator.generateSchema(ExampleModel.class);
+    Map<String, Object> schema =
+        config
+            .getObjectMapper()
+            .convertValue(schemaNode, new TypeReference<Map<String, Object>>() {});
+
+    assertThat(schema).extracting("properties.fieldOfOffsetDateTime.format").isEqualTo("date-time");
+    assertThat(schema).extracting("properties.fieldOfInstant.format").isEqualTo("date-time");
+    assertThat(schema).extracting("properties.fieldOfZonedDateTime.format").isEqualTo("date-time");
+    assertThat(schema).extracting("properties.fieldOfDate.format").isEqualTo("date-time");
+
+    assertThat(schema).extracting("properties.fieldOfLocalDate.format").isEqualTo("date");
+
+    assertThat(schema).extracting("properties.fieldOfDuration.format").isEqualTo("duration");
+    assertThat(schema).extracting("properties.fieldOfPeriod.format").isEqualTo("duration");
+  }
+
+  public static class ExampleModel {
+
+    private OffsetDateTime fieldOfOffsetDateTime;
+    private Instant fieldOfInstant;
+    private ZonedDateTime fieldOfZonedDateTime;
+    private Date fieldOfDate;
+
+    private LocalDate fieldOfLocalDate;
+
+    private Duration fieldOfDuration;
+    private Period fieldOfPeriod;
+  }
+}

--- a/sda-commons-shared-asyncapi/src/test/resources/asyncapi_expected.yaml
+++ b/sda-commons-shared-asyncapi/src/test/resources/asyncapi_expected.yaml
@@ -19,21 +19,19 @@ channels:
 components:
   messages:
     CarManufactured:
-      title: "Car Manufactured"
+      title: Car Manufactured
       description: "An event that represents when a new car is manufactured"
       payload:
         $ref: "#/components/schemas/CarManufactured"
     CarScrapped:
-      title: "Car Scrapped"
+      title: Car Scrapped
       description: "An event that represents when a car is scrapped"
       payload:
         $ref: "#/components/schemas/CarScrapped"
   schemas:
     Electrical:
       type: "object"
-      additionalProperties: true
       description: "An car model with an electrical engine"
-      title: "ELECTRICAL"
       properties:
         engineType:
           type: "string"
@@ -49,16 +47,13 @@ components:
         batteryCapacity:
           type: "integer"
           examples:
-          - "200"
+          - 200
           description: "The capacity of the battery in kwH"
       required:
-      - "engineType"
       - "batteryCapacity"
     Combustion:
       type: "object"
-      additionalProperties: true
       description: "An car model with a combustion engine"
-      title: "COMBUSTION"
       properties:
         engineType:
           type: "string"
@@ -74,16 +69,13 @@ components:
         tankVolume:
           type: "integer"
           examples:
-          - "95"
+          - 95
           description: "The capacity of the tank in liter"
       required:
-      - "engineType"
       - "tankVolume"
     CarManufactured:
       type: "object"
-      additionalProperties: true
       description: "A new car was manufactured"
-      title: "CAR_MANUFACTURED"
       properties:
         type:
           type: "string"
@@ -103,9 +95,7 @@ components:
         model:
           oneOf:
           - $ref: "#/components/schemas/Electrical"
-            title: "Electrical engine"
           - $ref: "#/components/schemas/Combustion"
-            title: "Combustion engine"
           description: "The model of the car"
         id:
           type: "string"
@@ -114,16 +104,13 @@ components:
           - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
           description: "The id of the message"
       required:
-      - "type"
       - "vehicleRegistration"
       - "date"
       - "model"
       - "id"
     CarScrapped:
       type: "object"
-      additionalProperties: true
       description: "A car was scrapped"
-      title: "CAR_SCRAPPED"
       properties:
         type:
           type: "string"
@@ -152,7 +139,6 @@ components:
           - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
           description: "The id of the message"
       required:
-      - "type"
       - "vehicleRegistration"
       - "date"
       - "id"

--- a/sda-commons-shared-asyncapi/src/test/resources/schema_expected.yaml
+++ b/sda-commons-shared-asyncapi/src/test/resources/schema_expected.yaml
@@ -1,17 +1,15 @@
 ---
 $schema: "http://json-schema.org/draft-07/schema#"
-title: "Base Event"
-oneOf:
-- $ref: "#/definitions/CarManufactured"
-  title: "Car manufactured"
-- $ref: "#/definitions/CarScrapped"
-  title: "Car scrapped"
+$ref: "#/definitions/BaseEvent"
 definitions:
+  BaseEvent:
+    anyOf:
+    - $ref: "#/definitions/CarManufactured"
+    - $ref: "#/definitions/CarScrapped"
   CarManufactured:
     type: "object"
     additionalProperties: false
     description: "A new car was manufactured"
-    title: "CAR_MANUFACTURED"
     properties:
       type:
         type: "string"
@@ -31,9 +29,7 @@ definitions:
       model:
         oneOf:
         - $ref: "#/definitions/Electrical"
-          title: "Electrical engine"
         - $ref: "#/definitions/Combustion"
-          title: "Combustion engine"
         description: "The model of the car"
       id:
         type: "string"
@@ -42,7 +38,6 @@ definitions:
         - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
         description: "The id of the message"
     required:
-    - "type"
     - "vehicleRegistration"
     - "date"
     - "model"
@@ -51,7 +46,6 @@ definitions:
     type: "object"
     additionalProperties: false
     description: "An car model with an electrical engine"
-    title: "ELECTRICAL"
     properties:
       engineType:
         type: "string"
@@ -67,16 +61,14 @@ definitions:
       batteryCapacity:
         type: "integer"
         examples:
-        - "200"
+        - 200
         description: "The capacity of the battery in kwH"
     required:
-    - "engineType"
     - "batteryCapacity"
   Combustion:
     type: "object"
     additionalProperties: false
     description: "An car model with a combustion engine"
-    title: "COMBUSTION"
     properties:
       engineType:
         type: "string"
@@ -92,16 +84,14 @@ definitions:
       tankVolume:
         type: "integer"
         examples:
-        - "95"
+        - 95
         description: "The capacity of the tank in liter"
     required:
-    - "engineType"
     - "tankVolume"
   CarScrapped:
     type: "object"
     additionalProperties: false
     description: "A car was scrapped"
-    title: "CAR_SCRAPPED"
     properties:
       type:
         type: "string"
@@ -130,7 +120,6 @@ definitions:
         - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
         description: "The id of the message"
     required:
-    - "type"
     - "vehicleRegistration"
     - "date"
     - "id"


### PR DESCRIPTION
The PR replaces the implementation of the AsyncAPI generation based on [mbknor-jackson-jsonSchema](https://github.com/mbknor/mbknor-jackson-jsonSchema) with [victools](https://github.com/victools/jsonschema-generator).

Right now we have the following issues:
* the generated JSON schema is not nice as it contains definition names with counting suffixes.
* It is also desired to implement support for Jackson `defaultImpl`.
* Update documentation
* Contribute some parts back to victools