### PR TITLE
feat(server-dropwizard): support configuration overrides from environment variables

### DIFF
--- a/sda-commons-server-dropwizard/README.md
+++ b/sda-commons-server-dropwizard/README.md
@@ -74,7 +74,7 @@ The bundle sets the log threshold for the console appender to `INFO` and uses th
 Make sure to add the bundle **after the `ConfigurationSubstitutionBundle`** if it's present.
 Logging related configuration is not required by this bundle. 
 
-```
+```java
 public void initialize(Bootstrap<Configuration> bootstrap) {
     bootstrap.addBundle(DefaultLoggingConfigurationBundle.builder().build());
 }
@@ -84,3 +84,30 @@ public void initialize(Bootstrap<Configuration> bootstrap) {
 To enable [JSON logging](https://www.dropwizard.io/en/latest/manual/core.html#logging), set the environment variable `ENABLE_JSON_LOGGING` to `"true"`.
 We recommend JSON logging in production as they are better parsable by tools.
 However they are hard to read for human beings, so better deactivate them when working with a service locally.
+
+### EnvironmentVariableConfigurationBundle
+
+The [`EnvironmentVariableConfigurationBundle`](./src/main/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundle.java)
+allows to override configuration values with environment variables, without the need for placeholders as in ConfigurationSubstitutionBundle.
+The syntax equals the behavior of overriding configuration values with [System Properties](https://www.dropwizard.io/en/latest/manual/core.html#configuration).
+
+> Don't use this to set properties for everyday use but only for special settings that are rarely used.
+> This includes Proxy Settings or custom trust- or keystores.
+
+Example Config:
+```yaml
+database:
+  driverClass: org.postgresql.Driver
+  user: dev
+  password: s3cr3t
+  url: localhost:12345
+```
+
+Example override
+```env
+dw.database.user=prod
+dw.database.password="s3cr3t++"
+```
+
+> Note that these kinds of environment variables might not be supported in any environment, but it
+> should be usable in Docker or Kubernetes environments.

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundle.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundle.java
@@ -105,7 +105,7 @@ public class EnvironmentVariableConfigurationBundle implements ConfiguredBundle<
         final String prefName = pref.getKey();
         if (prefName.startsWith(propertyPrefix)) {
           final String configName = prefName.substring(propertyPrefix.length());
-          addOverride(node, configName, System.getenv(prefName));
+          addOverride(node, configName.replace("..", "\\."), System.getenv(prefName));
         }
       }
 

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundle.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundle.java
@@ -1,0 +1,115 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.configuration.ConfigurationException;
+import io.dropwizard.configuration.ConfigurationFactory;
+import io.dropwizard.configuration.DefaultConfigurationFactoryFactory;
+import io.dropwizard.configuration.YamlConfigurationFactory;
+import io.dropwizard.setup.Bootstrap;
+import java.io.IOException;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.validation.Validator;
+
+/**
+ * This bundle extends the Dropwizard Support for overriding configurations via System Properties to
+ * Environment variables.
+ *
+ * <p>Given the following simple configuration:
+ *
+ * <pre>
+ * public class ExampleConfiguration extends Configuration {
+ *     private String name;
+ *
+ *     private List&lt;String&gt; names = Collections.emptyList();
+ *
+ *     public String getName() {
+ *         return name;
+ *     }
+ *
+ *     public List&lt;String&gt; getNames() {
+ *         return names;
+ *     }
+ * }
+ * </pre>
+ *
+ * Override the entries with as follows:
+ *
+ * <pre>
+ *   export dw.name="My Name"
+ *   export dw.names="One,Two,Three"
+ * </pre>
+ *
+ * Note that these kinds of environment variables might not be supported in any environment, but it
+ * should be usable in Docker or Kubernetes environments.
+ */
+public class EnvironmentVariableConfigurationBundle implements ConfiguredBundle<Configuration> {
+  public static EnvironmentVariableConfigurationBundle.Builder builder() {
+    return new EnvironmentVariableConfigurationBundle.Builder();
+  }
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+    bootstrap.setConfigurationFactoryFactory(new EnvConfigurationFactoryFactory<>());
+  }
+
+  public static class Builder {
+    public EnvironmentVariableConfigurationBundle build() {
+      return new EnvironmentVariableConfigurationBundle();
+    }
+  }
+
+  public static class EnvConfigurationFactoryFactory<T>
+      extends DefaultConfigurationFactoryFactory<T> {
+    @Override
+    public ConfigurationFactory<T> create(
+        Class<T> klass, Validator validator, ObjectMapper objectMapper, String propertyPrefix) {
+      return new EnvYamlConfigurationFactory<>(klass, validator, objectMapper, propertyPrefix);
+    }
+  }
+
+  /**
+   * A {@link YamlConfigurationFactory} that consumes all environment variables that begin with a
+   * configurable {@code propertyPrefix} (Dropwizard defaults to {@code dw.}) and uses them as
+   * overrides.
+   *
+   * @param <T> the type of the configuration objects to produce
+   */
+  public static class EnvYamlConfigurationFactory<T> extends YamlConfigurationFactory<T> {
+    private final String propertyPrefix;
+
+    /**
+     * Creates a new configuration factory for the given class.
+     *
+     * @param klass the configuration class
+     * @param validator the validator to use
+     * @param objectMapper the Jackson {@link ObjectMapper} to use
+     * @param propertyPrefix the system property name prefix used by overrides
+     */
+    public EnvYamlConfigurationFactory(
+        Class<T> klass,
+        @Nullable Validator validator,
+        ObjectMapper objectMapper,
+        String propertyPrefix) {
+      super(klass, validator, objectMapper, propertyPrefix);
+
+      this.propertyPrefix = propertyPrefix.endsWith(".") ? propertyPrefix : propertyPrefix + '.';
+    }
+
+    @Override
+    protected T build(JsonNode node, String path) throws IOException, ConfigurationException {
+      for (Map.Entry<String, String> pref : System.getenv().entrySet()) {
+        final String prefName = pref.getKey();
+        if (prefName.startsWith(propertyPrefix)) {
+          final String configName = prefName.substring(propertyPrefix.length());
+          addOverride(node, configName, System.getenv(prefName));
+        }
+      }
+
+      return super.build(node, path);
+    }
+  }
+}

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundleTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundleTest.java
@@ -1,0 +1,35 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.dropwizard.bundles.test.EnvTestApp;
+import org.sdase.commons.server.testing.EnvironmentRule;
+
+public class EnvironmentVariableConfigurationBundleTest {
+
+  public static final EnvironmentRule ENV =
+      new EnvironmentRule()
+          .setEnv("dw.metrics.frequency", "5d")
+          .setEnv("dw.config.my\\.property\\.value", "a")
+          .setEnv("dw.arrayConfig", "one.property,two.property");
+
+  public static final DropwizardAppRule<EnvTestApp.EnvConfiguration> DW =
+      new DropwizardAppRule<>(EnvTestApp.class);
+
+  @ClassRule public static final RuleChain RULE = RuleChain.outerRule(ENV).around(DW);
+
+  @Test
+  public void shouldUseValuesFromEnvironmentVariables() {
+    EnvTestApp.EnvConfiguration configuration = DW.getConfiguration();
+
+    assertThat(configuration.getMetricsFactory().getFrequency().toSeconds())
+        .isEqualTo(5L * 24 * 60 * 60);
+    assertThat(configuration.getConfig()).containsExactly(entry("my.property.value", "a"));
+    assertThat(configuration.getArrayConfig()).containsExactly("one.property", "two.property");
+  }
+}

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundleTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/EnvironmentVariableConfigurationBundleTest.java
@@ -16,6 +16,7 @@ public class EnvironmentVariableConfigurationBundleTest {
       new EnvironmentRule()
           .setEnv("dw.metrics.frequency", "5d")
           .setEnv("dw.config.my\\.property\\.value", "a")
+          .setEnv("dw.config.with..dots..property", "b")
           .setEnv("dw.arrayConfig", "one.property,two.property");
 
   public static final DropwizardAppRule<EnvTestApp.EnvConfiguration> DW =
@@ -29,7 +30,8 @@ public class EnvironmentVariableConfigurationBundleTest {
 
     assertThat(configuration.getMetricsFactory().getFrequency().toSeconds())
         .isEqualTo(5L * 24 * 60 * 60);
-    assertThat(configuration.getConfig()).containsExactly(entry("my.property.value", "a"));
+    assertThat(configuration.getConfig())
+        .containsExactly(entry("my.property.value", "a"), entry("with.dots.property", "b"));
     assertThat(configuration.getArrayConfig()).containsExactly("one.property", "two.property");
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/test/EnvTestApp.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/test/EnvTestApp.java
@@ -1,0 +1,37 @@
+package org.sdase.commons.server.dropwizard.bundles.test;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.sdase.commons.server.dropwizard.bundles.EnvironmentVariableConfigurationBundle;
+
+public class EnvTestApp extends Application<EnvTestApp.EnvConfiguration> {
+
+  @Override
+  public void initialize(Bootstrap<EnvConfiguration> bootstrap) {
+    bootstrap.addBundle(EnvironmentVariableConfigurationBundle.builder().build());
+  }
+
+  @Override
+  public void run(EnvConfiguration configuration, Environment environment) {
+    // nothing
+  }
+
+  public static class EnvConfiguration extends Configuration {
+    private final Map<String, Object> config = new HashMap<>();
+    private final List<String> arrayConfig = new ArrayList<>();
+
+    public Map<String, Object> getConfig() {
+      return config;
+    }
+
+    public List<String> getArrayConfig() {
+      return arrayConfig;
+    }
+  }
+}

--- a/sda-commons-server-starter/README.md
+++ b/sda-commons-server-starter/README.md
@@ -9,6 +9,7 @@ Apps built with the [`SdaPlatformBundle`](./src/main/java/org/sdase/commons/serv
 automatically contain
 
 - [Support for environment variables in configuration files and default console appender configuration](../sda-commons-server-dropwizard/README.md)
+- [Support for config overrides via environment variables as an alternative to system properties](../sda-commons-server-dropwizard/README.md)
 - [Trace Token support](../sda-commons-server-trace/README.md)
 - [a tolerant `ObjectMapper`, HAL support and a field filter](../sda-commons-server-jackson/README.md)
 - [Security checks on startup](../sda-commons-server-security/README.md)

--- a/sda-commons-server-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java
+++ b/sda-commons-server-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java
@@ -21,6 +21,7 @@ import org.sdase.commons.server.cors.CorsBundle;
 import org.sdase.commons.server.cors.CorsConfigProvider;
 import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
 import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBundle;
+import org.sdase.commons.server.dropwizard.bundles.EnvironmentVariableConfigurationBundle;
 import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.server.jaeger.JaegerBundle;
@@ -81,6 +82,7 @@ public class SdaPlatformBundle<C extends Configuration> implements ConfiguredBun
   public void initialize(Bootstrap<?> bootstrap) {
 
     // add normal bundles
+    bootstrap.addBundle(EnvironmentVariableConfigurationBundle.builder().build());
     bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build());
     bootstrap.addBundle(DefaultLoggingConfigurationBundle.builder().build());
     bootstrap.addBundle(InternalHealthCheckEndpointBundle.builder().build());

--- a/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/SdaPlatformBundleBuilderTest.java
@@ -8,6 +8,7 @@ import org.sdase.commons.server.consumer.ConsumerTokenBundle;
 import org.sdase.commons.server.cors.CorsBundle;
 import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
 import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBundle;
+import org.sdase.commons.server.dropwizard.bundles.EnvironmentVariableConfigurationBundle;
 import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.server.jaeger.JaegerBundle;
@@ -40,6 +41,11 @@ public class SdaPlatformBundleBuilderTest {
 
     SoftAssertions.assertSoftly(
         softly -> {
+          softly
+              .assertThat(
+                  bundleAssertion.getBundleOfType(
+                      bundle, EnvironmentVariableConfigurationBundle.class))
+              .isNotNull();
           softly
               .assertThat(
                   bundleAssertion.getBundleOfType(bundle, ConfigurationSubstitutionBundle.class))
@@ -78,7 +84,7 @@ public class SdaPlatformBundleBuilderTest {
           softly
               .assertThat(bundleAssertion.getBundleOfType(bundle, ConsumerTokenBundle.class))
               .isNotNull();
-          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(13);
+          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(14);
         });
   }
 }

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/Environment.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/Environment.java
@@ -1,6 +1,7 @@
 package org.sdase.commons.server.testing;
 
 import java.lang.reflect.Field;
+import java.util.HashMap;
 import java.util.Map;
 
 /** To be used with {@link EnvironmentRule} */
@@ -12,8 +13,11 @@ public final class Environment {
 
   public static void setEnv(String key, String value) {
     try {
-      Map<String, String> writableEnv = getWriteableEnv();
-      writableEnv.put(key, value);
+      // always set the value in the System.env map
+      getWriteableEnv().put(key, value);
+
+      // use the workaround that required for windows
+      getWriteableEnvWindows().put(key, value);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to set environment variable", e);
     }
@@ -21,15 +25,30 @@ public final class Environment {
 
   public static void unsetEnv(String key) {
     try {
-      Map<String, String> writableEnv = getWriteableEnv();
-      writableEnv.remove(key);
+      // always remove the value from the System.env map
+      getWriteableEnv().remove(key);
+
+      // use the workaround that required for windows
+      getWriteableEnvWindows().remove(key);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to unset environment variable", e);
     }
   }
 
+  @SuppressWarnings("unchecked")
   private static Map<String, String> getWriteableEnv()
-      throws IllegalAccessException, ClassNotFoundException, NoSuchFieldException {
+      throws IllegalAccessException, NoSuchFieldException {
+    // other environments
+    Map<String, String> env = System.getenv();
+    Class<?> cl = env.getClass();
+    Field field = cl.getDeclaredField("m");
+    field.setAccessible(true);
+    return (Map<String, String>) field.get(env);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, String> getWriteableEnvWindows()
+      throws IllegalAccessException, ClassNotFoundException {
 
     try {
       // based on solution in
@@ -41,13 +60,8 @@ public final class Environment {
       theCaseInsensitiveEnvironmentField.setAccessible(true);
       return (Map<String, String>) theCaseInsensitiveEnvironmentField.get(null);
     } catch (NoSuchFieldException e) {
-      // other environments
-      Map<String, String> env = System.getenv();
-      Class<?> cl = env.getClass();
-      Field field = cl.getDeclaredField("m");
-      field.setAccessible(true);
-      //noinspection unchecked
-      return (Map<String, String>) field.get(env);
+      // not needed in other environments
+      return new HashMap<>();
     }
   }
 }

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/EnvironmentRuleTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/EnvironmentRuleTest.java
@@ -21,6 +21,7 @@ public class EnvironmentRuleTest {
   @Test
   public void shouldBeSetInTest() {
     Assertions.assertThat(System.getenv("envForTesting")).isEqualTo("envForTestingValue");
+    Assertions.assertThat(System.getenv()).containsKeys("envForTesting");
   }
 
   @Test


### PR DESCRIPTION
Dropwizard supports configuration overrides by system properties (`-D dw.my.property=new-value`). This change supports the same name schema in environment variables (`export dw.my.property=new-value`).