### PR TITLE
feat: add HalLinkProvider to sda-commons-server-jackson

### DIFF
--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
@@ -1,0 +1,210 @@
+package org.sda.commons.server.jackson.hal;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An utility class to process and store the invocation information of a method. It also creates and
+ * returns a proxy that uses the method invocation handler to process the invocation information.
+ */
+public class HalLinkInvocationStateUtility {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HalLinkInvocationStateUtility.class);
+
+  private static final ThreadLocal<MethodInvocationState> THREAD_LOCAL_METHOD_INVOCATION_STATE =
+      ThreadLocal.withInitial(MethodInvocationState::new);
+
+  // Method invocation handler to process and save the current state of the method invocation
+  private static final InvocationHandler METHOD_PROCESSING_INVOCATION_HANDLER =
+      (proxy, method, methodArguments) -> {
+        // Get  invocation state from current thread
+        final MethodInvocationState methodInvocationState =
+            THREAD_LOCAL_METHOD_INVOCATION_STATE.get();
+        final String methodName = method.getName();
+        methodInvocationState.setInvokedMethod(methodName);
+        LOG.debug("Last invoked method '{}' added to current invocation state", methodName);
+        // Process annotated query and path parameters
+        processParams(methodInvocationState, methodArguments, method.getParameters());
+        methodInvocationState.processed();
+        // Do nothing
+        return null;
+      };
+
+  private HalLinkInvocationStateUtility() {}
+
+  /**
+   * Creates and returns a proxy instance based on the passed type parameter with a method
+   * invocation handler, which processes and saves the needed method invocation information in the
+   * current thread. Parameters in the afterwards called method of the proxy will be used to resolve
+   * the URI template of the corresponding method. It should be ensured that the parameters are
+   * annotated with {@linkplain PathParam} or with {@linkplain QueryParam}. The passed class type
+   * must represent interfaces, not classes or primitive types.
+   *
+   * @param <T> the type parameter based on the passed type. Should not be null {@literal null}.
+   * @param type the type on which the method should be invoked.
+   * @return the proxy instance
+   * @throws HalLinkMethodInvocationException if the proxy instance could not be created
+   */
+  static <T> T methodOn(Class<T> type) {
+    return createProxy(type);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T createProxy(Class<T> type) {
+    THREAD_LOCAL_METHOD_INVOCATION_STATE.get().setType(type);
+    LOG.debug("Class type: '{}' added to the current invocation state", type);
+    try {
+      return (T)
+          Proxy.newProxyInstance(
+              type.getClassLoader(), new Class[] {type}, METHOD_PROCESSING_INVOCATION_HANDLER);
+    } catch (IllegalArgumentException | SecurityException | NullPointerException e) {
+      throw new HalLinkMethodInvocationException(
+          String.format("Could not create proxy instance of type '%s' for method invocation", type),
+          e);
+    }
+  }
+
+  private static void processParams(
+      MethodInvocationState methodInvocationState,
+      Object[] methodArguments,
+      Parameter[] parameters) {
+    final List<Parameter> annotatedParams =
+        Arrays.stream(parameters)
+            .filter(
+                parameter ->
+                    parameter.getAnnotation(PathParam.class) != null
+                        || parameter.getAnnotation(QueryParam.class) != null)
+            .collect(Collectors.toList());
+
+    // Check if all parameters has an Query/Path-Param annotation
+    if (annotatedParams.size() != parameters.length) {
+      throw new HalLinkMethodInvocationException(
+          "Each method parameter needs at least a @PathParam or @QueryParam annotation.");
+    }
+
+    // Correlation between method argument order and annotatedParams order
+    for (int i = 0; i < annotatedParams.size(); i++) {
+      final PathParam pathParam = annotatedParams.get(i).getAnnotation(PathParam.class);
+      final Object paramValue = methodArguments[i];
+      if (pathParam != null) {
+        methodInvocationState.getPathParams().put(pathParam.value(), paramValue);
+        LOG.debug(
+            "Saved PathParam: '{}' with value: '{}' to current invocation state",
+            pathParam.value(),
+            paramValue);
+      } else {
+        final QueryParam queryParam = annotatedParams.get(i).getAnnotation(QueryParam.class);
+        methodInvocationState.getQueryParams().put(queryParam.value(), paramValue);
+        LOG.debug(
+            "Saved QueryParam: '{}' with value: '{}' to current invocation state",
+            queryParam.value(),
+            paramValue);
+      }
+    }
+  }
+
+  /**
+   * Load the method invocation state of the current thread.
+   *
+   * @return the method invocation state
+   */
+  static MethodInvocationState loadMethodInvocationState() {
+    LOG.debug("Load invocation state of current thread");
+    return THREAD_LOCAL_METHOD_INVOCATION_STATE.get();
+  }
+
+  /** Unload the method invocation state of the current thread. */
+  static void unloadMethodInvocationState() {
+    LOG.debug("Remove invocation state of current thread");
+    THREAD_LOCAL_METHOD_INVOCATION_STATE.remove();
+  }
+
+  /** Data class to save method invocation information */
+  static class MethodInvocationState {
+    private boolean processed = false;
+    private Class<?> type;
+    private String invokedMethod;
+    private final Map<String, Object> pathParams = new HashMap<>();
+    private final Map<String, Object> queryParams = new HashMap<>();
+
+    /**
+     * Gets type of the class of the invoked method.
+     *
+     * @return the type
+     */
+    Class<?> getType() {
+      return type;
+    }
+
+    /**
+     * Sets type of the class of the invoked method.
+     *
+     * @param type the type
+     */
+    void setType(Class<?> type) {
+      this.type = type;
+    }
+
+    /**
+     * Gets the method name.
+     *
+     * @return the invoked method name
+     */
+    String getInvokedMethod() {
+      return invokedMethod;
+    }
+
+    /**
+     * Sets the method name.
+     *
+     * @param invokedMethod the invoked method name
+     */
+    void setInvokedMethod(String invokedMethod) {
+      this.invokedMethod = invokedMethod;
+    }
+
+    /**
+     * Gets the Key-Value pairs of the processed {@linkplain PathParam#value()} and the
+     * corresponding method arguments of the invoked method.
+     *
+     * @return the path params
+     */
+    Map<String, Object> getPathParams() {
+      return pathParams;
+    }
+
+    /**
+     * Gets the Key-Value pairs of the processed {@linkplain QueryParam#value()} and the
+     * corresponding method arguments of the invoked method.
+     *
+     * @return the query params
+     */
+    Map<String, Object> getQueryParams() {
+      return queryParams;
+    }
+
+    /**
+     * Returns {@literal true} if the invoked method is processed.
+     *
+     * @return the boolean
+     */
+    boolean isProcessed() {
+      return processed;
+    }
+
+    /** Set the state of the method invocation to processed. */
+    void processed() {
+      this.processed = true;
+    }
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkMethodInvocationException.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkMethodInvocationException.java
@@ -1,0 +1,12 @@
+package org.sda.commons.server.jackson.hal;
+
+public class HalLinkMethodInvocationException extends RuntimeException {
+
+  public HalLinkMethodInvocationException(String message) {
+    super(message);
+  }
+
+  public HalLinkMethodInvocationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
@@ -1,7 +1,6 @@
 package org.sda.commons.server.jackson.hal;
 
 import io.openapitools.jackson.dataformat.hal.HALLink;
-import io.openapitools.jackson.dataformat.hal.HALLink.Builder;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
@@ -15,9 +14,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Helper utility that can be registered in the Jersey environment to be injected into services. It
- * provides the context-based HALLink for a JAX-RS interface using the {@linkplain
- * javax.ws.rs.PathParam} and {@linkplain javax.ws.rs.QueryParam} annotations.
+ * Helper utility which is registered as singleton instance in the jersey environment via the
+ * {@linkplain org.sdase.commons.server.jackson.JacksonConfigurationBundle}. It provides the
+ * context-based HALLink for a JAX-RS interface using the {@linkplain javax.ws.rs.PathParam} and
+ * {@linkplain javax.ws.rs.QueryParam} annotations.
  *
  * <p>Usage:
  *
@@ -29,17 +29,27 @@ import org.slf4j.LoggerFactory;
  *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
  * }
  *
- * HALLink link = halLinkProvider.linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed"));
+ * // Get the generated HALLink
+ * HALLink HalLink = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asHalLink();
+ * // Get the generated URI
+ * URI Uri = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asURI();
  * </pre>
  *
- * Would create a HALLink with the following URL: {@code
- * "contextBasePath/testPath/ResourceID?query=detailed"}
+ * <p>The example would create the following URI: {@code
+ * "baseUri/testPath/ResourceID?query=detailed"}
+ *
+ * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs. If
+ * no request context is available, it will fall back to a simple path without host that does not
+ * include any configured root or context path.
  */
 public class HalLinkProvider implements Feature {
 
   private static final Logger LOG = LoggerFactory.getLogger(HalLinkProvider.class);
+  private static HalLinkProvider instance;
 
   @Context private UriInfo uriInfo;
+
+  private HalLinkProvider() {}
 
   /**
    * Creates a {@linkplain HALLink} based on JAX-RS annotated parameters of an interface. This
@@ -58,18 +68,29 @@ public class HalLinkProvider implements Feature {
    *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
    * }
    *
-   * HALLink link = halLinkProvider.linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed"));
+   * // Get the generated HALLink
+   * HALLink halLink = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asHalLink();
+   * // Get the generated URI
+   * URI uri = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asURI();
    * </pre>
    *
-   * The example would create a HALLink with the following URL: {@code
-   * "contextBasePath/testPath/ResourceID?query=detailed"}
+   * <p>The example would create the following URI: {@code
+   * "baseUri/testPath/ResourceID?query=detailed"}
+   *
+   * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs.
+   * If no request context is available, it will fall back to a simple path without host that does
+   * not include any configured root or context path.
    *
    * @param invocation the invocation placeholder.
-   * @return the generated HALLink based on the method invocation
+   * @return the generated {@linkplain LinkResult} based on the method invocation
    * @throws HalLinkMethodInvocationException - If no method invocation is provided via {@linkplain
    *     HalLinkProvider#methodOn(Class)}
    */
-  public HALLink linkTo(Object invocation) {
+  public static LinkResult linkTo(Object invocation) {
+    return getInstance().linkToInvocation(invocation);
+  }
+
+  private LinkResult linkToInvocation(Object invocation) {
     final MethodInvocationState methodInvocationState =
         HalLinkInvocationStateUtility.loadMethodInvocationState();
     if (invocation != null || !methodInvocationState.isProcessed()) {
@@ -83,27 +104,28 @@ public class HalLinkProvider implements Feature {
             .resolveTemplates(methodInvocationState.getPathParams());
     // Add Query Params from invocation state
     methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
-    final HALLink link = new Builder(uriBuilder.build()).build();
+    LinkResult linkResult = new LinkResult(uriBuilder.build());
     HalLinkInvocationStateUtility.unloadMethodInvocationState();
-    return link;
+    return linkResult;
   }
 
   /**
    * Creates and returns a proxy instance based on the passed type parameter with a method
    * invocation handler, which processes and saves the needed method invocation information in the
    * current thread. Parameters in the afterwards called method of the proxy will be used to resolve
-   * the URI template of the corresponding method.
+   * the URI template of the corresponding method. The called method of the interface must have a
+   * return type, which means it should not be of type {@code void}.
    *
    * <p>After the method invocation of the proxy instance the outer method {@linkplain
-   * HalLinkProvider#linkTo(Object)} will process the derived information of the invocation to *
+   * HalLinkProvider#linkTo(Object)} will process the derived information of the invocation to
    * create the HALLink.
    *
    * <p>It should be ensured that the parameters are annotated with {@linkplain PathParam} or with
    * {@linkplain QueryParam}. The passed class type must represent interfaces, not classes or
    * primitive types.
    *
-   * @param <T> the type parameter based on the passed type. Should not be null {@literal null}.
-   * @param type the type on which the method should be invoked.
+   * @param <T> the type parameter based on the passed type.
+   * @param type the type on which the method should be invoked must be an interface.
    * @return the proxy instance
    * @throws HalLinkMethodInvocationException if the proxy instance could not be created
    */
@@ -125,5 +147,17 @@ public class HalLinkProvider implements Feature {
   @Override
   public boolean configure(FeatureContext context) {
     return true;
+  }
+
+  /**
+   * Returns the singleton instance of the HalLinkProvider
+   *
+   * @return the HalLinProvider instance
+   */
+  public static synchronized HalLinkProvider getInstance() {
+    if (instance == null) {
+      instance = new HalLinkProvider();
+    }
+    return instance;
   }
 }

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
@@ -1,0 +1,129 @@
+package org.sda.commons.server.jackson.hal;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.HALLink.Builder;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
+import org.sda.commons.server.jackson.hal.HalLinkInvocationStateUtility.MethodInvocationState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper utility that can be registered in the Jersey environment to be injected into services. It
+ * provides the context-based HALLink for a JAX-RS interface using the {@linkplain
+ * javax.ws.rs.PathParam} and {@linkplain javax.ws.rs.QueryParam} annotations.
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ * &#064;Path("")
+ * interface TestApi {
+ *  &#064;Path("/testPath/{testArg}")
+ *  &#064;GET
+ *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
+ * }
+ *
+ * HALLink link = halLinkProvider.linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed"));
+ * </pre>
+ *
+ * Would create a HALLink with the following URL: {@code
+ * "contextBasePath/testPath/ResourceID?query=detailed"}
+ */
+public class HalLinkProvider implements Feature {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HalLinkProvider.class);
+
+  @Context private UriInfo uriInfo;
+
+  /**
+   * Creates a {@linkplain HALLink} based on JAX-RS annotated parameters of an interface. This
+   * method requires a second entrypoint with {@linkplain
+   * HalLinkInvocationStateUtility#methodOn(Class)} to process the annotated JAX-RS interface with
+   * the corresponding {@linkplain PathParam} and {@linkplain QueryParam} and the passed arguments
+   * to the proxied method invocation.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * &#064;Path("")
+   * interface TestApi {
+   *  &#064;Path("/testPath/{testArg}")
+   *  &#064;GET
+   *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
+   * }
+   *
+   * HALLink link = halLinkProvider.linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed"));
+   * </pre>
+   *
+   * The example would create a HALLink with the following URL: {@code
+   * "contextBasePath/testPath/ResourceID?query=detailed"}
+   *
+   * @param invocation the invocation placeholder.
+   * @return the generated HALLink based on the method invocation
+   * @throws HalLinkMethodInvocationException - If no method invocation is provided via {@linkplain
+   *     HalLinkProvider#methodOn(Class)}
+   */
+  public HALLink linkTo(Object invocation) {
+    final MethodInvocationState methodInvocationState =
+        HalLinkInvocationStateUtility.loadMethodInvocationState();
+    if (invocation != null || !methodInvocationState.isProcessed()) {
+      throw new HalLinkMethodInvocationException("No proxied method invocation processed.");
+    }
+    final UriBuilder uriBuilder =
+        baseUriBuilder()
+            .path(methodInvocationState.getType())
+            .path(methodInvocationState.getType(), methodInvocationState.getInvokedMethod())
+            // Add Path Params from invocation state
+            .resolveTemplates(methodInvocationState.getPathParams());
+    // Add Query Params from invocation state
+    methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
+    final HALLink link = new Builder(uriBuilder.build()).build();
+    HalLinkInvocationStateUtility.unloadMethodInvocationState();
+    return link;
+  }
+
+  /**
+   * Creates and returns a proxy instance based on the passed type parameter with a method
+   * invocation handler, which processes and saves the needed method invocation information in the
+   * current thread. Parameters in the afterwards called method of the proxy will be used to resolve
+   * the URI template of the corresponding method.
+   *
+   * <p>After the method invocation of the proxy instance the outer method {@linkplain
+   * HalLinkProvider#linkTo(Object)} will process the derived information of the invocation to *
+   * create the HALLink.
+   *
+   * <p>It should be ensured that the parameters are annotated with {@linkplain PathParam} or with
+   * {@linkplain QueryParam}. The passed class type must represent interfaces, not classes or
+   * primitive types.
+   *
+   * @param <T> the type parameter based on the passed type. Should not be null {@literal null}.
+   * @param type the type on which the method should be invoked.
+   * @return the proxy instance
+   * @throws HalLinkMethodInvocationException if the proxy instance could not be created
+   */
+  public static <T> T methodOn(Class<T> type) {
+    return HalLinkInvocationStateUtility.methodOn(type);
+  }
+
+  private UriBuilder baseUriBuilder() {
+    try {
+      return uriInfo.getBaseUriBuilder();
+    } catch (Exception e) {
+      LOG.error(
+          "Unable to access baseUriBuilder from request context. Using context unaware builder as a fallback.",
+          e);
+      return new JerseyUriBuilder().path("/");
+    }
+  }
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    return true;
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/LinkResult.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/LinkResult.java
@@ -1,0 +1,39 @@
+package org.sda.commons.server.jackson.hal;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.HALLink.Builder;
+import java.net.URI;
+
+/** Wrapper class to provide the processed Link as {@linkplain URI} or {@linkplain HALLink} */
+public final class LinkResult {
+  private final URI uri;
+  private final HALLink halLink;
+
+  /**
+   * Instantiates a new Link result.
+   *
+   * @param uri the uri
+   */
+  public LinkResult(URI uri) {
+    this.uri = uri;
+    this.halLink = new Builder(uri).build();
+  }
+
+  /**
+   * Returns the link result as {@linkplain URI}
+   *
+   * @return the uri
+   */
+  public URI asUri() {
+    return this.uri;
+  }
+
+  /**
+   * Returns the link result as {@linkplain HALLink}
+   *
+   * @return the hal link
+   */
+  public HALLink asHalLink() {
+    return halLink;
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.time.ZonedDateTime;
 import java.util.function.Consumer;
+import org.sda.commons.server.jackson.hal.HalLinkProvider;
 import org.sdase.commons.server.jackson.errors.ApiExceptionMapper;
 import org.sdase.commons.server.jackson.errors.EarlyEofExceptionMapper;
 import org.sdase.commons.server.jackson.errors.JerseyValidationExceptionMapper;
@@ -86,6 +87,9 @@ public class JacksonConfigurationBundle implements ConfiguredBundle<Configuratio
       objectMapper.registerModule(jacksonFieldFilterModule);
       environment.jersey().register(jacksonFieldFilterModule);
     }
+
+    // register singleton HalLinkProvider
+    environment.jersey().register(HalLinkProvider.getInstance());
 
     // register Exception Mapper
     environment.jersey().register(ApiExceptionMapper.class);

--- a/sda-commons-server-jackson/src/test/java/org/sda/commons/server/jackson/hal/HalLinkProviderTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sda/commons/server/jackson/hal/HalLinkProviderTest.java
@@ -1,0 +1,105 @@
+package org.sda.commons.server.jackson.hal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.sda.commons.server.jackson.hal.HalLinkProvider.methodOn;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import org.junit.Test;
+
+public class HalLinkProviderTest {
+
+  HalLinkProvider testee = new HalLinkProvider();
+
+  @Test
+  public void shouldProvideHalLinkForNormalPathParams() {
+    final HALLink test = testee.linkTo(methodOn(TestApi.class).testMethod("TEST"));
+    assertThat(test.getHref()).isEqualTo("/testPath/TEST");
+  }
+
+  @Test
+  public void shouldFailWhenNoInterfaceIsProvided() {
+    assertThatThrownBy(() -> testee.linkTo(methodOn(TestController.class).testMethod("FAIL")))
+        .isInstanceOf(HalLinkMethodInvocationException.class);
+  }
+
+  @Test
+  public void shouldProvideHalLinkForQueryParam() {
+    final HALLink test = testee.linkTo(methodOn(TestApi.class).testMethodQueryParam("TEST"));
+    assertThat(test.getHref()).isEqualTo("/testPath?testRequestParam=TEST");
+  }
+
+  @Test
+  public void shouldProvideHalLinkForDetailed() {
+    final HALLink test =
+        testee.linkTo(methodOn(TestApi.class).testMethodDetail("TEST", 1, "testTheQuery"));
+    assertThat(test.getHref()).isEqualTo("/testPath/TEST/detail/testTheQuery?query=1");
+  }
+
+  @Test
+  public void shouldFailWithoutAnnotation() {
+    assertThatThrownBy(
+            () ->
+                testee.linkTo(methodOn(TestApi.class).testMethodWithoutPathParamAnnotation("FAIL")))
+        .isInstanceOf(HalLinkMethodInvocationException.class);
+  }
+
+  @Test
+  public void shouldDoNothingWhenNoParamsAreProvided() {
+    final HALLink test = testee.linkTo(methodOn(TestApi.class).testMethodWithoutParams());
+    assertThat(test.getHref()).isEqualTo("/testPathWithNoParams");
+  }
+
+  @Test
+  public void shouldFailWithNonProxiedMethod() {
+    assertThatThrownBy(() -> testee.linkTo("testMethod"))
+        .isInstanceOf(HalLinkMethodInvocationException.class);
+  }
+
+  @Test
+  public void shouldFailWithNullProxiedMethod() {
+    assertThatThrownBy(() -> testee.linkTo(null))
+        .isInstanceOf(HalLinkMethodInvocationException.class)
+        .hasMessageContaining("No proxied method invocation processed.");
+  }
+}
+
+@Path("")
+interface TestApi {
+  @Path("/testPath/{testArg}")
+  @GET
+  String testMethod(@PathParam("testArg") String testArg);
+
+  @Path("/testPath/{testArg}/detail/{testArg2}")
+  @GET
+  String testMethodDetail(
+      @PathParam("testArg") String testArg,
+      @QueryParam("query") int testArgTwo,
+      @PathParam("testArg2") String query);
+
+  @Path("/testPath")
+  @GET
+  String testMethodQueryParam(@QueryParam("testRequestParam") String testArg);
+
+  @Path("/testPathWithNoParams")
+  @GET
+  String testMethodWithoutParams();
+
+  @Path("/testPath/{testArg}")
+  @GET
+  String testMethodWithoutPathParamAnnotation(String testArg);
+}
+
+@Path("")
+class TestController {
+
+  @Path("/testPath/{testArg}")
+  @GET
+  public String testMethod(@PathParam("testArg") String testArg) {
+    return null;
+  }
+}


### PR DESCRIPTION
We have identified that the HalLinkProvider is often implemented redundantly if the required entity link is to be provided. 
Here is a suggestion how we can build the HALLink in a comfortable way.