### PR TITLE
feat(server-auth): add configuration options to the jersey client that is used to load keys

### DIFF
--- a/sda-commons-client-jersey-example/README.md
+++ b/sda-commons-client-jersey-example/README.md
@@ -6,7 +6,8 @@ that uses the client-jersey bundle to invoke another service.
 Beside the initialization of the bundle, it includes the generation of three different clients:
 * Generic Platform client
 * Generic External client
-* External client using an interface that describes the API to generate a proxy 
+* External client using an interface that describes the API to generate a proxy
+* Generic External client with custom configurations 
 
 The [integration test](./src/test/java/org/sdase/commons/client/jersey/JerseyClientExampleIT.java) shows
 how to setup a mock using the [`sda-commons-client-jersey-wiremock-testing`](../sda-commons-client-jersey-wiremock-testing/README.md) 

--- a/sda-commons-client-jersey-example/src/main/java/org/sdase/commons/client/jersey/JerseyClientExampleApplication.java
+++ b/sda-commons-client-jersey-example/src/main/java/org/sdase/commons/client/jersey/JerseyClientExampleApplication.java
@@ -21,6 +21,7 @@ public class JerseyClientExampleApplication extends Application<JerseyClientExam
   private Client platformClient;
   private ApiA apiClient;
   private String apiABaseUrl;
+  private Client configuredExternalClient;
 
   public static void main(String[] args) throws Exception {
     new JerseyClientExampleApplication().run(args);
@@ -60,10 +61,18 @@ public class JerseyClientExampleApplication extends Application<JerseyClientExam
             .externalClient()
             .api(ApiA.class)
             .atTarget(apiABaseUrl);
+
+    // Example 4:
+    // create an external client that can be configured
+    configuredExternalClient =
+        jerseyClientBundle
+            .getClientFactory()
+            .externalClient(configuration.getConfiguredClient())
+            .buildGenericClient("configuredExternalClient");
   }
 
   /**
-   * Method oly for testing platform client. Should not be implemented in real applications.
+   * Method only for testing platform client. Should not be implemented in real applications.
    *
    * @return the http status of the response
    */
@@ -78,7 +87,7 @@ public class JerseyClientExampleApplication extends Application<JerseyClientExam
   }
 
   /**
-   * Method oly for testing external client. Should not be implemented in real applications.
+   * Method only for testing external client. Should not be implemented in real applications.
    *
    * @return the http status of the response
    */
@@ -93,7 +102,23 @@ public class JerseyClientExampleApplication extends Application<JerseyClientExam
   }
 
   /**
-   * Method oly for testing api client. Should not be implemented in real applications.
+   * Method only for testing the configured external client. Should not be implemented in real
+   * applications.
+   *
+   * @return the http status of the response
+   */
+  @SuppressWarnings("WeakerAccess")
+  public int useConfiguredExternalClient() {
+    return configuredExternalClient
+        .target(apiABaseUrl)
+        .path("/cars")
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .get()
+        .getStatus();
+  }
+
+  /**
+   * Method only for testing api client. Should not be implemented in real applications.
    *
    * @return list of cars that is the result of the service invocation
    */

--- a/sda-commons-client-jersey-example/src/main/java/org/sdase/commons/client/jersey/JerseyClientExampleConfiguration.java
+++ b/sda-commons-client-jersey-example/src/main/java/org/sdase/commons/client/jersey/JerseyClientExampleConfiguration.java
@@ -1,10 +1,13 @@
 package org.sdase.commons.client.jersey;
 
 import io.dropwizard.Configuration;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 
 class JerseyClientExampleConfiguration extends Configuration {
 
   private String servicea;
+  @NotNull @Valid private HttpClientConfiguration configuredClient;
 
   String getServicea() {
     return servicea;
@@ -12,5 +15,13 @@ class JerseyClientExampleConfiguration extends Configuration {
 
   public void setServicea(String servicea) {
     this.servicea = servicea;
+  }
+
+  public HttpClientConfiguration getConfiguredClient() {
+    return configuredClient;
+  }
+
+  public void setConfiguredClient(HttpClientConfiguration configuredClient) {
+    this.configuredClient = configuredClient;
   }
 }

--- a/sda-commons-client-jersey-example/src/test/java/org/sdase/commons/client/jersey/JerseyClientExampleIT.java
+++ b/sda-commons-client-jersey-example/src/test/java/org/sdase/commons/client/jersey/JerseyClientExampleIT.java
@@ -1,6 +1,10 @@
 package org.sdase.commons.client.jersey;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static java.util.Arrays.asList;
@@ -8,8 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.apache.http.HttpHeaders;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -56,7 +63,6 @@ public class JerseyClientExampleIT {
 
   @BeforeClass
   public static void initWires() throws JsonProcessingException {
-    WIRE.start();
     WIRE.stubFor(
         get("/api/cars") // NOSONAR
             .withHeader("Accept", equalTo("application/json")) // NOSONAR
@@ -91,6 +97,14 @@ public class JerseyClientExampleIT {
   @Test
   public void shouldUseExternalClient() {
     assertThat(app.useExternalClient()).isEqualTo(200);
+  }
+
+  @Test
+  public void shouldUseConfiguredExternalClient() {
+    assertThat(app.useConfiguredExternalClient()).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/api/cars"))
+            .withHeader(HttpHeaders.USER_AGENT, equalTo("configured-client")));
   }
 
   @Test

--- a/sda-commons-client-jersey-example/src/test/resources/test-config.yaml
+++ b/sda-commons-client-jersey-example/src/test/resources/test-config.yaml
@@ -7,3 +7,8 @@ server:
     port: 0
 
 servicea: ${SERVICE_A_URL}
+
+configuredClient:
+  timeout: ${CONFIGURED_CLIENT_TIMEOUT:-2000ms}
+  # this is just an example setting to show that the configuration is applied
+  userAgent: configured-client

--- a/sda-commons-client-jersey/README.md
+++ b/sda-commons-client-jersey/README.md
@@ -168,10 +168,50 @@ executorService.submit(transferRequestContext(() -> {
 })).get();
 ```
 
+## HTTP Client Configuration and Proxy Support
 
-## Proxy Settings
+Each client can be configured with the standard
+[Dropwizard configuration](https://www.dropwizard.io/en/latest/manual/configuration.html#man-configuration-clients-http).
+Please note that this requires that there is a property in your Application's `Configuration` class. 
 
-All clients consume the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+```java
+import org.sdase.commons.client.jersey.HttpClientConfiguration;
+
+public class MyConfiguration extends Configuration {
+   private HttpClientConfiguration myClient = new HttpClientConfiguration();
+
+   public HttpClientConfiguration getMyClient() {
+     return myClient;
+   }
+
+   public void setMyClient(HttpClientConfiguration myClient) {
+     this.myClient = myClient;
+   }
+}
+```
+
+```java
+Client client = clientFactory.platformClient(configuration.getMyClient()).buildGenericClient("test");
+```
+
+```yaml
+myClient:
+  timeout: 500ms
+  proxy:
+    host: 192.168.52.11
+    port: 8080
+    scheme : http
+```
+
+> Tip: There is no need to make all configuration properties available as environment variables.
+> Seldomly used properties can always be configured using [System Properties](https://www.dropwizard.io/en/latest/manual/core.html#man-core-configuration).
+
+This configuration can be used to configure a proxy server if needed.
+Use this if all clients should use individual proxy configurations.
+
+In addition, each client can consume the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+Please note that a specific proxy configuration in the `HttpClientConfiguration` disables the proxy system properties for the client using that configuration.
+This can be helpful when all clients in an Application should use the same proxy configuration (this includes the clients that are used by the [`sda-commons-server-auth` bundle](../sda-commons-server-auth).
 
 ## Tips and Tricks
 

--- a/sda-commons-client-jersey/README.md
+++ b/sda-commons-client-jersey/README.md
@@ -169,6 +169,10 @@ executorService.submit(transferRequestContext(() -> {
 ```
 
 
+## Proxy Settings
+
+All clients consume the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+
 ## Tips and Tricks
 
 ### 3rd Party `javax.ws.rs-api` Client Implementations in Classpath

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
@@ -4,6 +4,8 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
+import java.net.ProxySelector;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.sdase.commons.client.jersey.builder.ExternalClientBuilder;
 import org.sdase.commons.client.jersey.builder.PlatformClientBuilder;
 
@@ -79,6 +81,9 @@ public class ClientFactory {
     configuration.setChunkedEncodingEnabled(httpClientConfiguration.isChunkedEncodingEnabled());
     configuration.setGzipEnabled(httpClientConfiguration.isGzipEnabled());
     configuration.setGzipEnabledForRequests(httpClientConfiguration.isGzipEnabledForRequests());
-    return new JerseyClientBuilder(environment).using(configuration);
+    return new JerseyClientBuilder(environment)
+        // register a route planner that uses the default proxy variables (e.g. http.proxyHost)
+        .using(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
+        .using(configuration);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
@@ -1,11 +1,7 @@
 package org.sdase.commons.client.jersey;
 
-import io.dropwizard.client.JerseyClientBuilder;
-import io.dropwizard.client.JerseyClientConfiguration;
 import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
-import java.net.ProxySelector;
-import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.sdase.commons.client.jersey.builder.ExternalClientBuilder;
 import org.sdase.commons.client.jersey.builder.PlatformClientBuilder;
 
@@ -49,8 +45,7 @@ public class ClientFactory {
    * @return a builder to configure the client
    */
   public PlatformClientBuilder platformClient(HttpClientConfiguration httpClientConfiguration) {
-    return new PlatformClientBuilder(
-        createClientBuilder(httpClientConfiguration), tracer, consumerToken);
+    return new PlatformClientBuilder(environment, httpClientConfiguration, tracer, consumerToken);
   }
 
   /**
@@ -73,17 +68,6 @@ public class ClientFactory {
    * @return a builder to configure the client
    */
   public ExternalClientBuilder externalClient(HttpClientConfiguration httpClientConfiguration) {
-    return new ExternalClientBuilder(createClientBuilder(httpClientConfiguration), tracer);
-  }
-
-  private JerseyClientBuilder createClientBuilder(HttpClientConfiguration httpClientConfiguration) {
-    JerseyClientConfiguration configuration = new JerseyClientConfiguration();
-    configuration.setChunkedEncodingEnabled(httpClientConfiguration.isChunkedEncodingEnabled());
-    configuration.setGzipEnabled(httpClientConfiguration.isGzipEnabled());
-    configuration.setGzipEnabledForRequests(httpClientConfiguration.isGzipEnabledForRequests());
-    return new JerseyClientBuilder(environment)
-        // register a route planner that uses the default proxy variables (e.g. http.proxyHost)
-        .using(new SystemDefaultRoutePlanner(ProxySelector.getDefault()))
-        .using(configuration);
+    return new ExternalClientBuilder(environment, httpClientConfiguration, tracer);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/HttpClientConfiguration.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/HttpClientConfiguration.java
@@ -1,58 +1,39 @@
 package org.sdase.commons.client.jersey;
 
-public class HttpClientConfiguration {
-  // Chunked encoding is disabled by default, because in combination with the
-  // underlying Apache Http Client it breaks support for multipart/form-data
-  private boolean chunkedEncodingEnabled = false;
-  private boolean gzipEnabled = true;
-  // Gzip for request is disabled by default, because it breaks with some
-  // server implementations in combination with the Content-Encoding: gzip
-  // header if supplied accidentally to a GET request. This happen after
-  // calling a POST and receiving a SEE_OTHER response that is executed with
-  // the same headers as the POST request.
-  private boolean gzipEnabledForRequests = false;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
 
-  /** @return if the http client should use chunked encoding, disabled by default. */
-  public boolean isChunkedEncodingEnabled() {
-    return chunkedEncodingEnabled;
-  }
+/** A class that overrides some defaults */
+public class HttpClientConfiguration extends JerseyClientConfiguration {
+  /**
+   * The default (read) timeout to wait for data in an established connection. 2 seconds is used as
+   * a trade between "fail fast" and "better return late than no result". The timeout may be changed
+   * according to the use case considering how long a user is willing to wait and how long backend
+   * operations need.
+   */
+  public static final int DEFAULT_TIMEOUT_MS = 2_000;
 
   /**
-   * @param chunkedEncodingEnabled if true, the http client should use chunked encoding.
-   * @return the configuration to enable chained configurations
+   * The default timeout to wait until a connection is established. 500ms should be suitable for all
+   * communication in the platform. Clients that request information from external services may
+   * extend this timeout if foreign services are usually slow.
    */
-  public HttpClientConfiguration setChunkedEncodingEnabled(boolean chunkedEncodingEnabled) {
-    this.chunkedEncodingEnabled = chunkedEncodingEnabled;
-    return this;
-  }
+  public static final int DEFAULT_CONNECTION_TIMEOUT_MS = 500;
 
-  /** @return if the http client should accept gzipped responses, enabled by default. */
-  public boolean isGzipEnabled() {
-    return gzipEnabled;
-  }
+  public HttpClientConfiguration() {
+    // Chunked encoding is disabled by default, because in combination with the
+    // underlying Apache Http Client it breaks support for multipart/form-data
+    setChunkedEncodingEnabled(false);
 
-  /**
-   * Configure
-   *
-   * @param gzipEnabled if true, the http client should accept gzipped responses.
-   * @return the configuration to enable chained configurations
-   */
-  public HttpClientConfiguration setGzipEnabled(boolean gzipEnabled) {
-    this.gzipEnabled = gzipEnabled;
-    return this;
-  }
+    // Gzip for request is disabled by default, because it breaks with some
+    // server implementations in combination with the Content-Encoding: gzip
+    // header if supplied accidentally to a GET request. This happen after
+    // calling a POST and receiving a SEE_OTHER response that is executed with
+    // the same headers as the POST request.
+    setGzipEnabledForRequests(false);
 
-  /** @return if the http client should gzip request bodies, disabled by default. */
-  public boolean isGzipEnabledForRequests() {
-    return gzipEnabledForRequests;
-  }
-
-  /**
-   * @param gzipEnabledForRequests if true, the http client should gzip request bodies.
-   * @return the configuration to enable chained configurations
-   */
-  public HttpClientConfiguration setGzipEnabledForRequests(boolean gzipEnabledForRequests) {
-    this.gzipEnabledForRequests = gzipEnabledForRequests;
-    return this;
+    // override the default timeouts
+    setTimeout(Duration.milliseconds(DEFAULT_TIMEOUT_MS));
+    setConnectionTimeout(Duration.milliseconds(DEFAULT_CONNECTION_TIMEOUT_MS));
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ExternalClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ExternalClientBuilder.java
@@ -1,11 +1,13 @@
 package org.sdase.commons.client.jersey.builder;
 
-import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
+import org.sdase.commons.client.jersey.HttpClientConfiguration;
 
 public class ExternalClientBuilder extends AbstractBaseClientBuilder<ExternalClientBuilder> {
 
-  public ExternalClientBuilder(JerseyClientBuilder jerseyClientBuilder, Tracer tracer) {
-    super(jerseyClientBuilder, tracer);
+  public ExternalClientBuilder(
+      Environment environment, HttpClientConfiguration httpClientConfiguration, Tracer tracer) {
+    super(environment, httpClientConfiguration, tracer);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformClientBuilder.java
@@ -1,10 +1,11 @@
 package org.sdase.commons.client.jersey.builder;
 
-import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
+import org.sdase.commons.client.jersey.HttpClientConfiguration;
 import org.sdase.commons.client.jersey.filter.AddRequestHeaderFilter;
 import org.sdase.commons.client.jersey.filter.AuthHeaderClientFilter;
 import org.sdase.commons.client.jersey.filter.TraceTokenClientFilter;
@@ -15,8 +16,11 @@ public class PlatformClientBuilder extends AbstractBaseClientBuilder<PlatformCli
   private Supplier<Optional<String>> consumerTokenSupplier;
 
   public PlatformClientBuilder(
-      JerseyClientBuilder jerseyClientBuilder, Tracer tracer, String consumerToken) {
-    super(jerseyClientBuilder, tracer);
+      Environment environment,
+      HttpClientConfiguration httpClientConfiguration,
+      Tracer tracer,
+      String consumerToken) {
+    super(environment, httpClientConfiguration, tracer);
     this.consumerTokenSupplier = () -> Optional.ofNullable(StringUtils.trimToNull(consumerToken));
     addFilter(new TraceTokenClientFilter());
   }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
@@ -1,0 +1,121 @@
+package org.sdase.commons.client.jersey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.Collections;
+import java.util.Optional;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.server.testing.SystemPropertyRule;
+
+/**
+ * A test that checks if the proxy can be configured via the configuration class. They should have a
+ * higher priority than the system properties.
+ */
+public class ClientConfiguredProxyTest {
+  private static final WireMockClassRule CONTENT_WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  private static final WireMockClassRule PROXY_WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  // set invalid values to see whether the correct values are used
+  private static final SystemPropertyRule PROP =
+      new SystemPropertyRule()
+          .setProperty("http.proxyHost", "0.0.0.0")
+          .setProperty("http.proxyPort", "12345")
+          .setProperty("http.nonProxyHosts", "localhost");
+
+  private static final DropwizardAppRule<ClientTestConfig> DW =
+      new DropwizardAppRule<>(
+          ClientTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("client.proxy.host", "localhost"),
+          config("client.proxy.port", () -> "" + PROXY_WIRE.port())
+          // TODO: activate the next line after https://github.com/dropwizard/dropwizard/pull/3442
+          // config("client.proxy.nonProxyHosts", "localhost")
+          );
+
+  @ClassRule
+  public static final RuleChain rule =
+      RuleChain.outerRule(CONTENT_WIRE).around(PROXY_WIRE).around(PROP).around(DW);
+
+  @Before
+  public void before() {
+    CONTENT_WIRE.resetAll();
+    PROXY_WIRE.resetAll();
+  }
+
+  @Test
+  public void shouldUseProxy() {
+    // given: expect that the proxy receives the request
+    PROXY_WIRE.stubFor(get("/").withHeader(HttpHeaders.HOST, equalTo("sda.se")).willReturn(ok()));
+
+    // when
+    Response response = getClient("shouldUseProxy").target("http://sda.se").request().get();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    CONTENT_WIRE.verify(0, RequestPatternBuilder.allRequests());
+    PROXY_WIRE.verify(
+        1,
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/"))
+            .withHeader(HttpHeaders.HOST, equalTo("sda.se")));
+  }
+
+  @Test
+  public void shouldNotUseProxy() {
+    String url = String.format("localhost:%d", CONTENT_WIRE.port());
+
+    // given: expect that the proxy is skipped
+    CONTENT_WIRE.stubFor(
+        get("/")
+            .withHeader(HttpHeaders.HOST, equalTo(url))
+            .willReturn(aResponse().withStatus(409)));
+
+    // when
+    Response response =
+        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+    PROXY_WIRE.verify(0, RequestPatternBuilder.allRequests());
+    CONTENT_WIRE.verify(
+        1,
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/"))
+            .withHeader(HttpHeaders.HOST, equalTo(url)));
+  }
+
+  private Client getClient(String name) {
+    // TODO: remove this code after https://github.com/dropwizard/dropwizard/pull/3442
+    HttpClientConfiguration conf = DW.getConfiguration().getClient();
+    Optional.ofNullable(conf.getProxyConfiguration())
+        .ifPresent(p -> p.setNonProxyHosts(Collections.singletonList("localhost")));
+
+    return DW.<ClientTestApp>getApplication()
+        .getJerseyClientBundle()
+        .getClientFactory()
+        .externalClient(conf)
+        .buildGenericClient(name);
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
@@ -1,0 +1,105 @@
+package org.sdase.commons.client.jersey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.Response;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.server.testing.LazyRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
+
+/** A test that checks if the proxy can be configured via system properties */
+public class ClientProxyTest {
+  private static final WireMockClassRule CONTENT_WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  private static final WireMockClassRule PROXY_WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  private static final LazyRule<SystemPropertyRule> PROP =
+      new LazyRule<>(
+          () ->
+              new SystemPropertyRule()
+                  .setProperty("http.proxyHost", "localhost")
+                  .setProperty("http.proxyPort", "" + PROXY_WIRE.port())
+                  .setProperty("http.nonProxyHosts", "localhost"));
+
+  private static final DropwizardAppRule<ClientTestConfig> DW =
+      new DropwizardAppRule<>(ClientTestApp.class, resourceFilePath("test-config.yaml"));
+
+  @ClassRule
+  public static final RuleChain rule =
+      RuleChain.outerRule(CONTENT_WIRE).around(PROXY_WIRE).around(PROP).around(DW);
+
+  @Before
+  public void before() {
+    CONTENT_WIRE.resetAll();
+    PROXY_WIRE.resetAll();
+  }
+
+  @Test
+  public void shouldUseProxy() {
+    // given: expect that the proxy receives the request
+    PROXY_WIRE.stubFor(get("/").withHeader(HttpHeaders.HOST, equalTo("sda.se")).willReturn(ok()));
+
+    // when
+    Response response = getClient("shouldUseProxy").target("http://sda.se").request().get();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    CONTENT_WIRE.verify(0, RequestPatternBuilder.allRequests());
+    PROXY_WIRE.verify(
+        1,
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/"))
+            .withHeader(HttpHeaders.HOST, equalTo("sda.se")));
+  }
+
+  @Test
+  public void shouldNotUseProxy() {
+    String url = String.format("localhost:%d", CONTENT_WIRE.port());
+
+    // given: expect that the proxy is skipped
+    CONTENT_WIRE.stubFor(
+        get("/")
+            .withHeader(HttpHeaders.HOST, equalTo(url))
+            .willReturn(aResponse().withStatus(409)));
+
+    // when
+    Response response =
+        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+    PROXY_WIRE.verify(0, RequestPatternBuilder.allRequests());
+    CONTENT_WIRE.verify(
+        1,
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/"))
+            .withHeader(HttpHeaders.HOST, equalTo(url)));
+  }
+
+  private Client getClient(String name) {
+    return DW.<ClientTestApp>getApplication()
+        .getJerseyClientBundle()
+        .getClientFactory()
+        .externalClient()
+        .buildGenericClient(name);
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestApp.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestApp.java
@@ -13,7 +13,7 @@ import org.sdase.commons.server.trace.TraceTokenBundle;
 public class ClientTestApp extends Application<ClientTestConfig> {
 
   private final MockTracer tracer = new MockTracer();
-  private JerseyClientBundle<ClientTestConfig> jerseyClientBundle =
+  private final JerseyClientBundle<ClientTestConfig> jerseyClientBundle =
       JerseyClientBundle.builder()
           .withConsumerTokenProvider(ClientTestConfig::getConsumerToken)
           .withTracer(tracer)
@@ -42,7 +42,7 @@ public class ClientTestApp extends Application<ClientTestConfig> {
                 jerseyClientBundle.getClientFactory(), configuration.getMockBaseUrl()));
   }
 
-  public JerseyClientBundle getJerseyClientBundle() {
+  public JerseyClientBundle<ClientTestConfig> getJerseyClientBundle() {
     return jerseyClientBundle;
   }
 

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestConfig.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestConfig.java
@@ -1,6 +1,7 @@
 package org.sdase.commons.client.jersey.test;
 
 import io.dropwizard.Configuration;
+import org.sdase.commons.client.jersey.HttpClientConfiguration;
 
 @SuppressWarnings("WeakerAccess")
 public class ClientTestConfig extends Configuration {
@@ -8,6 +9,8 @@ public class ClientTestConfig extends Configuration {
   private String consumerToken;
 
   private String mockBaseUrl;
+
+  private HttpClientConfiguration client = new HttpClientConfiguration();
 
   public String getConsumerToken() {
     return consumerToken;
@@ -24,6 +27,15 @@ public class ClientTestConfig extends Configuration {
 
   public ClientTestConfig setMockBaseUrl(String mockBaseUrl) {
     this.mockBaseUrl = mockBaseUrl;
+    return this;
+  }
+
+  public HttpClientConfiguration getClient() {
+    return client;
+  }
+
+  public ClientTestConfig setClient(HttpClientConfiguration client) {
+    this.client = client;
     return this;
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
@@ -1,0 +1,79 @@
+package org.sdase.commons.server.auth.testing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.auth.testing.test.AuthTestApp;
+import org.sdase.commons.server.auth.testing.test.AuthTestConfig;
+import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.LazyRule;
+
+/** A test that checks if the jersey client that is used to load keys is configurable */
+public class CustomKeyLoaderConfigIT {
+  public static final WireMockRule WIRE =
+      new WireMockRule(new WireMockConfiguration().dynamicPort());
+
+  public static final EnvironmentRule ENVIRONMENT_RULE =
+      new EnvironmentRule().setEnv("AUTH_RULE", "{\"keys\": [{}]}");
+
+  private static final LazyRule<DropwizardAppRule<AuthTestConfig>> DW =
+      new LazyRule<>(
+          () ->
+              new DropwizardAppRule<>(
+                  AuthTestApp.class,
+                  ResourceHelpers.resourceFilePath("test-config.yaml"),
+                  // add a custom keyLoader config
+                  config("auth.keyLoaderClient.userAgent", "my-user-agent"),
+                  config("auth.keys[0].type", "JWKS"),
+                  config("auth.keys[0].location", String.format("%s/jwks", WIRE.baseUrl()))));
+
+  @ClassRule
+  public static RuleChain RULE = RuleChain.outerRule(WIRE).around(ENVIRONMENT_RULE).around(DW);
+
+  @BeforeClass
+  public static void beforeClass() {
+    WIRE.resetAll();
+    WIRE.stubFor(get(anyUrl()).willReturn(okJson("{\"keys\": []}")));
+  }
+
+  @Test
+  public void shouldSendCustomUserAgentInTheJwksRequest() {
+    final String token =
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.e30.sJ38ARdiqW5NDXRzkwPGD_XVVBL_q50ytQr3CezUaWCUlDgOwa49G_GuiriVbAAhllyETulropgTvCxbsDdXOHW4YrQWrJ1rn-HLqceoNxSX_Z2HaR5CeNtUmGL2pX-kv_9rYmyjRVwcOMRsQx_a7DPl-Bo5RrKXHka1nnaQ1a55W4PPOSiCCq4oEYH6RerxODh7uvfB9cYruUMH60f-kZeMVVzKuFpwBdI8xCYEZxXcBPtERsOVBTnGpr8S2_2xpaP6vfLsY4M63GwRNsTL9e8Ghm5n7VMuMrJESCHSrCTMMAK90S_iA3VwbVSUMyrJNdeccAc4lBqizUb7JuBygA";
+    Response response =
+        createWebTarget()
+            .path("/secure") // NOSONAR
+            .request(APPLICATION_JSON)
+            .header(AUTHORIZATION, "Bearer " + token)
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+
+    WIRE.verify(
+        getRequestedFor(urlEqualTo("/jwks")).withHeader(USER_AGENT, equalTo("my-user-agent")));
+  }
+
+  private WebTarget createWebTarget() {
+    return DW.getRule().client().target("http://localhost:" + DW.getRule().getLocalPort());
+  }
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
@@ -1,0 +1,96 @@
+package org.sdase.commons.server.auth.testing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.apache.http.HttpHeaders;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.auth.testing.test.AuthTestApp;
+import org.sdase.commons.server.auth.testing.test.AuthTestConfig;
+import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.LazyRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
+
+/** A test that checks if the jersey client that is used to load keys can use a proxy server */
+public class KeyLoaderProxyIT {
+  @ClassRule
+  public static final WireMockClassRule PROXY_WIRE =
+      new WireMockClassRule(wireMockConfig().dynamicPort());
+
+  @ClassRule
+  public static final EnvironmentRule ENVIRONMENT_RULE =
+      new EnvironmentRule().setEnv("AUTH_RULE", "{\"keys\": [{}]}");
+
+  private final SystemPropertyRule systemProperty =
+      new SystemPropertyRule()
+          .setProperty("http.proxyHost", "localhost")
+          .setProperty("http.proxyPort", "" + PROXY_WIRE.port())
+          .setProperty("http.nonProxyHosts", "localhost");
+
+  private final LazyRule<DropwizardAppRule<AuthTestConfig>> dw =
+      new LazyRule<>(
+          () ->
+              new DropwizardAppRule<>(
+                  AuthTestApp.class,
+                  ResourceHelpers.resourceFilePath("test-config.yaml"),
+                  config("auth.keys[0].type", "JWKS"),
+                  config("auth.keys[0].location", "http://sda.se/jwks")));
+
+  @Rule public final RuleChain rule = RuleChain.outerRule(systemProperty).around(dw);
+
+  @BeforeClass
+  public static void setupWiremock() {
+    // expect that the proxy receives the request
+    PROXY_WIRE.stubFor(
+        get("/jwks")
+            .withHeader(HttpHeaders.HOST, equalTo("sda.se"))
+            .willReturn(okJson("{\"keys\": []}")));
+  }
+
+  @Test
+  public void shouldUseProxy() {
+    // given
+    final String tokenWithUnknownKid =
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImNHV1RlQUJwWnYyN3RfWDFnTW92NEVlRWhEOXRBMWVhcUgzVzFmMXE4Y28ifQ.eyJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0In0.nHN-k_uvKNl8Nh5lXctQkL8KrWKggGiBQ-jaR0xIq_TAWBbhz5zkGXQTiNZwjPFOIcjyuL1xMCqzLPAKiI0Jy0hwOa4xcqukrWr4UwhKC50dnJiFqUgpGM0xLyT1D8JKdSNiVtYL0k-E5XCcpDEqOjHOG3Gw03VoZ0iRNeU2X49Rko8646l5j2g4QbuuOSn1a5G4ICMCAY7C6Vb55dgJtG_WAvkhFdBd_ShQEp_XfWJh6uq0E95_8yfzBx4UuK1Q-TLuWrXKxOlYNCuCH90NYG-3oF9w0gFtdXtYOFzPIEVIkU0Ra6sk_s0IInrEMD_3Q4fgE2PqOzqpuVaD_lHdAA";
+
+    // when
+    Response response =
+        createWebTarget()
+            .path("/secure") // NOSONAR
+            .request(APPLICATION_JSON)
+            .header(AUTHORIZATION, "Bearer " + tokenWithUnknownKid)
+            .get();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+
+    // one call on startup, one call from the request
+    PROXY_WIRE.verify(
+        2,
+        RequestPatternBuilder.newRequestPattern(RequestMethod.GET, urlEqualTo("/jwks"))
+            .withHeader(HttpHeaders.HOST, equalTo("sda.se")));
+  }
+
+  private WebTarget createWebTarget() {
+    return dw.getRule().client().target("http://localhost:" + dw.getRule().getLocalPort());
+  }
+}

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -327,8 +327,10 @@ opa:
   # Package name of the policy file that should be evaluated for authorization decision
   # The package name is used to resolve the full path
   policyPackage: http.authz
-  # readTimeout for OPA requests in millis, default 500
-  readTimeout: 500
+  # Advanced configuration of the HTTP client that is used to call the Open Policy Agent
+  opaClient:
+    # timeout for OPA requests, default 500ms
+    timeout: 500ms
 ```
 
 The config may be filled from environment variables if the
@@ -341,6 +343,25 @@ opa:
   baseUrl: ${OPA_URL:-http://localhost:8181}
   policyPackage: ${OPA_POLICY_PACKAGE}
 ```
+
+### HTTP Client Configuration and Proxy Support
+
+The client that calls the Open Policy Agent is configurable with the standard
+[Dropwizard configuration](https://www.dropwizard.io/en/latest/manual/configuration.html#man-configuration-clients-http).
+
+> Tip: There is no need to make all configuration properties available as environment variables.
+> Seldomly used properties can always be configured using [System Properties](https://www.dropwizard.io/en/latest/manual/core.html#man-core-configuration).
+> 
+```yaml
+opa:
+  opaClient:
+    timeout: 500ms
+```
+
+This configuration can be used to configure a proxy server if needed.
+
+*Please note that this client __does not__ consume the standard proxy system properties but needs to be configured manually! 
+The OPA should be deployed as near to the service as possible, so we don't expect the need for universal proxy settings.*
 
 ## Testing
 

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -147,8 +147,29 @@ In this case, the `AUTH_KEYS` variable should contain a JSON array of
 ]
 ```
 
-### Proxy Support
-The client consumes the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+### HTTP Client Configuration and Proxy Support
+
+The client that calls the OpenID Discovery endpoint or the JWKS url, is configurable with the standard
+[Dropwizard configuration](https://www.dropwizard.io/en/latest/manual/configuration.html#man-configuration-clients-http).
+
+> Tip: There is no need to make all configuration properties available as environment variables.
+> Seldomly used properties can always be configured using [System Properties](https://www.dropwizard.io/en/latest/manual/core.html#man-core-configuration).
+
+```yaml
+auth:
+  keyLoaderClient:
+    timeout: 500ms
+    proxy:
+      host: 192.168.52.11
+      port: 8080
+      scheme : http
+```
+
+This configuration can be used to configure a proxy server if needed.
+Use this if all clients should use an individual proxy configuration.
+
+In addition, the client consumes the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+Please note that a specific proxy configuration in the `HttpClientConfiguration` disables the proxy system properties for the client using that configuration.
 This can be helpful when all clients in an Application should use the same proxy configuration (this includes all clients that are created by the [`sda-commons-client-jersey` bundle](../sda-commons-client-jersey).
 
 ## OPA Bundle

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -147,6 +147,10 @@ In this case, the `AUTH_KEYS` variable should contain a JSON array of
 ]
 ```
 
+### Proxy Support
+The client consumes the standard [proxy system properties](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies).
+This can be helpful when all clients in an Application should use the same proxy configuration (this includes all clients that are created by the [`sda-commons-client-jersey` bundle](../sda-commons-client-jersey).
+
 ## OPA Bundle
 
 Details about the authorization with Open Policy Agent are documented within the authorization concept (see Confluence). 

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
@@ -10,7 +10,9 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
+import java.net.ProxySelector;
 import javax.ws.rs.client.Client;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.sdase.commons.server.auth.config.AuthConfig;
 import org.sdase.commons.server.auth.config.AuthConfigProvider;
 import org.sdase.commons.server.auth.config.KeyLocation;
@@ -93,8 +95,14 @@ public class AuthBundle<T extends Configuration> implements ConfiguredBundle<T> 
     environment.jersey().register(ForbiddenExceptionMapper.class);
   }
 
-  private Client createKeyLoaderClient(Environment environment, Tracer tracer) {
-    Client client = new JerseyClientBuilder(environment).build("keyLoader");
+  private Client createKeyLoaderClient(Environment environment, AuthConfig config, Tracer tracer) {
+    JerseyClientBuilder jerseyClientBuilder = new JerseyClientBuilder(environment);
+
+    // register a route planner that uses the default proxy variables (e.g. http.proxyHost)
+    jerseyClientBuilder.using(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
+
+    Client client = jerseyClientBuilder.build("keyLoader");
+
     registerTracing(client, tracer);
     return client;
   }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/config/AuthConfig.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/config/AuthConfig.java
@@ -1,10 +1,14 @@
 package org.sdase.commons.server.auth.config;
 
+import io.dropwizard.client.JerseyClientConfiguration;
 import java.util.ArrayList;
 import java.util.List;
 
 /** Configuration for authentication using JWT. */
 public class AuthConfig {
+
+  /** The client configuration of the HTTP client that is used for the key loader. */
+  private JerseyClientConfiguration keyLoaderClient;
 
   /** Keys that are allowed to sign tokens. */
   private List<KeyLocation> keys = new ArrayList<>();
@@ -20,6 +24,15 @@ public class AuthConfig {
    * production.
    */
   private boolean disableAuth;
+
+  public JerseyClientConfiguration getKeyLoaderClient() {
+    return keyLoaderClient;
+  }
+
+  public AuthConfig setKeyLoaderClient(JerseyClientConfiguration keyLoaderClient) {
+    this.keyLoaderClient = keyLoaderClient;
+    return this;
+  }
 
   public List<KeyLocation> getKeys() {
     return keys;

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaClientConfiguration.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaClientConfiguration.java
@@ -1,0 +1,11 @@
+package org.sdase.commons.server.opa.config;
+
+import io.dropwizard.client.JerseyClientConfiguration;
+
+/** A customized {@link JerseyClientConfiguration} that disables gzip by default. */
+public class OpaClientConfiguration extends JerseyClientConfiguration {
+  public OpaClientConfiguration() {
+    setGzipEnabled(false);
+    setGzipEnabledForRequests(false);
+  }
+}

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaConfig.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaConfig.java
@@ -5,6 +5,8 @@ import javax.validation.constraints.NotNull;
 /** Configuration for requesting OPA PDP. */
 @SuppressWarnings("UnusedReturnValue")
 public class OpaConfig {
+  /** The client configuration of the HTTP client that is used to call the Open Policy Agent. */
+  private OpaClientConfiguration opaClient;
 
   /** flag if OPA is disabled (for testing) */
   private boolean disableOpa;
@@ -20,8 +22,27 @@ public class OpaConfig {
    */
   @NotNull private String policyPackage = "";
 
-  /** readTimeout for opa requests in milliseconds */
-  private int readTimeout = 500;
+  /**
+   * readTimeout for opa requests in milliseconds
+   *
+   * @deprecated The client that is used to call the OPA is now configurable. Prefer to configure
+   *     {@code opaClient.timeout} instead:
+   *     <pre>{@code
+   * opa:
+   *   opaClient:
+   *     timeout: 500ms
+   * }</pre>
+   */
+  @Deprecated private Integer readTimeout;
+
+  public OpaClientConfiguration getOpaClient() {
+    return opaClient;
+  }
+
+  public OpaConfig setOpaClient(OpaClientConfiguration opaClient) {
+    this.opaClient = opaClient;
+    return this;
+  }
 
   public boolean isDisableOpa() {
     return disableOpa;
@@ -50,11 +71,32 @@ public class OpaConfig {
     return this;
   }
 
-  public int getReadTimeout() {
+  /**
+   * @deprecated The client that is used to call the OPA is now configurable. Prefer to configure
+   *     {@code opaClient.timeout} instead:
+   *     <pre>{@code
+   * opa:
+   *   opaClient:
+   *     timeout: 500ms
+   * }</pre>
+   */
+  @Deprecated
+  public Integer getReadTimeout() {
     return readTimeout;
   }
 
-  public OpaConfig setReadTimeout(int readTimeout) {
+  /**
+   * @param readTimeout the read timeout
+   * @deprecated The client that is used to call the OPA is now configurable. Prefer to configure
+   *     {@code opaClient.timeout} instead:
+   *     <pre>{@code
+   * opa:
+   *   opaClient:
+   *     timeout: 500ms
+   * }</pre>
+   */
+  @Deprecated
+  public OpaConfig setReadTimeout(Integer readTimeout) {
     this.readTimeout = readTimeout;
     return this;
   }

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
@@ -1,0 +1,113 @@
+package org.sdase.commons.server.opa;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.ResourceHelpers;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.HashMap;
+import java.util.Map;
+import javax.validation.Valid;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.opa.config.OpaConfig;
+import org.sdase.commons.server.testing.LazyRule;
+
+public class OpaBundleClientConfigurationIT {
+  public static final WireMockRule WIRE =
+      new WireMockRule(new WireMockConfiguration().dynamicPort());
+
+  private static final LazyRule<DropwizardAppRule<TestConfiguration>> DW =
+      new LazyRule<>(
+          () ->
+              new DropwizardAppRule<>(
+                  TestApplication.class,
+                  ResourceHelpers.resourceFilePath("test-config-key-provider.yaml"),
+                  config("opa.baseUrl", WIRE.baseUrl()),
+                  config("opa.policyPackage", "test"),
+                  config("opa.opaClient.userAgent", "my-user-agent")));
+
+  @ClassRule public static RuleChain RULE = RuleChain.outerRule(WIRE).around(DW);
+
+  @BeforeClass
+  public static void beforeClass() {
+    WIRE.resetAll();
+    WIRE.stubFor(post(anyUrl()).willReturn(okJson("{\"result\": {\"allow\": true}}")));
+  }
+
+  @Test
+  public void shouldSendCustomUserAgentInTheOpaRequest() {
+    Response response =
+        createWebTarget()
+            .path("/") // NOSONAR
+            .request(APPLICATION_JSON)
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+
+    WIRE.verify(
+        postRequestedFor(urlEqualTo("/v1/data/test"))
+            .withHeader(USER_AGENT, equalTo("my-user-agent")));
+  }
+
+  private WebTarget createWebTarget() {
+    return DW.getRule().client().target("http://localhost:" + DW.getRule().getLocalPort());
+  }
+
+  public static class TestConfiguration extends Configuration {
+    @Valid private OpaConfig opa;
+
+    public OpaConfig getOpa() {
+      return opa;
+    }
+
+    public TestConfiguration setOpa(OpaConfig opa) {
+      this.opa = opa;
+      return this;
+    }
+  }
+
+  @Path("")
+  public static class TestApplication extends Application<TestConfiguration> {
+    final OpaBundle<TestConfiguration> opaBundle =
+        OpaBundle.builder().withOpaConfigProvider(TestConfiguration::getOpa).build();
+
+    @Override
+    public void initialize(Bootstrap<TestConfiguration> bootstrap) {
+      bootstrap.addBundle(opaBundle);
+    }
+
+    @Override
+    public void run(TestConfiguration configuration, Environment environment) {
+      environment.jersey().register(this);
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Map<String, Object> get() {
+      return new HashMap<>();
+    }
+  }
+}

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/SystemPropertyRule.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/SystemPropertyRule.java
@@ -1,0 +1,61 @@
+package org.sdase.commons.server.testing;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * This {@link TestRule} allows to set system properties for JUnit tests. All system properties will
+ * be reset after the test has run.
+ *
+ * <p>Example:
+ *
+ * <pre>
+ *   class MyTest {
+ *     &#64;ClassRule public static final SystemPropertyRule PROP = new SystemPropertyRule().setProperty("DISABLE_JWT", "true");
+ *   }
+ * </pre>
+ */
+public class SystemPropertyRule implements TestRule {
+
+  private final Map<String, String> propertiesToSet = new HashMap<>();
+
+  private final Map<String, String> propertiesToReset = new HashMap<>();
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        propertiesToSet.forEach(SystemPropertyRule.this::applyProperty);
+        try {
+          base.evaluate();
+        } finally {
+          propertiesToReset.forEach(SystemPropertyRule.this::applyProperty);
+        }
+      }
+    };
+  }
+
+  public SystemPropertyRule setProperty(String key, String value) {
+    propertiesToSet.put(key, value);
+    propertiesToReset.put(key, System.getProperty(key));
+    return this;
+  }
+
+  public SystemPropertyRule unsetProperty(String key) {
+    propertiesToSet.put(key, null);
+    propertiesToReset.put(key, System.getProperty(key));
+    return this;
+  }
+
+  private void applyProperty(String key, String value) {
+    if (value == null) {
+      System.clearProperty(key);
+    } else {
+      System.setProperty(key, value);
+    }
+  }
+}

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/EnvironmentRuleTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/EnvironmentRuleTest.java
@@ -31,6 +31,7 @@ public class EnvironmentRuleTest {
   @AfterClass
   public static void assertVariableIsNotSetAfterTest() {
     Assertions.assertThat(System.getenv("envForTesting")).isNull();
+    Assertions.assertThat(System.getenv("envNotForTesting")).isEqualTo("envNotForTestingValue");
     Environment.unsetEnv("envNotForTesting");
   }
 }

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/SystemPropertyRuleTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/SystemPropertyRuleTest.java
@@ -1,0 +1,41 @@
+package org.sdase.commons.server.testing;
+
+import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class SystemPropertyRuleTest {
+
+  @Rule
+  public SystemPropertyRule PROP =
+      new SystemPropertyRule()
+          .setProperty("envForTesting", "envForTestingValue")
+          .unsetProperty("envNotForTesting");
+
+  @BeforeClass
+  public static void assertVariableIsNotSetBeforeTest() {
+    Assertions.assertThat(System.getProperty("envForTesting")).isNull();
+    Assertions.assertThat(System.getProperty("envNotForTesting")).isNull();
+    System.setProperty("envNotForTesting", "envNotForTestingValue");
+  }
+
+  @Test
+  public void shouldBeSetInTest() {
+    Assertions.assertThat(System.getProperty("envForTesting")).isEqualTo("envForTestingValue");
+  }
+
+  @Test
+  public void shouldBeUnsetInTest() {
+    Assertions.assertThat(System.getProperty("envNotForTesting")).isNull();
+  }
+
+  @AfterClass
+  public static void assertVariableIsNotSetAfterTest() {
+    Assertions.assertThat(System.getProperty("envForTesting")).isNull();
+    Assertions.assertThat(System.getProperty("envNotForTesting"))
+        .isEqualTo("envNotForTestingValue");
+    System.clearProperty("envNotForTesting");
+  }
+}


### PR DESCRIPTION
Adds a property to the `AuthConfig` in order to use all properties of Dropwizard's original [`HttpClientConfiguration`](https://github.com/dropwizard/dropwizard/blob/master/dropwizard-client/src/main/java/io/dropwizard/client/HttpClientConfiguration.java), including Proxy settings.

Dropwizard also provides the option to override configurations via [system properties](https://www.dropwizard.io/en/latest/manual/core.html#configuration). Thus something like
```sh
java -Ddw.auth.keyLoaderClient.proxyConfiguration.host=asdf server my-config.json
```
 should work even if the service doesn't specify the options in the original `config.yml`. This might be an alternative to #453 that is more aligned with the features of Dropwizard.

---

In addition I added an experimental commit that makes our custom `HttpClientConfiguration` extend the `JerseyClientConfiguration`. This would be a breaking change (builder-pattern setters switch to void-setters, though I didn't find any use in our organization). It will be possible to also configure all other clients (as long as the configuration has been added to the application's configuration class). I think this a way better pattern than circumventing our limiting configuration class by custom configurations whenever we need to make timeouts configurable. It also adds out-of-the-box proxy support that can be individually controlled for every HTTP client.

---

Both the `AuthConfig` as well as the `JerseyClientBuilder` can now read the [global java proxy settings](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html#Proxies). So the application operator can decide whether they want to globally activate a proxy or if they only want to configure it on the client level.
