### PR TITLE
feat(server-kafka): Make timeout for KafkaHealthCheck configurable

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaConfiguration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaConfiguration.java
@@ -6,12 +6,13 @@ import java.util.List;
 import java.util.Map;
 import org.sdase.commons.server.kafka.config.AdminConfig;
 import org.sdase.commons.server.kafka.config.ConsumerConfig;
+import org.sdase.commons.server.kafka.config.HealthCheckConfig;
 import org.sdase.commons.server.kafka.config.ListenerConfig;
 import org.sdase.commons.server.kafka.config.ProducerConfig;
 import org.sdase.commons.server.kafka.config.Security;
 import org.sdase.commons.server.kafka.config.TopicConfig;
 
-/** Subclass of Dropwizard Configuration class to hold any values necessary to connect to Kafka */
+/** Class to hold any values necessary to connect to Kafka */
 public class KafkaConfiguration {
 
   private boolean disabled = false;
@@ -29,6 +30,8 @@ public class KafkaConfiguration {
   private Security security = new Security();
 
   private AdminConfig adminConfig = new AdminConfig();
+
+  private HealthCheckConfig healthCheck = new HealthCheckConfig();
 
   public List<String> getBrokers() {
     return brokers;
@@ -92,5 +95,14 @@ public class KafkaConfiguration {
 
   public void setAdminConfig(AdminConfig adminConfig) {
     this.adminConfig = adminConfig;
+  }
+
+  public HealthCheckConfig getHealthCheck() {
+    return healthCheck;
+  }
+
+  public KafkaConfiguration setHealthCheck(HealthCheckConfig healthCheck) {
+    this.healthCheck = healthCheck;
+    return this;
   }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/HealthCheckConfig.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/HealthCheckConfig.java
@@ -1,0 +1,16 @@
+package org.sdase.commons.server.kafka.config;
+
+/** Configuration for Kafka Health Checks. */
+public class HealthCheckConfig {
+
+  private int timeoutInSeconds = 2;
+
+  public int getTimeoutInSeconds() {
+    return timeoutInSeconds;
+  }
+
+  public HealthCheckConfig setTimeoutInSeconds(int timeoutInSeconds) {
+    this.timeoutInSeconds = timeoutInSeconds;
+    return this;
+  }
+}

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/KafkaHealthCheck.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/KafkaHealthCheck.java
@@ -31,7 +31,10 @@ public class KafkaHealthCheck extends HealthCheck {
     logger.setLevel(Level.WARN);
 
     try (AdminClient adminClient = AdminClient.create(KafkaProperties.forAdminClient(config))) {
-      adminClient.listTopics().names().get(2, TimeUnit.SECONDS);
+      adminClient
+          .listTopics()
+          .names()
+          .get(config.getHealthCheck().getTimeoutInSeconds(), TimeUnit.SECONDS);
     } catch (Exception e) {
       LOGGER.warn("Kafka health check failed", e);
       return Result.unhealthy("Connection to broker failed within 2 seconds");

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaHealthCheckIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaHealthCheckIT.java
@@ -1,4 +1,4 @@
-package org.sdase.commons.server.kafka;
+package org.sdase.commons.server.kafka.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,7 +8,7 @@ import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.kafka.health.KafkaHealthCheck;
+import org.sdase.commons.server.kafka.KafkaConfiguration;
 
 public class KafkaHealthCheckIT {
 
@@ -30,6 +30,7 @@ public class KafkaHealthCheckIT {
         KAFKA.getKafkaBrokers().stream()
             .map(KafkaBroker::getConnectString)
             .collect(Collectors.toList()));
+    config.getHealthCheck().setTimeoutInSeconds(5);
 
     KafkaHealthCheck check = new KafkaHealthCheck(config);
     HealthCheck.Result result = check.execute();


### PR DESCRIPTION
Adds new configuration to kafka for setting the value in seconds. Default is 2.

Example:
```
kafka:
  ...
  healthCheck:
    timeoutInSeconds: 2
```