### PR TITLE
feat(server-kafka): allow the configuration of the sasl.mechanism

### DIFF
--- a/sda-commons-server-kafka/README.md
+++ b/sda-commons-server-kafka/README.md
@@ -11,19 +11,18 @@ implements a polling loop for Kafka consumers. The user of this bundle must only
 
 ## Usage
 Add the following dependency:
-```
+```groovy
 compile 'org.sdase.commons:sda-commons-server-kafka:<current-version>'
 ```
 
 **Bootstrap**
 
-The bundle got enhanced to allow more control and flexibility how Kafka messages are consumed and which commit strategy is used. How to use
-the old and now deprecated `KafkaBundle::registerMessageHandler` approach is documented [here](docs/deprecated.md).
+The bundle got enhanced to allow more control and flexibility how Kafka messages are consumed and which commit strategy is used.
      
 The bundle should be added as field to the application since it provides methods for the creation of `MessageProducer` and `MessageListener`.
 The Builders for `MessageListenerRegistration` and `ProducerRegistration` supports the user in the creation of these complex configurable objects. 
  
-```
+```java
 public class DemoApplication {
    private final KafkaBundle<AppConfiguration> kafkaBundle = KafkaBundle.builder().withConfigurationProvider(AppConfiguration::getKafka).build();
    private final MessageProducer<String, ProductBundle> producer;
@@ -133,7 +132,7 @@ But be aware that the `key` or `value` can be `null` in this case in both `Messa
 Another alternative is to implement your own Deserializer to have even more control and where you can potentially apply any fallback deserialization
 strategy. 
 
-```
+```java
 public class DemoApplication {
    private final KafkaBundle<AppConfiguration> kafkaBundle = KafkaBundle.builder().withConfigurationProvider(AppConfiguration::getKafka).build();
    private final MessageProducer<String, ProductBundle> producer;
@@ -184,7 +183,7 @@ kafka:
       user: user
       password: password
       protocol: SASL_SSL
-    
+
   # List of brokers to bootstrap consumer and provider connection
   brokers:
     - kafka-broker-1:9092 
@@ -195,6 +194,7 @@ kafka:
     user: user
     password: password
     protocol: SASL_SSL
+    saslMechanism: PLAIN
 
   # Additional configuration properties that are added to all consumers, producers, and the admin client
   # configuration key -> values as defined in the kafka documentation
@@ -255,6 +255,95 @@ kafka:
       topicMissingRetryMs: 60000
       # Milliseconds to sleep between two poll intervals if no messages are available
       pollInterval: 200
+```
+
+### Security Settings
+
+There are different configuration options to connect to a Kafka Broker.
+
+#### PLAINTEXT
+
+The server uses an unencrypted connection with no authentication. 
+
+```yaml
+  security :
+    protocol: PLAINTEXT # can be omitted, default value
+```
+
+#### SSL
+
+The server uses an encrypted connection with no authentication. 
+
+```yaml
+  security :
+    protocol: SSL
+```
+
+#### SASL_PLAINTEXT
+
+The server uses an unencrypted connection with `PLAIN` authentication. 
+
+```yaml
+  security :
+    protocol: SASL_PLAINTEXT
+    saslMechanism: PLAIN # can be omitted, default value when username and password are specified
+    user: user
+    password: password
+```
+
+#### SASL_SSL
+
+The server uses an encrypted connection with `PLAIN` authentication. 
+
+```yaml
+  security :
+    protocol: SASL_SSL
+    saslMechanism: PLAIN # can be omitted, default value when username and password are specified
+    user: user
+    password: password
+```
+
+#### Other SASL mechanisms
+
+Beside `sasl.mechanism: PLAIN`, the bundle also supports `SCRAM-SHA-256` and `SCRAM-SHA-512`.
+All mechanisms can be used with both `SASL_PLAINTEXT` and `SASL_SSL`.
+
+```yaml
+  security :
+    protocol: SASL_PLAINTEXT # or SASL_SSL
+    saslMechanism: SCRAM-SHA-512 # or SCRAM-SHA-256
+    user: user
+    password: password
+```
+
+Other mechanisms can be configured by overriding the config properties.
+Note that the properties can also be configured individually for each consumer, each producer, and the admin client.
+
+```yaml
+  config:
+    sasl.mechanism: OTHER-VALUE
+    sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username='youruser' password='yourpassword';"
+```
+
+OR
+
+```yaml
+  consumers:
+    yourConsumer:
+      config:
+        sasl.mechanism: OTHER-VALUE
+        sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username='youruser' password='yourpassword';"
+
+  producers:
+    yourProducer:
+      config:
+        sasl.mechanism: OTHER-VALUE
+        sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username='youruser' password='yourpassword';"
+
+  adminConfig:
+    config:
+      sasl.mechanism: OTHER-VALUE
+      sasl.jaas.config: "org.apache.kafka.common.security.scram.ScramLoginModule required username='youruser' password='yourpassword';"
 ```
 
 ### Configuration value defaults (extending/changing the Kafka defaults)

--- a/sda-commons-server-kafka/README.md
+++ b/sda-commons-server-kafka/README.md
@@ -195,6 +195,12 @@ kafka:
     user: user
     password: password
     protocol: SASL_SSL
+
+  # Additional configuration properties that are added to all consumers, producers, and the admin client
+  # configuration key -> values as defined in the kafka documentation
+  config:
+    ssl.truststore.location: /my/truststore/location.jks
+
   # Map with consumer configurations. The key is used as name/id to address the configuration within the code. 
   consumers:
     # id/name of the consumer configuration

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaConfiguration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaConfiguration.java
@@ -19,6 +19,8 @@ public class KafkaConfiguration {
 
   private List<String> brokers = new ArrayList<>();
 
+  private Map<String, String> config = new HashMap<>();
+
   private Map<String, ProducerConfig> producers = new HashMap<>();
 
   private Map<String, ConsumerConfig> consumers = new HashMap<>();
@@ -39,6 +41,14 @@ public class KafkaConfiguration {
 
   public void setBrokers(List<String> brokers) {
     this.brokers = brokers;
+  }
+
+  public Map<String, String> getConfig() {
+    return config;
+  }
+
+  public void setConfig(Map<String, String> config) {
+    this.config = config;
   }
 
   public Security getSecurity() {

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -86,6 +86,7 @@ public class KafkaProperties extends Properties {
     props.put(
         AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG,
         configuration.getAdminConfig().getAdminClientRequestTimeoutMs());
+    props.putAll(configuration.getAdminConfig().getConfig());
     return props;
   }
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -6,8 +6,11 @@ import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.security.plain.PlainLoginModule;
+import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.sdase.commons.server.kafka.config.Security;
 
 public class KafkaProperties extends Properties {
 
@@ -16,6 +19,31 @@ public class KafkaProperties extends Properties {
 
   private KafkaProperties() {
     //
+  }
+
+  private static Properties configureSecurity(Security security) {
+    KafkaProperties props = new KafkaProperties();
+
+    if (security == null) {
+      return props;
+    }
+
+    if (security.getProtocol() != null) {
+      props.put("security.protocol", security.getProtocol().name());
+    }
+
+    if (security.getPassword() != null && security.getUser() != null) {
+      props.put("sasl.mechanism", security.getSaslMechanism());
+      props.put(
+          "sasl.jaas.config",
+          String.format(
+              "%s required username='%s' password='%s';",
+              getLoginModule(security.getSaslMechanism()).getName(),
+              security.getUser(),
+              security.getPassword()));
+    }
+
+    return props;
   }
 
   private static KafkaProperties baseProperties(KafkaConfiguration configuration) {
@@ -27,19 +55,7 @@ public class KafkaProperties extends Properties {
           CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
           String.join(",", configuration.getBrokers()));
     }
-    if (configuration.getSecurity().getPassword() != null
-        && configuration.getSecurity().getUser() != null
-        && configuration.getSecurity().getProtocol() != null) {
-      props.put("sasl.mechanism", "PLAIN");
-      props.put(
-          "sasl.jaas.config",
-          "org.apache.kafka.common.security.plain.PlainLoginModule required username='"
-              .concat(configuration.getSecurity().getUser())
-              .concat("' password='")
-              .concat(configuration.getSecurity().getPassword())
-              .concat("';"));
-      props.put("security.protocol", configuration.getSecurity().getProtocol().name());
-    }
+    props.putAll(configureSecurity(configuration.getSecurity()));
 
     if (configuration.getConfig() != null) {
       props.putAll(configuration.getConfig());
@@ -66,21 +82,7 @@ public class KafkaProperties extends Properties {
         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
         String.join(",", configuration.getAdminConfig().getAdminEndpoint()));
 
-    if (configuration.getAdminConfig().getAdminSecurity().getPassword() != null
-        && configuration.getAdminConfig().getAdminSecurity().getUser() != null
-        && configuration.getAdminConfig().getAdminSecurity().getProtocol() != null) {
-      props.put("sasl.mechanism", "PLAIN");
-      props.put(
-          "sasl.jaas.config",
-          "org.apache.kafka.common.security.plain.PlainLoginModule required username='"
-              .concat(configuration.getAdminConfig().getAdminSecurity().getUser())
-              .concat("' password='")
-              .concat(configuration.getAdminConfig().getAdminSecurity().getPassword())
-              .concat("';"));
-      props.put(
-          "security.protocol",
-          configuration.getAdminConfig().getAdminSecurity().getProtocol().name());
-    }
+    props.putAll(configureSecurity(configuration.getAdminConfig().getAdminSecurity()));
 
     return props;
   }
@@ -109,6 +111,7 @@ public class KafkaProperties extends Properties {
 
   public static KafkaProperties forProducer(KafkaConfiguration configuration) {
     KafkaProperties props = baseProperties(configuration);
+
     props.put(ProducerConfig.ACKS_CONFIG, "all");
     props.put(ProducerConfig.RETRIES_CONFIG, "0");
     props.put(ProducerConfig.LINGER_MS_CONFIG, "0");
@@ -116,5 +119,17 @@ public class KafkaProperties extends Properties {
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
 
     return props;
+  }
+
+  private static Class<?> getLoginModule(String saslMechanism) {
+    switch (saslMechanism.toUpperCase()) {
+      case "PLAIN":
+        return PlainLoginModule.class;
+      case "SCRAM-SHA-256":
+      case "SCRAM-SHA-512":
+        return ScramLoginModule.class;
+      default:
+        throw new IllegalArgumentException("Unsupported SASL mechanism " + saslMechanism);
+    }
   }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -41,6 +41,10 @@ public class KafkaProperties extends Properties {
       props.put("security.protocol", configuration.getSecurity().getProtocol().name());
     }
 
+    if (configuration.getConfig() != null) {
+      props.putAll(configuration.getConfig());
+    }
+
     return props;
   }
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/AdminConfig.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/AdminConfig.java
@@ -1,7 +1,9 @@
 package org.sdase.commons.server.kafka.config;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AdminConfig {
 
@@ -10,6 +12,8 @@ public class AdminConfig {
   private List<String> adminEndpoint = new ArrayList<>();
 
   private Security adminSecurity = new Security();
+
+  private Map<String, String> config = new HashMap<>();
 
   public int getAdminClientRequestTimeoutMs() {
     return adminClientRequestTimeoutMs;
@@ -33,5 +37,13 @@ public class AdminConfig {
 
   public void setAdminSecurity(Security adminSecurity) {
     this.adminSecurity = adminSecurity;
+  }
+
+  public Map<String, String> getConfig() {
+    return config;
+  }
+
+  public void setConfig(Map<String, String> config) {
+    this.config = config;
   }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/Security.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/Security.java
@@ -8,6 +8,8 @@ public class Security {
 
   private ProtocolType protocol;
 
+  private String saslMechanism = "PLAIN";
+
   public String getUser() {
     return user;
   }
@@ -30,5 +32,13 @@ public class Security {
 
   public void setProtocol(ProtocolType protocol) {
     this.protocol = protocol;
+  }
+
+  public String getSaslMechanism() {
+    return saslMechanism;
+  }
+
+  public void setSaslMechanism(String saslMechanism) {
+    this.saslMechanism = saslMechanism;
   }
 }

--- a/sda-commons-server-kafka/src/test/java/com/salesforce/kafka/test/SharedKafkaTestResourceScram.java
+++ b/sda-commons-server-kafka/src/test/java/com/salesforce/kafka/test/SharedKafkaTestResourceScram.java
@@ -1,0 +1,100 @@
+package com.salesforce.kafka.test;
+
+import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import com.salesforce.kafka.test.junit4.SharedZookeeperTestResource;
+import com.salesforce.kafka.test.listeners.BrokerListener;
+import com.salesforce.kafka.test.listeners.SaslScramListener;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import kafka.admin.ConfigCommand;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Creates and starts up a {@link SharedKafkaTestResource} that uses a custom {@link
+ * SharedZookeeperTestResource} with installed SCRAM-SHA-* credentials.
+ *
+ * <p>See {@link SharedKafkaTestResource} for usage.
+ */
+public class SharedKafkaTestResourceScram extends SharedKafkaTestResource {
+  private final SharedZookeeperTestResource sharedZookeeperTestResource =
+      new SharedZookeeperTestResource();
+
+  @Override
+  protected void setKafkaCluster(KafkaCluster kafkaCluster) {
+    // we need to replace the zkTestServer in the kafka cluster in order to change the Zookeper
+    // configuration after it started and before the kafka broker starts.
+    if (kafkaCluster instanceof KafkaTestCluster) {
+      try {
+        Field f = KafkaTestCluster.class.getDeclaredField("zkTestServer");
+
+        // the field is private, so we need to make it accessible
+        f.setAccessible(true);
+
+        // the field is final, so we need to remove the modifier
+        Field modifiersField = Field.class.getDeclaredField("modifiers");
+        modifiersField.setAccessible(true);
+        modifiersField.setInt(f, f.getModifiers() & ~Modifier.FINAL);
+
+        // use the already started (and configured) zookeeper server.
+        f.set(kafkaCluster, sharedZookeeperTestResource.getZookeeperTestServer());
+      } catch (NoSuchFieldException | IllegalAccessException e) {
+        throw new RuntimeException("Error on replacing the zkTestServer", e);
+      }
+    }
+
+    super.setKafkaCluster(kafkaCluster);
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    Statement startKafkaStatement = super.apply(base, description);
+
+    // this statement should be wrapped by the SharedZookeeperTestResource
+    Statement thisStatement =
+        new Statement() {
+          @Override
+          public void evaluate() throws Throwable {
+            // create the admin user
+            configureScramUser("admin", "admin-secret");
+
+            // create the user that was registered in the SaslScramListener
+            BrokerListener registeredListener = getRegisteredListener();
+            if (registeredListener instanceof SaslScramListener) {
+              configureScramUser(
+                  ((SaslScramListener) registeredListener).getUsername(),
+                  ((SaslScramListener) registeredListener).getPassword());
+            }
+
+            // start the kafka broker
+            startKafkaStatement.evaluate();
+          }
+        };
+
+    // start the zookeeper and execute the custom statement
+    return sharedZookeeperTestResource.apply(thisStatement, description);
+  }
+
+  /**
+   * Calls a command that sets up SCRAM-SHA-* credentials in the zookeeper. There is no other
+   * possibility to do this yet (see also
+   * https://cwiki.apache.org/confluence/display/KAFKA/KIP-506%3A+Allow+setting+SCRAM+password+via+Admin+interface).
+   *
+   * @param username the name of the user to update
+   * @param password the password to set
+   */
+  private void configureScramUser(String username, String password) {
+    ConfigCommand.main(
+        new String[] {
+          "--zookeeper",
+          sharedZookeeperTestResource.getZookeeperConnectString(),
+          "--alter",
+          "--add-config",
+          "SCRAM-SHA-256=[password=" + password + "],SCRAM-SHA-512=[password=" + password + "]",
+          "--entity-type",
+          "users",
+          "--entity-name",
+          username
+        });
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/com/salesforce/kafka/test/listeners/SaslScramListener.java
+++ b/sda-commons-server-kafka/src/test/java/com/salesforce/kafka/test/listeners/SaslScramListener.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017-2020, Salesforce.com, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+ * following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+ *   disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * * Neither the name of Salesforce.com nor the names of its contributors may be used to endorse or promote products
+ *   derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Based on https://github.com/salesforce/kafka-junit/blob/9675c18b5221a156821d534129b9f03e6b6779b3/kafka-junit-core/src/main/java/com/salesforce/kafka/test/listeners/SaslPlainListener.java
+ */
+package com.salesforce.kafka.test.listeners;
+
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Define and register a SASL_SCRAM listener on a Kafka broker.
+ *
+ * <p>NOTE: Kafka reads in the JAAS file as defined by an Environment variable at JVM start up. This
+ * property can not be set at run time.
+ *
+ * <p>In order to make use of this Listener, you **must** start the JVM with the following:
+ * -Djava.security.auth.login.config=/path/to/your/jaas.conf
+ */
+public class SaslScramListener extends AbstractListener<SaslScramListener> {
+  private static final Logger logger = LoggerFactory.getLogger(SaslPlainListener.class);
+
+  private String username = "";
+  private String password = "";
+
+  /**
+   * Constructor. Only purpose is to emit an ERROR log message if the System environment variable
+   * java.security.auth.login.config has not be set.
+   */
+  public SaslScramListener() {
+    if (!JaasValidationTool.isJaasEnvironmentValueSet()) {
+      logger.error(
+          "Missing required environment variable set: " + JaasValidationTool.JAAS_VARIABLE_NAME);
+    }
+  }
+
+  /**
+   * Setter.
+   *
+   * @param username SASL username to authenticate with.
+   * @return SaslScramListener for method chaining.
+   */
+  public SaslScramListener withUsername(final String username) {
+    this.username = username;
+    return this;
+  }
+
+  /**
+   * Setter.
+   *
+   * @param password SASL password to authenticate with.
+   * @return SaslScramListener for method chaining.
+   */
+  public SaslScramListener withPassword(final String password) {
+    this.password = password;
+    return this;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getProtocol() {
+    return "SASL_PLAINTEXT";
+  }
+
+  @Override
+  public Properties getBrokerProperties() {
+    final Properties properties = new Properties();
+    properties.put("sasl.enabled.mechanisms", "SCRAM-SHA-256,SCRAM-SHA-512");
+    properties.put("sasl.mechanism.inter.broker.protocol", "SCRAM-SHA-512");
+
+    properties.put("security.inter.broker.protocol", "SASL_PLAINTEXT");
+
+    return properties;
+  }
+
+  @Override
+  public Properties getClientProperties() {
+    final Properties properties = new Properties();
+    properties.put("sasl.mechanism", "SCRAM-SHA-512");
+    properties.put("security.protocol", "SASL_PLAINTEXT");
+    properties.put(
+        "sasl.jaas.config",
+        "org.apache.kafka.common.security.scram.ScramLoginModule required\n"
+            + "username=\""
+            + username
+            + "\"\n"
+            + "password=\""
+            + password
+            + "\";");
+
+    return properties;
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/CleanupJaasConfigurationRule.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/CleanupJaasConfigurationRule.java
@@ -1,0 +1,27 @@
+package org.sdase.commons.server.kafka;
+
+import javax.security.auth.login.Configuration;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A {@link TestRule} that resets the {@link javax.security.auth.login.Configuration} after
+ * executing the tests. This might be required if different tests use different values in the {@code
+ * java.security.auth.login.config} System property in the same JVM.
+ */
+public class CleanupJaasConfigurationRule implements TestRule {
+  @Override
+  public Statement apply(Statement base, Description description) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        // reset the configuration state
+        Configuration.setConfiguration(null);
+
+        // run the nested rules and tests
+        base.evaluate();
+      }
+    };
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
@@ -1,0 +1,82 @@
+package org.sdase.commons.server.kafka;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import com.salesforce.kafka.test.listeners.SaslPlainListener;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.security.JaasUtils;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.sdase.commons.server.kafka.builder.MessageListenerRegistration;
+import org.sdase.commons.server.kafka.consumer.strategies.synccommit.SyncCommitMLS;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
+import org.sdase.commons.server.testing.SystemPropertyRule;
+
+public class KafkaBundleWithSaslPlainIT {
+  private static final SystemPropertyRule PROP =
+      new SystemPropertyRule()
+          .setProperty(
+              JaasUtils.JAVA_LOGIN_CONFIG_PARAM,
+              KafkaBundleWithSaslPlainIT.class.getResource("/sasl-jaas.conf").getFile());
+
+  private static final SharedKafkaTestResource KAFKA =
+      new SharedKafkaTestResource()
+          .registerListener(
+              new SaslPlainListener().withUsername("kafkaclient").withPassword("client-secret"));
+
+  private static final DropwizardAppRule<KafkaTestConfiguration> DW =
+      new DropwizardAppRule<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString),
+          config("kafka.security.user", "kafkaclient"),
+          config("kafka.security.password", "client-secret"),
+          config("kafka.security.protocol", "SASL_PLAINTEXT"));
+
+  @ClassRule
+  public static final TestRule CHAIN = RuleChain.outerRule(PROP).around(KAFKA).around(DW);
+
+  @BeforeClass
+  public static void beforeClass() {
+    final KafkaProducer<String, String> producer =
+        KAFKA.getKafkaTestUtils().getKafkaProducer(StringSerializer.class, StringSerializer.class);
+    producer.send(new ProducerRecord<>("my-topic", "My Message"));
+    producer.close();
+  }
+
+  @Test
+  public void shouldReceiveEntries() {
+    Set<String> results = new HashSet<>();
+
+    DW.<KafkaTestApplication>getApplication()
+        .kafkaBundle()
+        .createMessageListener(
+            MessageListenerRegistration.builder()
+                .withDefaultListenerConfig()
+                .forTopic("my-topic")
+                .withDefaultConsumer()
+                .withKeyDeserializer(new StringDeserializer())
+                .withValueDeserializer(new StringDeserializer())
+                .withListenerStrategy(new SyncCommitMLS<>(r -> results.add(r.value()), null))
+                .build());
+
+    await()
+        .atMost(KafkaBundleConsts.N_MAX_WAIT_MS, MILLISECONDS)
+        .untilAsserted(() -> assertThat(results).containsOnly("My Message"));
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
@@ -6,8 +6,9 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import com.salesforce.kafka.test.SharedKafkaTestResourceScram;
 import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
-import com.salesforce.kafka.test.listeners.SaslPlainListener;
+import com.salesforce.kafka.test.listeners.SaslScramListener;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.HashSet;
 import java.util.Set;
@@ -27,19 +28,19 @@ import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
 import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
 import org.sdase.commons.server.testing.SystemPropertyRule;
 
-public class KafkaBundleWithSaslPlainIT {
+public class KafkaBundleWithSaslScramIT {
   private static final CleanupJaasConfigurationRule CLEANUP = new CleanupJaasConfigurationRule();
 
   private static final SystemPropertyRule PROP =
       new SystemPropertyRule()
           .setProperty(
               JaasUtils.JAVA_LOGIN_CONFIG_PARAM,
-              KafkaBundleWithSaslPlainIT.class.getResource("/sasl-jaas.conf").getFile());
+              KafkaBundleWithSaslScramIT.class.getResource("/sasl-scram-jaas.conf").getFile());
 
   private static final SharedKafkaTestResource KAFKA =
-      new SharedKafkaTestResource()
+      new SharedKafkaTestResourceScram()
           .registerListener(
-              new SaslPlainListener().withUsername("kafkaclient").withPassword("client-secret"));
+              new SaslScramListener().withUsername("kafkaclient").withPassword("client-secret"));
 
   private static final DropwizardAppRule<KafkaTestConfiguration> DW =
       new DropwizardAppRule<>(
@@ -48,7 +49,8 @@ public class KafkaBundleWithSaslPlainIT {
           config("kafka.brokers", KAFKA::getKafkaConnectString),
           config("kafka.security.user", "kafkaclient"),
           config("kafka.security.password", "client-secret"),
-          config("kafka.security.protocol", "SASL_PLAINTEXT"));
+          config("kafka.security.protocol", "SASL_PLAINTEXT"),
+          config("kafka.security.saslMechanism", "SCRAM-SHA-512"));
 
   @ClassRule
   public static final TestRule CHAIN =

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesSpec.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesSpec.java
@@ -26,4 +26,47 @@ public class KafkaPropertiesSpec {
         "org.apache.kafka.common.security.plain.PlainLoginModule required username='user' password='password';";
     assertThat(props.getProperty("sasl.jaas.config")).isEqualTo(saslJaasConfig);
   }
+
+  @Test
+  public void itShouldConfigureSecurityForAdminConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    Security sec = new Security();
+    sec.setPassword("password");
+    sec.setUser("user");
+    sec.setProtocol(ProtocolType.SASL_SSL);
+
+    config.setSecurity(sec);
+
+    Properties props = KafkaProperties.forAdminClient(config);
+
+    final String saslJaasConfig =
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username='user' password='password';";
+    assertThat(props.getProperty("sasl.jaas.config")).isEqualTo(saslJaasConfig);
+    assertThat(props.getProperty("sasl.mechanism")).isEqualTo("PLAIN");
+  }
+
+  @Test
+  public void itShouldUseCustomConfigForAdminConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    Security sec = new Security();
+    sec.setPassword("password");
+    sec.setUser("user");
+    sec.setProtocol(ProtocolType.SASL_SSL);
+
+    config.setSecurity(sec);
+
+    AdminConfig adminConfig = new AdminConfig();
+    adminConfig.getConfig().put("custom.property", "custom.property.value");
+    adminConfig.getConfig().put("sasl.jaas.config", "custom.sasl.jaas.config");
+    adminConfig.getConfig().put("sasl.mechanism", "SCRAM-SHA-512");
+    config.setAdminConfig(adminConfig);
+
+    Properties props = KafkaProperties.forAdminClient(config);
+
+    assertThat(props.getProperty("custom.property")).isEqualTo("custom.property.value");
+    assertThat(props.getProperty("sasl.jaas.config")).isEqualTo("custom.sasl.jaas.config");
+    assertThat(props.getProperty("sasl.mechanism")).isEqualTo("SCRAM-SHA-512");
+  }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesSpec.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesSpec.java
@@ -8,6 +8,31 @@ import org.sdase.commons.server.kafka.KafkaConfiguration;
 import org.sdase.commons.server.kafka.KafkaProperties;
 
 public class KafkaPropertiesSpec {
+  @Test
+  public void itShouldUseGlobalConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    config.getConfig().put("setting", "from.global");
+
+    KafkaProperties.forProducer(config).get("from.global");
+    KafkaProperties.forConsumer(config).get("from.global");
+    KafkaProperties.forAdminClient(config).get("from.global");
+  }
+
+  @Test
+  public void itShouldUseAdminConfigOverGlobalConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    AdminConfig adminConfig = new AdminConfig();
+    adminConfig.getConfig().put("setting", "from.admin");
+    config.setAdminConfig(adminConfig);
+
+    config.getConfig().put("setting", "from.global");
+
+    KafkaProperties.forProducer(config).get("from.global");
+    KafkaProperties.forConsumer(config).get("from.global");
+    KafkaProperties.forAdminClient(config).get("from.admin");
+  }
 
   @Test
   public void itShouldBuildSaslStringCorrectly() {

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
@@ -15,9 +15,9 @@ public class KafkaPropertiesTest {
 
     config.getConfig().put("setting", "from.global");
 
-    KafkaProperties.forProducer(config).get("from.global");
-    KafkaProperties.forConsumer(config).get("from.global");
-    KafkaProperties.forAdminClient(config).get("from.global");
+    assertThat(KafkaProperties.forProducer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forConsumer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forAdminClient(config).get("setting")).isEqualTo("from.global");
   }
 
   @Test
@@ -30,9 +30,9 @@ public class KafkaPropertiesTest {
 
     config.getConfig().put("setting", "from.global");
 
-    KafkaProperties.forProducer(config).get("from.global");
-    KafkaProperties.forConsumer(config).get("from.global");
-    KafkaProperties.forAdminClient(config).get("from.admin");
+    assertThat(KafkaProperties.forProducer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forConsumer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forAdminClient(config).get("setting")).isEqualTo("from.admin");
   }
 
   @Test

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.sdase.commons.server.kafka.KafkaConfiguration;
 import org.sdase.commons.server.kafka.KafkaProperties;
 
-public class KafkaPropertiesSpec {
+public class KafkaPropertiesTest {
   @Test
   public void itShouldUseGlobalConfig() {
     KafkaConfiguration config = new KafkaConfiguration();

--- a/sda-commons-server-kafka/src/test/resources/sasl-jaas.conf
+++ b/sda-commons-server-kafka/src/test/resources/sasl-jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+   org.apache.kafka.common.security.plain.PlainLoginModule required
+   username="admin"
+   password="admin-secret"
+   user_admin="admin-secret"
+   user_kafkaclient="client-secret";
+};

--- a/sda-commons-server-kafka/src/test/resources/sasl-scram-jaas.conf
+++ b/sda-commons-server-kafka/src/test/resources/sasl-scram-jaas.conf
@@ -1,0 +1,7 @@
+KafkaServer {
+   org.apache.kafka.common.security.scram.ScramLoginModule required
+   username="admin"
+   password="admin-secret"
+   user_admin="admin-secret"
+   user_kafkaclient="client-secret";
+};

--- a/sda-commons-server-kafka/src/test/resources/test-config-default.yml
+++ b/sda-commons-server-kafka/src/test/resources/test-config-default.yml
@@ -6,4 +6,4 @@ server:
   - type: http
     port: 0
 kafka:
-  brokers: ${BROKER_CONNECTION_STRING}
+  brokers: ${BROKER_CONNECTION_STRING:-[]}


### PR DESCRIPTION
This PR adds support for the `SCRAM-SHA-512` SASL-mechanism.

The changes:
1. Automatically select the correct login module for the SASL mechanisms (`PLAIN`-> `PlainLoginModule`, `SCRAM-SHA-*` -> `ScramLoginModule`). Other mechanisms lead to a failing bundle. Those should be used with the `config` overrides or an sda-dropwizard-commons PR.
2. The `AdminConfig` lacked a `config` property to provide custom configurations if needed.
3. Don't require username or password to configure the security protocol. `SSL` doesn't need credentials, but it wasn't obvious that one still need to fill the username and password fields before.
4. A new Readme-section that describes the different auth-configurations.
5. A new test that checks if the bundle can connect to a `SASL_PLAINTEXT` / `PLAIN` Kafka broker.
6. A new test that checks if the bundle can connect to a `SASL_PLAINTEXT` / `SCRAM-SHA-512` Kafka broker.

Plus: I increased the log level for the tests because I hope that it helps to find some strange errors in flaky tests in the future.