### PR TITLE
feat(shared-asyncapi) sort definitions in generated json schema and asyncapi files

### DIFF
--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/AsyncApiGenerator.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/AsyncApiGenerator.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.shared.asyncapi;
 
+import static org.sdase.commons.shared.asyncapi.internal.JsonNodeUtil.sortJsonNodeInPlace;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URL;
 import java.util.HashMap;
@@ -117,7 +119,9 @@ public class AsyncApiGenerator {
 
     @Override
     public JsonNode generate() {
-      return jsonSchemaEmbedder.resolve(asyncApiBaseTemplate);
+      JsonNode jsonNode = jsonSchemaEmbedder.resolve(asyncApiBaseTemplate);
+      sortJsonNodeInPlace(jsonNode.at("/components/schemas"));
+      return jsonNode;
     }
 
     @Override

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/JsonSchemaGenerator.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/JsonSchemaGenerator.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.shared.asyncapi;
 
+import static org.sdase.commons.shared.asyncapi.internal.JsonNodeUtil.sortJsonNodeInPlace;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kjetland.jackson.jsonSchema.JsonSchemaConfig;
@@ -86,8 +88,9 @@ public class JsonSchemaGenerator {
                   // https://www.asyncapi.com/docs/specifications/2.0.0/#a-name-messageobjectschemaformattable-a-schema-formats-table
                   .withJsonSchemaDraft(JsonSchemaDraft.DRAFT_07)
                   .withFailOnUnknownProperties(!allowAdditionalPropertiesEnabled));
-
-      return jsonSchemaGenerator.generateJsonSchema(clazz);
+      JsonNode jsonNode = jsonSchemaGenerator.generateJsonSchema(clazz);
+      sortJsonNodeInPlace(jsonNode.at("/definitions"));
+      return jsonNode;
     }
 
     @Override

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonNodeUtil.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonNodeUtil.java
@@ -1,0 +1,23 @@
+package org.sdase.commons.shared.asyncapi.internal;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class JsonNodeUtil {
+
+  private JsonNodeUtil() {
+    // No constructor
+  }
+
+  public static void sortJsonNodeInPlace(JsonNode node) {
+    if (!node.isMissingNode() && node.isObject()) {
+      ObjectNode objectNode = (ObjectNode) node;
+      SortedMap<String, JsonNode> fields = new TreeMap<>();
+      objectNode.fields().forEachRemaining(e -> fields.put(e.getKey(), e.getValue()));
+      objectNode.removeAll();
+      fields.forEach(objectNode::set);
+    }
+  }
+}

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/AsyncApiGeneratorTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/AsyncApiGeneratorTest.java
@@ -3,8 +3,11 @@ package org.sdase.commons.shared.asyncapi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import org.sdase.commons.shared.asyncapi.models.BaseEvent;
@@ -26,6 +29,20 @@ public class AsyncApiGeneratorTest {
     Map<String, Object> actualJson =
         YamlUtil.load(actual, new TypeReference<Map<String, Object>>() {});
 
-    assertThat(actualJson).isEqualToComparingFieldByFieldRecursively(expectedJson);
+    assertThat(actualJson).usingRecursiveComparison().isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void shouldSortSchemas() {
+    JsonNode actual =
+        AsyncApiGenerator.builder()
+            .withAsyncApiBase(getClass().getResource("/asyncapi_template.yaml"))
+            .withSchema("./schema.json", BaseEvent.class)
+            .generate();
+    JsonNode schemas = actual.at("/components/schemas");
+    List<String> keys = new ArrayList<>();
+    schemas.fieldNames().forEachRemaining(keys::add);
+    // usingRecursiveComparison() is unable to compare the order, so we have to do it manually.
+    assertThat(keys).isSorted();
   }
 }

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/JsonSchemaGeneratorTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/JsonSchemaGeneratorTest.java
@@ -3,8 +3,11 @@ package org.sdase.commons.shared.asyncapi;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import org.sdase.commons.shared.asyncapi.models.BaseEvent;
@@ -22,6 +25,16 @@ public class JsonSchemaGeneratorTest {
     Map<String, Object> actualJson =
         YamlUtil.load(actual, new TypeReference<Map<String, Object>>() {});
 
-    assertThat(actualJson).isEqualToComparingFieldByFieldRecursively(expectedJson);
+    assertThat(actualJson).usingRecursiveComparison().isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void shouldSortDefinitions() {
+    JsonNode actual = JsonSchemaGenerator.builder().forClass(BaseEvent.class).generate();
+    JsonNode definitions = actual.at("/definitions");
+    List<String> keys = new ArrayList<>();
+    definitions.fieldNames().forEachRemaining(keys::add);
+    // usingRecursiveComparison() is unable to compare the order, so we have to do it manually.
+    assertThat(keys).isSorted();
   }
 }

--- a/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/internal/JsonNodeUtilTest.java
+++ b/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/internal/JsonNodeUtilTest.java
@@ -1,0 +1,24 @@
+package org.sdase.commons.shared.asyncapi.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sdase.commons.shared.asyncapi.internal.JsonNodeUtil.sortJsonNodeInPlace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.sdase.commons.shared.yaml.YamlUtil;
+
+public class JsonNodeUtilTest {
+
+  @Test
+  public void shouldSortJsonNodeInPlace() {
+    JsonNode jsonNode =
+        YamlUtil.load("{\"toSort\": {\"b\": 1, \"z\": 2, \"a\": 0}}", JsonNode.class);
+    JsonNode nodeToSort = jsonNode.at("/toSort");
+    sortJsonNodeInPlace(nodeToSort);
+    List<String> keys = new ArrayList<>();
+    nodeToSort.fieldNames().forEachRemaining(keys::add);
+    assertThat(keys).isSorted();
+  }
+}

--- a/sda-commons-shared-asyncapi/src/test/resources/asyncapi_expected.yaml
+++ b/sda-commons-shared-asyncapi/src/test/resources/asyncapi_expected.yaml
@@ -29,56 +29,6 @@ components:
       payload:
         $ref: "#/components/schemas/CarScrapped"
   schemas:
-    Electrical:
-      type: "object"
-      additionalProperties: true
-      description: "An car model with an electrical engine"
-      title: "ELECTRICAL"
-      properties:
-        engineType:
-          type: "string"
-          enum:
-          - "ELECTRICAL"
-          default: "ELECTRICAL"
-        name:
-          type: "string"
-          examples:
-          - "Tesla Roadster"
-          - "Hummer H1"
-          description: "The name of the car model"
-        batteryCapacity:
-          type: "integer"
-          examples:
-          - "200"
-          description: "The capacity of the battery in kwH"
-      required:
-      - "engineType"
-      - "batteryCapacity"
-    Combustion:
-      type: "object"
-      additionalProperties: true
-      description: "An car model with a combustion engine"
-      title: "COMBUSTION"
-      properties:
-        engineType:
-          type: "string"
-          enum:
-          - "COMBUSTION"
-          default: "COMBUSTION"
-        name:
-          type: "string"
-          examples:
-          - "Tesla Roadster"
-          - "Hummer H1"
-          description: "The name of the car model"
-        tankVolume:
-          type: "integer"
-          examples:
-          - "95"
-          description: "The capacity of the tank in liter"
-      required:
-      - "engineType"
-      - "tankVolume"
     CarManufactured:
       type: "object"
       additionalProperties: true
@@ -156,3 +106,53 @@ components:
       - "vehicleRegistration"
       - "date"
       - "id"
+    Combustion:
+      type: "object"
+      additionalProperties: true
+      description: "An car model with a combustion engine"
+      title: "COMBUSTION"
+      properties:
+        engineType:
+          type: "string"
+          enum:
+            - "COMBUSTION"
+          default: "COMBUSTION"
+        name:
+          type: "string"
+          examples:
+            - "Tesla Roadster"
+            - "Hummer H1"
+          description: "The name of the car model"
+        tankVolume:
+          type: "integer"
+          examples:
+            - "95"
+          description: "The capacity of the tank in liter"
+      required:
+        - "engineType"
+        - "tankVolume"
+    Electrical:
+      type: "object"
+      additionalProperties: true
+      description: "An car model with an electrical engine"
+      title: "ELECTRICAL"
+      properties:
+        engineType:
+          type: "string"
+          enum:
+            - "ELECTRICAL"
+          default: "ELECTRICAL"
+        name:
+          type: "string"
+          examples:
+            - "Tesla Roadster"
+            - "Hummer H1"
+          description: "The name of the car model"
+        batteryCapacity:
+          type: "integer"
+          examples:
+            - "200"
+          description: "The capacity of the battery in kwH"
+      required:
+        - "engineType"
+        - "batteryCapacity"

--- a/sda-commons-shared-asyncapi/src/test/resources/schema_expected.yaml
+++ b/sda-commons-shared-asyncapi/src/test/resources/schema_expected.yaml
@@ -47,6 +47,68 @@ definitions:
     - "date"
     - "model"
     - "id"
+  CarScrapped:
+    type: "object"
+    additionalProperties: false
+    description: "A car was scrapped"
+    title: "CAR_SCRAPPED"
+    properties:
+      type:
+        type: "string"
+        enum:
+          - "CAR_SCRAPPED"
+        default: "CAR_SCRAPPED"
+      vehicleRegistration:
+        type: "string"
+        examples:
+          - "BB324A81"
+          - "BFCB7DF1"
+        description: "The registration of the vehicle"
+      date:
+        type: "string"
+        format: "date-time"
+        description: "The time of scrapping"
+      location:
+        type: "string"
+        examples:
+          - "Hamburg"
+        description: "The location where the car was scrapped"
+      id:
+        type: "string"
+        examples:
+          - "626A0F21-D940-4B44-BD36-23F0F567B0D0"
+          - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
+        description: "The id of the message"
+    required:
+      - "type"
+      - "vehicleRegistration"
+      - "date"
+      - "id"
+  Combustion:
+    type: "object"
+    additionalProperties: false
+    description: "An car model with a combustion engine"
+    title: "COMBUSTION"
+    properties:
+      engineType:
+        type: "string"
+        enum:
+          - "COMBUSTION"
+        default: "COMBUSTION"
+      name:
+        type: "string"
+        examples:
+          - "Tesla Roadster"
+          - "Hummer H1"
+        description: "The name of the car model"
+      tankVolume:
+        type: "integer"
+        examples:
+          - "95"
+        description: "The capacity of the tank in liter"
+    required:
+      - "engineType"
+      - "tankVolume"
   Electrical:
     type: "object"
     additionalProperties: false
@@ -72,65 +134,3 @@ definitions:
     required:
     - "engineType"
     - "batteryCapacity"
-  Combustion:
-    type: "object"
-    additionalProperties: false
-    description: "An car model with a combustion engine"
-    title: "COMBUSTION"
-    properties:
-      engineType:
-        type: "string"
-        enum:
-        - "COMBUSTION"
-        default: "COMBUSTION"
-      name:
-        type: "string"
-        examples:
-        - "Tesla Roadster"
-        - "Hummer H1"
-        description: "The name of the car model"
-      tankVolume:
-        type: "integer"
-        examples:
-        - "95"
-        description: "The capacity of the tank in liter"
-    required:
-    - "engineType"
-    - "tankVolume"
-  CarScrapped:
-    type: "object"
-    additionalProperties: false
-    description: "A car was scrapped"
-    title: "CAR_SCRAPPED"
-    properties:
-      type:
-        type: "string"
-        enum:
-        - "CAR_SCRAPPED"
-        default: "CAR_SCRAPPED"
-      vehicleRegistration:
-        type: "string"
-        examples:
-        - "BB324A81"
-        - "BFCB7DF1"
-        description: "The registration of the vehicle"
-      date:
-        type: "string"
-        format: "date-time"
-        description: "The time of scrapping"
-      location:
-        type: "string"
-        examples:
-        - "Hamburg"
-        description: "The location where the car was scrapped"
-      id:
-        type: "string"
-        examples:
-        - "626A0F21-D940-4B44-BD36-23F0F567B0D0"
-        - "A6E6928D-EF92-4BE8-9DFA-76C935EF3446"
-        description: "The id of the message"
-    required:
-    - "type"
-    - "vehicleRegistration"
-    - "date"
-    - "id"


### PR DESCRIPTION
Sorting the schema makes it easier to find entities in a definition but also allows to compare them easier.
This might break assertions on generated files as the order of the content changes, but beside that there are no changes to
content.

Btw. changing the order in the `_expected` files has no influence on the tests, but I did it for fun 😉 