### PR TITLE
chore(deps): add another label to dependabot PRs

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,6 +12,9 @@ update_configs:
     target_branch: "release/1.x.x"
     directory: "/"
     update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+      - "release-1.x.x"
     commit_message:
       prefix: "fix"
       prefix_development: "chore"
@@ -28,6 +31,9 @@ update_configs:
     target_branch: "release/1.x.x"
     directory: "/"
     update_schedule: "monthly"
+    default_labels:
+      - "dependencies"
+      - "release-1.x.x"
     commit_message:
       prefix: "chore"
       prefix_development: "chore"


### PR DESCRIPTION
This way it's easier to distinguish updates for the current release and the maintenance branch.

See https://dependabot.com/docs/config-file/#default_labels