### PR TITLE
feat: allow disabling of kafka health check

### DIFF
--- a/sda-commons-server-kafka/README.md
+++ b/sda-commons-server-kafka/README.md
@@ -363,6 +363,23 @@ kafka:
       pollInterval: 200
 ```
 
+You can disable the  health check manually if Kafka is not essential for the functionality of your service,
+e.g. it's only used to invalidate a cache, notify about updates or other minor tasks that could fail without
+affecting the service so much it's no longer providing a viable functionality.
+
+This way your service can stay healthy even if the connection to Kafka is disrupted.
+
+```java
+private KafkaBundle<KafkaTestConfiguration> bundle =
+  KafkaBundle.builder()
+    .withConfigurationProvider(KafkaTestConfiguration::getKafka)
+    .withoutHealthCheck() // disable kafkas health check
+    .build();
+```
+Keep in mind that in this case a producer might fail if the broker is not available, so depending on the
+use case the producer should do appropriate error handling e.g. storing unprocessed messages in a queue until the broker is available again.
+If no error handling is done you might be better off not disabling the health check.
+
 ### Security Settings
 
 There are different configuration options to connect to a Kafka Broker.

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/dropwizard/KafkaWithoutHealthCheckTestApplication.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/dropwizard/KafkaWithoutHealthCheckTestApplication.java
@@ -1,0 +1,34 @@
+package org.sdase.commons.server.kafka.dropwizard;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
+import org.sdase.commons.server.kafka.KafkaBundle;
+
+public class KafkaWithoutHealthCheckTestApplication extends Application<KafkaTestConfiguration> {
+
+  private final KafkaBundle<KafkaTestConfiguration> bundle =
+      KafkaBundle.builder()
+          .withConfigurationProvider(KafkaTestConfiguration::getKafka)
+          .withoutHealthCheck()
+          .build();
+
+  private HealthCheckRegistry healthCheckRegistry;
+
+  @Override
+  public void initialize(Bootstrap<KafkaTestConfiguration> bootstrap) {
+    bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build());
+    bootstrap.addBundle(bundle);
+  }
+
+  @Override
+  public void run(KafkaTestConfiguration configuration, Environment environment) {
+    healthCheckRegistry = environment.healthChecks();
+  }
+
+  public HealthCheckRegistry healthCheckRegistry() {
+    return healthCheckRegistry;
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
@@ -1,0 +1,49 @@
+package org.sdase.commons.server.kafka.health;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.SortedSet;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.sdase.commons.server.kafka.KafkaBundle;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
+import org.sdase.commons.server.kafka.dropwizard.KafkaWithoutHealthCheckTestApplication;
+
+public class KafkaWithoutHealthCheckIT {
+
+  private static final SharedKafkaTestResource KAFKA =
+      new SharedKafkaTestResource()
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
+
+  private static final DropwizardAppRule<KafkaTestConfiguration> DW =
+      new DropwizardAppRule<>(
+          KafkaWithoutHealthCheckTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString));
+
+  @ClassRule public static final TestRule CHAIN = RuleChain.outerRule(KAFKA).around(DW);
+
+  private KafkaWithoutHealthCheckTestApplication app;
+
+  @Before
+  public void before() {
+    app = DW.getApplication();
+  }
+
+  @Test
+  public void healthCheckShouldNotContainKafka() {
+    SortedSet<String> checks = app.healthCheckRegistry().getNames();
+    assertThat(checks).isNotEmpty().doesNotContain(KafkaBundle.HEALTHCHECK_NAME);
+  }
+}


### PR DESCRIPTION
An alternativ solution could be a field in the kafka configuration yml instead of `withoutHealthCheck()` in the builder.