### PR TITLE
fix(server-auth): don't include the exception class when a token decoding failed

### DIFF
--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/error/JwtAuthException.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/error/JwtAuthException.java
@@ -18,6 +18,6 @@ public class JwtAuthException extends RuntimeException {
   }
 
   public JwtAuthException(Throwable cause) {
-    super(cause);
+    this(cause.getMessage(), cause);
   }
 }


### PR DESCRIPTION
This PR also adds tests that checks if the error messages are actually the ones that are expected to be returned.