### PR TITLE
feat(server-kafka): register external kafka health check if internal …

### DIFF
--- a/sda-commons-server-kafka/README.md
+++ b/sda-commons-server-kafka/README.md
@@ -380,6 +380,10 @@ Keep in mind that in this case a producer might fail if the broker is not availa
 use case the producer should do appropriate error handling e.g. storing unprocessed messages in a queue until the broker is available again.
 If no error handling is done you might be better off not disabling the health check.
 
+Disabling the internal health check registers an external health check for monitoring purposes
+and to determine the fitness of the service. The connection to the broker can be monitored through
+Prometheus metrics without impacting the health of the service.
+
 ### Security Settings
 
 There are different configuration options to connect to a Kafka Broker.

--- a/sda-commons-server-kafka/build.gradle
+++ b/sda-commons-server-kafka/build.gradle
@@ -8,6 +8,8 @@ buildscript {
 dependencies {
   compile project(':sda-commons-server-dropwizard')
 
+  compile project(':sda-commons-server-healthcheck')
+
   compile "org.apache.kafka:kafka-clients"
 
   compile 'io.prometheus:simpleclient'

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/ExternalKafkaHealthCheck.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/ExternalKafkaHealthCheck.java
@@ -1,0 +1,12 @@
+package org.sdase.commons.server.kafka.health;
+
+import org.sdase.commons.server.healthcheck.ExternalHealthCheck;
+import org.sdase.commons.server.kafka.KafkaConfiguration;
+
+@ExternalHealthCheck
+public class ExternalKafkaHealthCheck extends KafkaHealthCheck {
+
+  public ExternalKafkaHealthCheck(KafkaConfiguration config) {
+    super(config);
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/ExternalKafkaHealthCheckIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/ExternalKafkaHealthCheckIT.java
@@ -1,0 +1,46 @@
+package org.sdase.commons.server.kafka.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.salesforce.kafka.test.KafkaBroker;
+import com.salesforce.kafka.test.junit4.SharedKafkaTestResource;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sdase.commons.server.kafka.KafkaConfiguration;
+
+public class ExternalKafkaHealthCheckIT {
+
+  @ClassRule
+  public static final SharedKafkaTestResource KAFKA =
+      new SharedKafkaTestResource()
+          .withBrokers(1)
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
+
+  @Test
+  public void testHealthCheckIt() throws Exception {
+
+    KafkaConfiguration config = new KafkaConfiguration();
+    config.setBrokers(
+        KAFKA.getKafkaBrokers().stream()
+            .map(KafkaBroker::getConnectString)
+            .collect(Collectors.toList()));
+    config.getHealthCheck().setTimeoutInSeconds(5);
+
+    ExternalKafkaHealthCheck check = new ExternalKafkaHealthCheck(config);
+    HealthCheck.Result result = check.execute();
+    assertThat(result.isHealthy()).isTrue();
+
+    for (int i = 1; i <= KAFKA.getKafkaBrokers().size(); i++) {
+      KAFKA.getKafkaBrokers().getBrokerById(i).stop();
+    }
+
+    HealthCheck.Result resultFalse = check.execute();
+    assertThat(resultFalse.isHealthy()).isFalse();
+  }
+}


### PR DESCRIPTION
…is disabled

We implemented the external health-check originally in the document-access-service to determine the fitness of it without the internal Kafka health-check. However, we think it makes sense to register it directly from the KafkaBundle if the internal health-check is disabled.