### PR TITLE
fix(server-jackson): use a custom hibernate node name provider to resolve the paths in the validation exceptions

### DIFF
--- a/sda-commons-server-errorhandling-example/src/main/java/org/sdase/commons/server/errorhandling/rest/model/RequestObject.java
+++ b/sda-commons-server-errorhandling-example/src/main/java/org/sdase/commons/server/errorhandling/rest/model/RequestObject.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.errorhandling.rest.model;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 import org.sdase.commons.server.errorhandling.rest.validation.UpperCase;
 
 /** Dummy object for request to get {@link javax.validation.ValidationException} */

--- a/sda-commons-server-hibernate-example/src/main/java/org/sdase/commons/server/hibernate/example/rest/model/PersonResource.java
+++ b/sda-commons-server-hibernate-example/src/main/java/org/sdase/commons/server/hibernate/example/rest/model/PersonResource.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.hibernate.example.rest.model;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 /** REST resource data model */
 public class PersonResource {

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
@@ -3,6 +3,7 @@ package org.sdase.commons.server.jackson;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.jersey.validation.Validators;
 import io.dropwizard.server.AbstractServerFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
@@ -11,6 +12,7 @@ import java.util.function.Consumer;
 import org.sda.commons.server.jackson.hal.HalLinkProvider;
 import org.sdase.commons.server.jackson.errors.ApiExceptionMapper;
 import org.sdase.commons.server.jackson.errors.EarlyEofExceptionMapper;
+import org.sdase.commons.server.jackson.errors.JacksonPropertyNodeNameProvider;
 import org.sdase.commons.server.jackson.errors.JerseyValidationExceptionMapper;
 import org.sdase.commons.server.jackson.errors.JsonProcessingExceptionMapper;
 import org.sdase.commons.server.jackson.errors.RuntimeExceptionMapper;
@@ -73,6 +75,12 @@ public class JacksonConfigurationBundle implements ConfiguredBundle<Configuratio
   public void initialize(Bootstrap<?> bootstrap) {
     // Overwrite with custom defaults
     bootstrap.setObjectMapper(objectMapperBuilder.build());
+
+    // Configure the Hibernate Validator to ask Jackson for property names
+    bootstrap.setValidatorFactory(
+        Validators.newConfiguration()
+            .propertyNodeNameProvider(new JacksonPropertyNodeNameProvider())
+            .buildValidatorFactory());
   }
 
   @Override

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/errors/JacksonPropertyNodeNameProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/errors/JacksonPropertyNodeNameProvider.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Hibernate Validator Authors
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copied from https://github.com/hibernate/hibernate-validator/blob/2427912f7bf3ec698c9229e9920b50dfa83d21be/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/jackson/JacksonAnnotationPropertyNodeNameProvider.java
+ */
+
+package org.sdase.commons.server.jackson.errors;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty;
+import org.hibernate.validator.spi.nodenameprovider.Property;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+
+/**
+ * A {@link PropertyNodeNameProvider} that resolves the name of the property via Jackson. By
+ * default, Hibernate reports the name of the properties. With this changes, it resolves it to the
+ * name of the property or of {@code @JsonProperty("...name...")}.
+ */
+public class JacksonPropertyNodeNameProvider implements PropertyNodeNameProvider {
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public String getName(Property property) {
+    if (property instanceof JavaBeanProperty) {
+      return getJavaBeanPropertyName((JavaBeanProperty) property);
+    }
+
+    return getDefaultName(property);
+  }
+
+  private String getJavaBeanPropertyName(JavaBeanProperty property) {
+    JavaType type = objectMapper.constructType(property.getDeclaringClass());
+    BeanDescription desc = objectMapper.getSerializationConfig().introspect(type);
+
+    return desc.findProperties().stream()
+        .filter(prop -> prop.getInternalName().equals(property.getName()))
+        .map(BeanPropertyDefinition::getName)
+        .findFirst()
+        .orElse(property.getName());
+  }
+
+  private String getDefaultName(Property property) {
+    return property.getName();
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/errors/JerseyValidationExceptionMapper.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/errors/JerseyValidationExceptionMapper.java
@@ -1,19 +1,10 @@
 package org.sdase.commons.server.jackson.errors;
 
-import com.fasterxml.jackson.databind.BeanDescription;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.google.common.base.CaseFormat;
+import io.dropwizard.jersey.validation.ConstraintMessage;
 import io.dropwizard.jersey.validation.JerseyViolationException;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Stream;
-import javax.validation.ElementKind;
-import javax.validation.Path;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -30,7 +21,6 @@ import org.sdase.commons.shared.api.error.ApiInvalidParam;
 public class JerseyValidationExceptionMapper implements ExceptionMapper<JerseyViolationException> {
 
   private static final String VALIDATION_EXCEPTION_MESSAGE = "Request parameters are not valid.";
-  private ObjectMapper mapper = new ObjectMapper();
 
   @Override
   public Response toResponse(JerseyViolationException e) {
@@ -41,7 +31,7 @@ public class JerseyValidationExceptionMapper implements ExceptionMapper<JerseyVi
         .forEach(
             cv -> {
               String propertyPath =
-                  getCorrectedPropertyPath(cv.getPropertyPath(), cv.getLeafBean());
+                  ConstraintMessage.isRequestEntity(cv, e.getInvocable()).orElse("N/A");
               String annotation =
                   cv.getConstraintDescriptor().getAnnotation().annotationType().toString();
 
@@ -57,67 +47,5 @@ public class JerseyValidationExceptionMapper implements ExceptionMapper<JerseyVi
 
     ApiError apiError = new ApiError(VALIDATION_EXCEPTION_MESSAGE, invalidParameters);
     return Response.status(422).type(MediaType.APPLICATION_JSON_TYPE).entity(apiError).build();
-  }
-
-  private String getCorrectedPropertyPath(Path propertyPath, Object leafBean) {
-    List<String> propertyPathStrings = new ArrayList<>();
-    Iterator<Path.Node> iterator = propertyPath.iterator();
-    Path.MethodNode method = null;
-    Path.ParameterNode parameter = null;
-    Class<?> lastClazz = null;
-    Path.PropertyNode lastNode = null;
-
-    while (iterator.hasNext()) {
-      Path.Node node = iterator.next();
-      if (ElementKind.METHOD == node.getKind()) {
-        // store method to retrieve type later
-        method = (Path.MethodNode) node;
-      } else if (ElementKind.PARAMETER == node.getKind()) {
-        // store parameter to retrieve type later
-        parameter = (Path.ParameterNode) node;
-      } else if (ElementKind.PROPERTY == node.getKind()) {
-        Path.PropertyNode propertyNode = (Path.PropertyNode) node;
-        Class<?> includingClass = null;
-        if (lastClazz == null && method != null && parameter != null) { // NOSONAR
-          // not nested property
-          includingClass = method.getParameterTypes().get(parameter.getParameterIndex());
-          lastClazz = includingClass;
-        } else if (lastClazz != null) { // NOSONAR
-          // nested property
-          String fieldname = lastNode.getName();
-          Optional<? extends Class<?>> first =
-              Stream.of(lastClazz.getDeclaredFields())
-                  .filter(f -> f.getName().equalsIgnoreCase(fieldname))
-                  .map(Field::getType)
-                  .findFirst();
-          includingClass = first.orElse(null);
-        }
-
-        // The leaf bean (i.e. the bean instance the constraint is applied on) might be a subclass
-        // of includingClass. This happens when using an abstract base class and the @JsonSubTypes
-        // annotation. If it matches, we use the original class instead of the abstract base class.
-        if (includingClass != null && includingClass.isInstance(leafBean)) {
-          includingClass = leafBean.getClass();
-        }
-
-        Optional<String> first = getPropertyName(propertyNode, includingClass);
-        propertyPathStrings.add(first.orElse("N/A"));
-        lastNode = propertyNode;
-      }
-    }
-    return String.join(".", propertyPathStrings);
-  }
-
-  private Optional<String> getPropertyName(
-      Path.PropertyNode propertyNode, Class<?> parameterBeanClass) {
-
-    JavaType javaType = mapper.getTypeFactory().constructType(parameterBeanClass);
-    BeanDescription introspection = mapper.getSerializationConfig().introspect(javaType);
-    List<BeanPropertyDefinition> properties = introspection.findProperties();
-
-    return properties.stream()
-        .filter(property -> propertyNode.getName().equals(property.getField().getName()))
-        .map(BeanPropertyDefinition::getName)
-        .findFirst();
   }
 }

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameNotRepeatedValidator.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameNotRepeatedValidator.java
@@ -19,13 +19,12 @@ public class NameNotRepeatedValidator
       context.disableDefaultConstraintViolation();
       context
           .buildConstraintViolationWithTemplate("First name and last name must be different.")
-          .addPropertyNode("firstName")
-          .addBeanNode()
+          // The property firstName is annotated with @JsonProperty("name")
+          .addPropertyNode("name")
           .addConstraintViolation();
       context
           .buildConstraintViolationWithTemplate("First name and last name must be different.")
           .addPropertyNode("lastName")
-          .addBeanNode()
           .addConstraintViolation();
       return false;
     }

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameSearchFilterResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NameSearchFilterResource.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.jackson.test;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 public class NameSearchFilterResource extends SearchFilterResource {
@@ -7,6 +8,8 @@ public class NameSearchFilterResource extends SearchFilterResource {
   static final String TYPE = "NAME";
 
   @NotNull private String name;
+
+  @Valid private NestedResource nestedResource;
 
   public NameSearchFilterResource() {
     super(TYPE);
@@ -18,6 +21,15 @@ public class NameSearchFilterResource extends SearchFilterResource {
 
   public NameSearchFilterResource setName(String name) {
     this.name = name;
+    return this;
+  }
+
+  public NestedResource getNestedResource() {
+    return nestedResource;
+  }
+
+  public NameSearchFilterResource setNestedResource(NestedResource nestedResource) {
+    this.nestedResource = nestedResource;
     return this;
   }
 }

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedNestedResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedNestedResource.java
@@ -1,0 +1,14 @@
+package org.sdase.commons.server.jackson.test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotEmpty;
+
+public class NestedNestedResource {
+
+  @NotEmpty()
+  @JsonProperty("anotherNestedField")
+  private String anotherNested;
+
+  @JsonProperty("someNumber")
+  private int anotherNumber;
+}

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedResource.java
@@ -2,7 +2,7 @@ package org.sdase.commons.server.jackson.test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.Valid;
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 public class NestedResource {
 

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/NestedResource.java
@@ -1,6 +1,7 @@
 package org.sdase.commons.server.jackson.test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.Valid;
 import org.hibernate.validator.constraints.NotEmpty;
 
 public class NestedResource {
@@ -11,4 +12,17 @@ public class NestedResource {
 
   @JsonProperty("someNumber")
   private int number;
+
+  @Valid
+  @JsonProperty("myNestedResource")
+  private NestedNestedResource anotherNestedResource;
+
+  public NestedNestedResource getAnotherNestedResource() {
+    return anotherNestedResource;
+  }
+
+  public NestedResource setAnotherNestedResource(NestedNestedResource anotherNestedResource) {
+    this.anotherNestedResource = anotherNestedResource;
+    return this;
+  }
 }

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/ValidationResource.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/ValidationResource.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.validation.OneOf;
 import io.dropwizard.validation.ValidationMethod;
 import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
-import org.hibernate.validator.constraints.NotEmpty;
 
 @CheckNameRepeated
 public class ValidationResource {

--- a/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/MongoConfiguration.java
+++ b/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/MongoConfiguration.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.morphia;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 public class MongoConfiguration {
 

--- a/sda-commons-server-s3/src/main/java/org/sdase/commons/server/s3/S3Configuration.java
+++ b/sda-commons-server-s3/src/main/java/org/sdase/commons/server/s3/S3Configuration.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.s3;
 
-import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotEmpty;
 
 /** Defines the configuration ot the {@link S3Bundle}. */
 public class S3Configuration {


### PR DESCRIPTION
Previously, we used custom code to correctly resolve the property names (if used with `@JsonProperty("name")`). Hibernate now supports providing a custom property node name provider (see https://github.com/hibernate/hibernate-validator/pull/1029). They also provide an example implementation for Jackson in their documentation. After applying this custom `propertyNodeNameProvider`, we can use an existing function from Dropwizard (`ConstraintMessage.isRequestEntity(...)`) that computes the correct property path.

Closes #611 