### PR TITLE
fix(server-kafka): only configure the sasl settings if a sasl protocol is configured

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -10,6 +10,7 @@ import org.apache.kafka.common.security.plain.PlainLoginModule;
 import org.apache.kafka.common.security.scram.ScramLoginModule;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.sdase.commons.server.kafka.config.ProtocolType;
 import org.sdase.commons.server.kafka.config.Security;
 
 public class KafkaProperties extends Properties {
@@ -32,7 +33,9 @@ public class KafkaProperties extends Properties {
       props.put("security.protocol", security.getProtocol().name());
     }
 
-    if (security.getPassword() != null && security.getUser() != null) {
+    if (ProtocolType.isSasl(security.getProtocol())
+        && security.getPassword() != null
+        && security.getUser() != null) {
       props.put("sasl.mechanism", security.getSaslMechanism());
       props.put(
           "sasl.jaas.config",

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/ProtocolType.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/ProtocolType.java
@@ -4,5 +4,15 @@ public enum ProtocolType {
   PLAINTEXT,
   SSL,
   SASL_PLAINTEXT,
-  SASL_SSL
+  SASL_SSL;
+
+  /**
+   * Tells whether the {@link ProtocolType} is a SASL type or not.
+   *
+   * @param type the type to check
+   * @return if true, the type is a SASL type
+   */
+  public static boolean isSasl(ProtocolType type) {
+    return type == SASL_PLAINTEXT || type == SASL_SSL;
+  }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
+import org.apache.kafka.common.config.SaslConfigs;
 import org.junit.Test;
 import org.sdase.commons.server.kafka.KafkaConfiguration;
 import org.sdase.commons.server.kafka.KafkaProperties;
@@ -104,6 +105,7 @@ public class KafkaPropertiesTest {
     sec.setPassword("password");
     sec.setUser("user");
     sec.setSaslMechanism("SCRAM-SHA-512");
+    sec.setProtocol(ProtocolType.SASL_PLAINTEXT);
 
     config.setSecurity(sec);
 
@@ -129,5 +131,39 @@ public class KafkaPropertiesTest {
     assertThatThrownBy(() -> KafkaProperties.forProducer(config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Unsupported SASL mechanism OAUTHBEARER");
+  }
+
+  @Test
+  public void itShouldNotConfigureSaslForPLAINTEXT() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    Security sec = new Security();
+    sec.setPassword("password");
+    sec.setUser("user");
+    sec.setSaslMechanism("PLAIN");
+    sec.setProtocol(ProtocolType.PLAINTEXT);
+
+    config.setSecurity(sec);
+
+    Properties props = KafkaProperties.forProducer(config);
+    assertThat(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG)).isNull();
+    assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isNull();
+  }
+
+  @Test
+  public void itShouldNotConfigureSaslForSSL() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    Security sec = new Security();
+    sec.setPassword("password");
+    sec.setUser("user");
+    sec.setSaslMechanism("PLAIN");
+    sec.setProtocol(ProtocolType.SSL);
+
+    config.setSecurity(sec);
+
+    Properties props = KafkaProperties.forProducer(config);
+    assertThat(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG)).isNull();
+    assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isNull();
   }
 }


### PR DESCRIPTION
The service emits a warning in the log if the `sasl.jaas.config` property is set even if the security protocol doesn't support SASL:

> The configuration 'sasl.jaas.config' was supplied but isn't a known config.

This behavior was introduced in #548 that allowed the configuration of `SSL` without configured (and unneeded) user credentials.