### PR TITLE
fix(server-jackson): support nullable query params in the HalLinkProvider

### DIFF
--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
@@ -104,11 +104,17 @@ public class HalLinkInvocationStateUtility {
             paramValue);
       } else {
         final QueryParam queryParam = annotatedParams.get(i).getAnnotation(QueryParam.class);
-        methodInvocationState.getQueryParams().put(queryParam.value(), paramValue);
-        LOG.debug(
-            "Saved QueryParam: '{}' with value: '{}' to current invocation state",
-            queryParam.value(),
-            paramValue);
+        if (paramValue != null) {
+          methodInvocationState.getQueryParams().put(queryParam.value(), paramValue);
+          LOG.debug(
+              "Saved QueryParam: '{}' with value: '{}' to current invocation state",
+              queryParam.value(),
+              paramValue);
+        } else {
+          LOG.debug(
+              "Ignoring QueryParam: '{}' with null-value. Won't be used for building the Link.",
+              queryParam.value());
+        }
       }
     }
   }

--- a/sda-commons-server-jackson/src/test/java/org/sda/commons/server/jackson/hal/HalLinkProviderTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sda/commons/server/jackson/hal/HalLinkProviderTest.java
@@ -41,6 +41,13 @@ public class HalLinkProviderTest {
   }
 
   @Test
+  public void shouldProvideHalLinkForDetailedAndIgnoreQueryParamWithNullValue() {
+    final LinkResult linkResult =
+        linkTo(methodOn(TestApi.class).testMethodDetail("TEST", null, "testTheQuery"));
+    assertLinkResult(linkResult, "/testPath/TEST/detail/testTheQuery");
+  }
+
+  @Test
   public void shouldFailWithoutAnnotation() {
     assertThatThrownBy(
             () -> linkTo(methodOn(TestApi.class).testMethodWithoutPathParamAnnotation("FAIL")))
@@ -84,7 +91,7 @@ interface TestApi {
   @GET
   String testMethodDetail(
       @PathParam("testArg") String testArg,
-      @QueryParam("query") int testArgTwo,
+      @QueryParam("query") Integer testArgTwo,
       @PathParam("testArg2") String query);
 
   @Path("/testPath")


### PR DESCRIPTION
In some cases it could be required that the QueryParam is nullable. Maybe you want to link to a specific set of entities which are prefiltered?

```
    URI uri = linkTo(methodOn(MedicalHistoryService.class).getEvents("12345", null, null, null, null, null, null)).asUri();
    assertThat(uri).hasPath("/medicalEvents").hasParameter("insuredPersonId", "12345");
    assertThat(uri.toString()).isEqualTo("/medicalEvents?insuredPersonId=12345");
```