### PR TITLE
chore: define a virtual-platform for all bouncycastle modules in orde…

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     // sda-commons-server-morphia
     api "dev.morphia.morphia:core:$morphiaVersion"
     api "dev.morphia.morphia:validation:$morphiaVersion"
-    api "org.bouncycastle:bcpkix-jdk15on:1.67"
+    api "org.bouncycastle:bcpkix-jdk15on:1.67" // use the same version as bcprov-jdk15on in DW
 
     // sda-commons-server-swagger
     api "io.openapitools.hal:swagger-hal:1.0.4"

--- a/sda-commons-dependency-check/build.gradle
+++ b/sda-commons-dependency-check/build.gradle
@@ -1,4 +1,8 @@
 dependencies {
+  // Dropwizard only manages bcprov but we want to make sure that all bouncycastle modules that we
+  // import use the same version.
+  components.all(BouncycastleAlignmentRule)
+
   // Add all new modules here to verify that there are no dependency clashes.
   compile project(':sda-commons-client-jersey')
   compile project(':sda-commons-client-jersey-wiremock-testing')
@@ -34,4 +38,19 @@ dependencies {
   compile project(':sda-commons-shared-forms')
   compile project(':sda-commons-shared-tracing')
   compile project(':sda-commons-shared-yaml')
+}
+
+/**
+ * A rule that forces all bouncycastle modules to use the same version.
+ */
+class BouncycastleAlignmentRule implements ComponentMetadataRule {
+  @Override
+  void execute(ComponentMetadataContext ctx) {
+    ctx.details.with {
+      if (id.group == "org.bouncycastle") {
+        // declare that the modules belong to the bouncycastle virtual platform
+        belongsTo("org.bouncycastle:bouncycastle-virtual-platform:${id.version}")
+      }
+    }
+  }
 }


### PR DESCRIPTION
…r to get dependency conflicts when only one of the modules is updated

Based on https://docs.gradle.org/current/userguide/dependency_version_alignment.html#sec:virtual_platform