### PR TITLE
feat(server-auth): use HttpUrlConnectorProvider for loading public ke…

### DIFF
--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
@@ -11,6 +11,7 @@ import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import javax.ws.rs.client.Client;
+import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.sdase.commons.server.auth.config.AuthConfig;
 import org.sdase.commons.server.auth.config.AuthConfigProvider;
 import org.sdase.commons.server.auth.config.KeyLocation;
@@ -94,7 +95,9 @@ public class AuthBundle<T extends Configuration> implements ConfiguredBundle<T> 
   }
 
   private Client createKeyLoaderClient(Environment environment, Tracer tracer) {
-    Client client = new JerseyClientBuilder(environment).build("keyLoader");
+    Client client = new JerseyClientBuilder(environment)
+        .using(new HttpUrlConnectorProvider())
+        .build("keyLoader");
     registerTracing(client, tracer);
     return client;
   }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
@@ -95,9 +95,10 @@ public class AuthBundle<T extends Configuration> implements ConfiguredBundle<T> 
   }
 
   private Client createKeyLoaderClient(Environment environment, Tracer tracer) {
-    Client client = new JerseyClientBuilder(environment)
-        .using(new HttpUrlConnectorProvider())
-        .build("keyLoader");
+    Client client =
+        new JerseyClientBuilder(environment)
+            .using(new HttpUrlConnectorProvider())
+            .build("keyLoader");
     registerTracing(client, tracer);
     return client;
   }


### PR DESCRIPTION
Die SI implementiert zurzeit einen neuen OIDC Provider, welcher außerhalb des internes Netzes zur Verfügung steht.
Die SI Infrastruktur sieht vor, dass Ressourcen außerhalb des internen Netzes über den Proxy angefragt werden müssen.

Zur Verwendung der Java Standard Networking Properties (https.proxyHost, etc. -> https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html) muss eine kleine Anpassung vorgenommen.

Generell ist diese Lösung auch interessant für andere Services (Firebase, Scanner-Service) die von se erstellt werden