### PR TITLE
Feat/test updates

### DIFF
--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
@@ -14,8 +14,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import java.util.Collections;
-import java.util.Optional;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpHeaders;
@@ -51,10 +49,8 @@ public class ClientConfiguredProxyTest {
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),
           config("client.proxy.host", "localhost"),
-          config("client.proxy.port", () -> "" + PROXY_WIRE.port())
-          // TODO: activate the next line after https://github.com/dropwizard/dropwizard/pull/3442
-          // config("client.proxy.nonProxyHosts", "localhost")
-          );
+          config("client.proxy.port", () -> "" + PROXY_WIRE.port()),
+          config("client.proxy.nonProxyHosts", "localhost"));
 
   @ClassRule
   public static final RuleChain rule =
@@ -107,15 +103,10 @@ public class ClientConfiguredProxyTest {
   }
 
   private Client getClient(String name) {
-    // TODO: remove this code after https://github.com/dropwizard/dropwizard/pull/3442
-    HttpClientConfiguration conf = DW.getConfiguration().getClient();
-    Optional.ofNullable(conf.getProxyConfiguration())
-        .ifPresent(p -> p.setNonProxyHosts(Collections.singletonList("localhost")));
-
     return DW.<ClientTestApp>getApplication()
         .getJerseyClientBundle()
         .getClientFactory()
-        .externalClient(conf)
+        .externalClient(DW.getConfiguration().getClient())
         .buildGenericClient(name);
   }
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.client.jersey.test.ClientTestApp;
 import org.sdase.commons.client.jersey.test.ClientTestConfig;
-import org.sdase.commons.server.testing.LazyRule;
 import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /** A test that checks if the proxy can be configured via system properties */
@@ -34,13 +33,11 @@ public class ClientProxyTest {
   private static final WireMockClassRule PROXY_WIRE =
       new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private static final LazyRule<SystemPropertyRule> PROP =
-      new LazyRule<>(
-          () ->
-              new SystemPropertyRule()
-                  .setProperty("http.proxyHost", "localhost")
-                  .setProperty("http.proxyPort", "" + PROXY_WIRE.port())
-                  .setProperty("http.nonProxyHosts", "localhost"));
+  private static final SystemPropertyRule PROP =
+      new SystemPropertyRule()
+          .setProperty("http.proxyHost", "localhost")
+          .setProperty("http.proxyPort", () -> "" + PROXY_WIRE.port())
+          .setProperty("http.nonProxyHosts", "localhost");
 
   private static final DropwizardAppRule<ClientTestConfig> DW =
       new DropwizardAppRule<>(ClientTestApp.class, resourceFilePath("test-config.yaml"));

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/util/ClientRequestExceptionConditions.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/util/ClientRequestExceptionConditions.java
@@ -12,6 +12,12 @@ public class ClientRequestExceptionConditions {
 
   private ClientRequestExceptionConditions() {}
 
+  public static Condition<Throwable> asClientRequestException(Condition<ClientRequestException> c) {
+    return new Condition<>(
+        t -> t instanceof ClientRequestException && c.matches((ClientRequestException) t),
+        "asClientRequestException");
+  }
+
   public static Condition<ClientRequestException> clientError() {
     return new Condition<>(ClientRequestException::isClientError, "client error");
   }

--- a/sda-commons-server-auth-testing/README.md
+++ b/sda-commons-server-auth-testing/README.md
@@ -115,9 +115,9 @@ public class OpaIT {
 
    private static final OpaRule OPA_RULE = new OpaRule();
 
-   private static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW = new LazyRule<>(
-         () -> new DropwizardAppRule<>(OpaBundleTestApp.class, ResourceHelpers.resourceFilePath("test-opa-config.yaml"),
-               config("opa.baseUrl", OPA_RULE.getUrl())));
+   private static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
+         new DropwizardAppRule<>(OpaBundleTestApp.class, ResourceHelpers.resourceFilePath("test-opa-config.yaml"),
+         config("opa.baseUrl", OPA_RULE::getUrl));
 
 
    @ClassRule
@@ -134,11 +134,11 @@ public class OpaRuleProgrammaticIT {
 
   private static final OpaRule OPA_RULE = new OpaRule();
 
-  private static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW = new LazyRule<>( () ->
+  private static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
        DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
            .withConfigFrom(OpaBundeTestAppConfiguration::new)
       .withRandomPorts()
-      .withConfigurationModifier(c -> c.getOpa().setBaseUrl(OPA_RULE.getUrl())).build());
+      .withConfigurationModifier(c -> c.getOpa().setBaseUrl(OPA_RULE.getUrl())).build();
   @ClassRule
   public static final RuleChain chain = RuleChain.outerRule(OPA_RULE).around(DW);
          

--- a/sda-commons-server-auth-testing/README.md
+++ b/sda-commons-server-auth-testing/README.md
@@ -66,24 +66,6 @@ public class AuthRuleIT {
 }
 ```
 
-The `AuthRule` may also be used with programmatic configuration omitting a `test-config.yaml`:
-
-```java
-public class AuthRuleProgrammaticIT {
-
-   private static AuthRule AUTH = AuthRule.builder().build();
-
-   @ClassRule
-   public static DropwizardAppRule<AuthTestConfig> DW = DropwizardRuleHelper.dropwizardTestAppFrom(AuthTestApp.class)
-         .withConfigFrom(AuthTestConfig::new)
-         .withRandomPorts()
-         .withConfigurationModifier(AUTH.applyConfig(AuthTestConfig::setAuth))
-         .build();
-
-   // @Test
-}
-```
-
 The `AuthRule` provides functions to generate a valid token that matches to the auth configuration in tests.
 ```java
    Response response = createWebTarget()
@@ -122,26 +104,6 @@ public class OpaIT {
 
    @ClassRule
    public static RuleChain CHAIN = RuleChain.outerRule(OPA_RULE).around(DW);
-
-   // @Test
-}
-```
-
-The `OpaRule` may also be used with programmatic configuration omitting a `test-config.yaml`:
-
-```java
-public class OpaRuleProgrammaticIT {
-
-  private static final OpaRule OPA_RULE = new OpaRule();
-
-  private static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
-       DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
-           .withConfigFrom(OpaBundeTestAppConfiguration::new)
-      .withRandomPorts()
-      .withConfigurationModifier(c -> c.getOpa().setBaseUrl(OPA_RULE.getUrl())).build();
-  @ClassRule
-  public static final RuleChain chain = RuleChain.outerRule(OPA_RULE).around(DW);
-         
 
    // @Test
 }

--- a/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthRule.java
+++ b/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthRule.java
@@ -117,8 +117,10 @@ public class AuthRule implements TestRule {
    *     org.sdase.commons.server.testing.DropwizardRuleHelper#withConfigurationModifier(Consumer)}
    *     or {@link
    *     org.sdase.commons.server.testing.DropwizardConfigurationHelper#withConfigurationModifier(Consumer)}
+   * @deprecated see {@link org.sdase.commons.server.testing.DropwizardRuleHelper}
    */
   @SuppressWarnings("WeakerAccess")
+  @Deprecated
   public <C extends Configuration> Consumer<C> applyConfig(
       BiConsumer<C, AuthConfig> authConfigSetter) {
     return c -> authConfigSetter.accept(c, this.authConfig);

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.opa.testing;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -9,16 +10,12 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.opa.testing.test.OpaBundeTestAppConfiguration;
 import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 
 public class OpaConnectionMisconfiguredIT {
 
   @ClassRule
   public static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
-          .withConfigFrom(OpaBundeTestAppConfiguration::new)
-          .withRandomPorts()
-          .build();
+      new DropwizardAppRule<>(OpaBundleTestApp.class, resourceFilePath("test-opa-config.yaml"));
 
   @Test
   public void shouldDenyAccess() {

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
@@ -10,25 +10,21 @@ import org.junit.Test;
 import org.sdase.commons.server.opa.testing.test.OpaBundeTestAppConfiguration;
 import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
 import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 public class OpaConnectionMisconfiguredIT {
 
   @ClassRule
-  public static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
-                  .withConfigFrom(OpaBundeTestAppConfiguration::new)
-                  .withRandomPorts()
-                  .build());
+  public static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
+      DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
+          .withConfigFrom(OpaBundeTestAppConfiguration::new)
+          .withRandomPorts()
+          .build();
 
   @Test
   public void shouldDenyAccess() {
     Response response =
-        DW.getRule()
-            .client()
-            .target("http://localhost:" + DW.getRule().getLocalPort()) // NOSONAR
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
             .get(); // NOSONAR

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
@@ -13,10 +13,13 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.opa.testing.test.OpaJwtPrincipalInjectApp;
+import org.sdase.commons.server.testing.Retry;
+import org.sdase.commons.server.testing.RetryRule;
 
 public class OpaJwtPrincipalInjectIT {
 
@@ -31,12 +34,15 @@ public class OpaJwtPrincipalInjectIT {
 
   @ClassRule public static RuleChain CHAIN = RuleChain.outerRule(AUTH).around(OPA).around(DW);
 
+  @Rule public final RetryRule retryRule = new RetryRule();
+
   @Before
   public void setUp() {
     OPA.reset();
   }
 
   @Test
+  @Retry(5)
   public void shouldInjectPrincipalWithConstraints() {
 
     String token = AUTH.auth().buildToken();
@@ -59,6 +65,7 @@ public class OpaJwtPrincipalInjectIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldProvideConstraintsWithoutUserContext() {
 
     OPA.mock(
@@ -79,6 +86,7 @@ public class OpaJwtPrincipalInjectIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldRejectWithForbiddenWithoutUserContext() {
 
     OPA.mock(OpaRule.onAnyRequest().deny());
@@ -94,6 +102,7 @@ public class OpaJwtPrincipalInjectIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldCreateSeparateContextForEachRequest() {
 
     String token1 = AUTH.auth().addClaim("foo", "bar").buildToken();

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
@@ -3,6 +3,8 @@ package org.sdase.commons.server.opa.testing;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -22,8 +24,6 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.opa.testing.test.OpaBundeTestAppConfiguration;
 import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
 
@@ -34,20 +34,12 @@ public class OpaRequestsIT {
 
   private static final AuthRule AUTH = AuthRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
-                  .withConfigFrom(OpaBundeTestAppConfiguration::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getOpa()
-                              .setBaseUrl(WIRE.baseUrl())
-                              .setPolicyPackage("my.policy")) // NOSONAR
-                  .withConfigurationModifier(
-                      AUTH.applyConfig(OpaBundeTestAppConfiguration::setAuth))
-                  .build());
+  private static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
+      new DropwizardAppRule<>(
+          OpaBundleTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("opa.baseUrl", WIRE::baseUrl),
+          config("opa.policyPackage", "my.policy"));
 
   @ClassRule
   public static final RuleChain chain = RuleChain.outerRule(WIRE).around(AUTH).around(DW);
@@ -158,9 +150,8 @@ public class OpaRequestsIT {
 
   private void doGetRequest(MultivaluedMap<String, Object> headers) {
     Response response =
-        DW.getRule()
-            .client()
-            .target("http://localhost:" + DW.getRule().getLocalPort())
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
             .path("resources")
             .request()
             .headers(headers)

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,11 +44,6 @@ public class OpaRequestsIT {
   public static final RuleChain chain = RuleChain.outerRule(WIRE).around(AUTH).around(DW);
 
   @Rule public RetryRule retryRule = new RetryRule();
-
-  @BeforeClass
-  public static void start() {
-    WIRE.start();
-  }
 
   private void mock() {
     WIRE.stubFor(

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
@@ -16,7 +16,6 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,11 +40,6 @@ public class OpaResponsesIT {
 
   @ClassRule public static final RuleChain chain = RuleChain.outerRule(WIRE).around(DW);
   @Rule public RetryRule retryRule = new RetryRule();
-
-  @BeforeClass
-  public static void start() {
-    WIRE.start();
-  }
 
   @Before
   public void before() {

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaTimeoutIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaTimeoutIT.java
@@ -3,19 +3,21 @@ package org.sdase.commons.server.opa.testing;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.opa.testing.test.OpaBundeTestAppConfiguration;
 import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
 
@@ -24,21 +26,21 @@ public class OpaTimeoutIT {
   private static final WireMockClassRule WIRE =
       new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private static final LazyRule<DropwizardAppRule<OpaBundeTestAppConfiguration>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(OpaBundleTestApp.class)
-                  .withConfigFrom(OpaBundeTestAppConfiguration::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getOpa()
-                              .setBaseUrl(WIRE.baseUrl())
-                              .setPolicyPackage("my.policy")) // NOSONAR
-                  .withConfigurationModifier(c -> c.getOpa().setReadTimeout(100))
-                  .build());
+  private static final DropwizardAppRule<OpaBundeTestAppConfiguration> DW =
+      new DropwizardAppRule<>(
+          OpaBundleTestApp.class,
+          resourceFilePath("test-opa-config.yaml"),
+          config("opa.baseUrl", WIRE::baseUrl),
+          config("opa.policyPackage", "my.policy"),
+          config("opa.opaClient.timeout", "100ms"));
 
-  @Rule public final RuleChain chain = RuleChain.outerRule(new RetryRule()).around(WIRE).around(DW);
+  @ClassRule public static final RuleChain chain = RuleChain.outerRule(WIRE).around(DW);
+  @Rule public final RetryRule retryRule = new RetryRule();
+
+  @Before
+  public void before() {
+    WIRE.resetAll();
+  }
 
   @Test
   @Retry(5)
@@ -53,9 +55,8 @@ public class OpaTimeoutIT {
                     .withFixedDelay(400)));
 
     Response response =
-        DW.getRule()
-            .client()
-            .target("http://localhost:" + DW.getRule().getLocalPort())
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
             .path("resources")
             .request()
             .get();
@@ -76,9 +77,8 @@ public class OpaTimeoutIT {
                     .withFixedDelay(1)));
 
     Response response =
-        DW.getRule()
-            .client()
-            .target("http://localhost:" + DW.getRule().getLocalPort())
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
             .path("resources")
             .request()
             .get();

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalInjectApp.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/test/OpaJwtPrincipalInjectApp.java
@@ -7,6 +7,7 @@ import io.dropwizard.setup.Environment;
 import java.util.List;
 import org.sdase.commons.server.auth.AuthBundle;
 import org.sdase.commons.server.auth.config.AuthConfig;
+import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
 import org.sdase.commons.server.opa.OpaBundle;
 import org.sdase.commons.server.opa.config.OpaConfig;
 
@@ -14,6 +15,7 @@ public class OpaJwtPrincipalInjectApp extends Application<OpaJwtPrincipalInjectA
 
   @Override
   public void initialize(Bootstrap<Config> bootstrap) {
+    bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build());
     bootstrap.addBundle(
         AuthBundle.builder()
             .withAuthConfigProvider(Config::getAuth)

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
@@ -31,10 +31,13 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.opa.config.OpaConfig;
 import org.sdase.commons.server.opa.extension.OpaInputExtension;
+import org.sdase.commons.server.testing.Retry;
+import org.sdase.commons.server.testing.RetryRule;
 
 public class OpaBundleBodyInputExtensionTest {
   private static final WireMockClassRule WIRE =
@@ -64,6 +67,8 @@ public class OpaBundleBodyInputExtensionTest {
   public static RuleChain CHAIN =
       RuleChain.outerRule(WIRE).around(DW_WITH_EXTENSION).around(DW_WITHOUT_EXTENSION);
 
+  @Rule public final RetryRule retryRule = new RetryRule();
+
   @BeforeClass
   public static void before() {
     WIRE.resetAll();
@@ -88,6 +93,7 @@ public class OpaBundleBodyInputExtensionTest {
   }
 
   @Test
+  @Retry(5)
   public void testFailureWhenExtensionIsActivated() {
     // given
     WIRE.resetRequests();
@@ -107,6 +113,7 @@ public class OpaBundleBodyInputExtensionTest {
   }
 
   @Test
+  @Retry(5)
   public void testSuccessWhenExtensionIsNotActivated() {
     // given
     WIRE.resetRequests();

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -18,7 +19,6 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,21 +33,18 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.opa.config.OpaConfig;
-import org.sdase.commons.server.testing.LazyRule;
 
 public class OpaBundleClientConfigurationIT {
   public static final WireMockRule WIRE =
       new WireMockRule(new WireMockConfiguration().dynamicPort());
 
-  private static final LazyRule<DropwizardAppRule<TestConfiguration>> DW =
-      new LazyRule<>(
-          () ->
-              new DropwizardAppRule<>(
-                  TestApplication.class,
-                  ResourceHelpers.resourceFilePath("test-config-key-provider.yaml"),
-                  config("opa.baseUrl", WIRE.baseUrl()),
-                  config("opa.policyPackage", "test"),
-                  config("opa.opaClient.userAgent", "my-user-agent")));
+  private static final DropwizardAppRule<TestConfiguration> DW =
+      new DropwizardAppRule<>(
+          TestApplication.class,
+          resourceFilePath("test-config-key-provider.yaml"),
+          config("opa.baseUrl", WIRE::baseUrl),
+          config("opa.policyPackage", "test"),
+          config("opa.opaClient.userAgent", "my-user-agent"));
 
   @ClassRule public static RuleChain RULE = RuleChain.outerRule(WIRE).around(DW);
 
@@ -73,7 +70,7 @@ public class OpaBundleClientConfigurationIT {
   }
 
   private WebTarget createWebTarget() {
-    return DW.getRule().client().target("http://localhost:" + DW.getRule().getLocalPort());
+    return DW.client().target("http://localhost:" + DW.getLocalPort());
   }
 
   public static class TestConfiguration extends Configuration {

--- a/sda-commons-server-circuitbreaker/src/test/java/org/sdase/commons/server/circuitbreaker/CircuitBreakerBundleTestIT.java
+++ b/sda-commons-server-circuitbreaker/src/test/java/org/sdase/commons/server/circuitbreaker/CircuitBreakerBundleTestIT.java
@@ -21,23 +21,20 @@ import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.sdase.commons.server.circuitbreaker.CircuitBreakerWrapperHelperTest.Simple;
 import org.sdase.commons.server.prometheus.PrometheusBundle;
-import org.sdase.commons.server.testing.LazyRule;
 
 public class CircuitBreakerBundleTestIT {
   private static final WireMockClassRule WIRE =
       new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private static final LazyRule<DropwizardAppRule<AppConfiguration>> DW =
-      new LazyRule<>(
-          () -> new DropwizardAppRule<>(TestApp.class, resourceFilePath("test-config.yml")));
+  private static final DropwizardAppRule<AppConfiguration> DW =
+      new DropwizardAppRule<>(TestApp.class, resourceFilePath("test-config.yml"));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
 
   @Test
   public void shouldCreateCircuitBreaker() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     CircuitBreaker circuitBreaker =
         circuitBreakerBundle.createCircuitBreaker("create").withDefaultConfig().build();
@@ -47,7 +44,7 @@ public class CircuitBreakerBundleTestIT {
 
   @Test
   public void shouldHaveDefaultConfiguration() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     CircuitBreaker circuitBreaker =
         circuitBreakerBundle.createCircuitBreaker("default").withDefaultConfig().build();
@@ -68,7 +65,7 @@ public class CircuitBreakerBundleTestIT {
 
   @Test
   public void shouldHaveCustomConfiguration() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     CircuitBreaker circuitBreaker =
         circuitBreakerBundle
@@ -97,7 +94,7 @@ public class CircuitBreakerBundleTestIT {
 
   @Test
   public void shouldApplyIgnoredExceptions() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     CircuitBreaker circuitBreaker =
         circuitBreakerBundle
@@ -122,7 +119,7 @@ public class CircuitBreakerBundleTestIT {
 
   @Test
   public void shouldWrapTarget() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     Simple target =
         circuitBreakerBundle
@@ -135,16 +132,15 @@ public class CircuitBreakerBundleTestIT {
 
   @Test
   public void shouldProvideMetrics() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     CircuitBreakerBundle circuitBreakerBundle = app.getCircuitBreakerBundle();
     CircuitBreaker circuitBreaker =
         circuitBreakerBundle.createCircuitBreaker("metrics").withDefaultConfig().build();
     circuitBreaker.executeSupplier(() -> true);
 
     String metrics =
-        DW.getRule()
-            .client()
-            .target("http://localhost:" + DW.getRule().getAdminPort())
+        DW.client()
+            .target("http://localhost:" + DW.getAdminPort())
             .path("metrics/prometheus")
             .request()
             .get()

--- a/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
+++ b/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.errorhandling;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
@@ -11,18 +12,15 @@ import javax.ws.rs.core.Response;
 import org.assertj.core.groups.Tuple;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 import org.sdase.commons.shared.api.error.ApiError;
 import org.sdase.commons.shared.api.error.ApiInvalidParam;
 
-public class ErrorHandlineExampleIT {
+public class ErrorHandlingExampleIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(ErrorHandlingExampleApplication.class)
-          .withConfigFrom(Configuration::new)
-          .withRandomPorts()
-          .build();
+      new DropwizardAppRule<>(
+          ErrorHandlingExampleApplication.class, resourceFilePath("test-config.yaml"));
 
   @Test
   public void shouldGetNotFoundException() {

--- a/sda-commons-server-errorhandling-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-errorhandling-example/src/test/resources/test-config.yaml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0

--- a/sda-commons-server-healthcheck-example/src/main/java/org/sdase/commons/server/healthcheck/example/HealthExampleApplication.java
+++ b/sda-commons-server-healthcheck-example/src/main/java/org/sdase/commons/server/healthcheck/example/HealthExampleApplication.java
@@ -39,13 +39,12 @@ public class HealthExampleApplication extends Application<HealthExampleConfigura
    * method only for testing issues: changes internal state of the application to simulate healthy
    * and unhealthy
    */
-  void stopCountingThread() {
+  void stopCountingThread() throws InterruptedException {
     CountingThread counting = threadAliveHealthCheck.getThread();
     counting.setStop(true);
-    //noinspection StatementWithEmptyBody,LoopConditionNotUpdatedInsideLoop
-    while (counting.isAlive()) {
-      // wait until thread is dead
-    }
+
+    // wait until thread is dead
+    counting.join();
   }
 
   /** method only for testing issues: resets initial state of the application */

--- a/sda-commons-server-healthcheck-example/src/main/java/org/sdase/commons/server/healthcheck/example/thread/CountingThread.java
+++ b/sda-commons-server-healthcheck-example/src/main/java/org/sdase/commons/server/healthcheck/example/thread/CountingThread.java
@@ -3,7 +3,7 @@ package org.sdase.commons.server.healthcheck.example.thread;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Example thread. It just counts every second and stops by a method call */
+/** Example thread. It just counts every quarter second and stops by a method call */
 public class CountingThread extends Thread {
 
   private static final Logger LOG = LoggerFactory.getLogger(CountingThread.class);
@@ -15,7 +15,7 @@ public class CountingThread extends Thread {
   public void run() {
     while (!stop) {
       try {
-        Thread.sleep(1000);
+        Thread.sleep(250);
         LOG.info("still counting {}", count++);
 
       } catch (InterruptedException e) {

--- a/sda-commons-server-healthcheck-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-healthcheck-example/src/test/resources/test-config.yaml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0

--- a/sda-commons-server-healthcheck/src/test/java/org/sdase/commons/server/healthcheck/HealthCheckIT.java
+++ b/sda-commons-server-healthcheck/src/test/java/org/sdase/commons/server/healthcheck/HealthCheckIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.healthcheck;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -11,7 +12,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.healthcheck.helper.ExternalServiceHealthCheck;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,10 +21,7 @@ public class HealthCheckIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> RULE =
-      DropwizardRuleHelper.dropwizardTestAppFrom(HealthApplication.class)
-          .withConfigFrom(Configuration::new)
-          .withRandomPorts()
-          .build();
+      new DropwizardAppRule<>(HealthApplication.class, resourceFilePath("test-config.yaml"));
 
   @Before
   public void setUp() {

--- a/sda-commons-server-healthcheck/src/test/resources/test-config.yaml
+++ b/sda-commons-server-healthcheck/src/test/resources/test-config.yaml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0

--- a/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleIT.java
+++ b/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.hibernate.example.test;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,11 +18,13 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.sdase.commons.server.hibernate.example.HibernateExampleApplication;
 import org.sdase.commons.server.hibernate.example.HibernateExampleConfiguration;
 import org.sdase.commons.server.hibernate.example.db.model.PersonEntity;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 
 @DBUnit(
     url = HibernateExampleIT.DB_URI,
@@ -33,20 +37,15 @@ public class HibernateExampleIT {
 
   @ClassRule
   public static final DropwizardAppRule<HibernateExampleConfiguration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(HibernateExampleApplication.class)
-          .withConfigFrom(HibernateExampleConfiguration::new)
-          .withRandomPorts()
-          .withConfigurationModifier(
-              c -> {
-                c.setDatabase(new DataSourceFactory());
-                c.getDatabase().setDriverClass("org.h2.Driver");
-                c.getDatabase().setUser("sa");
-                c.getDatabase().setPassword("sa");
-                c.getDatabase().setUrl(DB_URI);
-              })
-          .build();
+      new DropwizardAppRule<>(
+          HibernateExampleApplication.class,
+          resourceFilePath("test-config.yaml"),
+          config("database.driverClass", "org.h2.Driver"),
+          config("database.user", "sa"),
+          config("database.password", "sa"),
+          config("database.url", DB_URI));
 
-  @Rule public final DBUnitRule dbUnitRule = DBUnitRule.instance();
+  @ClassRule public static final DBUnitRule dbUnitRule = DBUnitRule.instance();
 
   @BeforeClass
   public static void initDb() {

--- a/sda-commons-server-hibernate-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-hibernate-example/src/test/resources/test-config.yaml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0

--- a/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateIT.java
+++ b/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateIT.java
@@ -17,7 +17,10 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 import org.flywaydb.core.Flyway;
 import org.flywaydb.core.api.configuration.FluentConfiguration;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.sdase.commons.server.hibernate.test.HibernateApp;
 import org.sdase.commons.server.hibernate.test.HibernateITestConfiguration;
 import org.sdase.commons.server.hibernate.test.model.Person;
@@ -32,7 +35,7 @@ public class HibernateIT {
       new DropwizardAppRule<>(
           HibernateApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 
-  @Rule public final DBUnitRule dbUnitRule = DBUnitRule.instance();
+  @ClassRule public static final DBUnitRule dbUnitRule = DBUnitRule.instance();
 
   @BeforeClass
   public static void initDb() {

--- a/sda-commons-server-kafka-example/src/test/java/org/sdase/commons/server/kafka/KafkaExampleConsumerIT.java
+++ b/sda-commons-server-kafka-example/src/test/java/org/sdase/commons/server/kafka/KafkaExampleConsumerIT.java
@@ -21,7 +21,14 @@ import org.sdase.commons.server.kafka.model.Value;
 
 public class KafkaExampleConsumerIT {
 
-  private static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource().withBrokers(2);
+  private static final SharedKafkaTestResource KAFKA =
+      new SharedKafkaTestResource()
+          .withBrokers(2)
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
 
   private static final KafkaBrokerEnvironmentRule KAFKA_BROKER_ENVIRONMENT_RULE =
       new KafkaBrokerEnvironmentRule(KAFKA);

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppDisabledKafkaServerIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppDisabledKafkaServerIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.kafka;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNull;
 
@@ -20,18 +22,16 @@ import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
 import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
 import org.sdase.commons.server.kafka.exception.ConfigurationException;
 import org.sdase.commons.server.kafka.producer.MessageProducer;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 
 /** checks that all public bundle methods can be called without any exception */
 public class AppDisabledKafkaServerIT {
 
   @ClassRule
   public static final DropwizardAppRule<KafkaTestConfiguration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(KafkaTestApplication.class)
-          .withConfigFrom(KafkaTestConfiguration::new)
-          .withRandomPorts()
-          .withConfigurationModifier(c -> c.getKafka().setDisabled(true))
-          .build();
+      new DropwizardAppRule<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.disabled", "true"));
 
   private List<String> results = Collections.synchronizedList(new ArrayList<>());
 

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppWithoutKafkaServerIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppWithoutKafkaServerIT.java
@@ -1,6 +1,8 @@
 package org.sdase.commons.server.kafka;
 
-import com.google.common.collect.Lists;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -16,18 +18,15 @@ import org.sdase.commons.server.kafka.consumer.IgnoreAndProceedErrorHandler;
 import org.sdase.commons.server.kafka.consumer.strategies.autocommit.AutocommitMLS;
 import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
 import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 
 public class AppWithoutKafkaServerIT {
 
   @ClassRule
   public static final DropwizardAppRule<KafkaTestConfiguration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(KafkaTestApplication.class)
-          .withConfigFrom(KafkaTestConfiguration::new)
-          .withRandomPorts()
-          .withConfigurationModifier(
-              c -> c.getKafka().setBrokers(Lists.newArrayList("PLAINTEXT://127.0.0.1:1")))
-          .build();
+      new DropwizardAppRule<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", "PLAINTEXT://127.0.0.1:1"));
 
   private List<String> results = Collections.synchronizedList(new ArrayList<>());
 

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
@@ -81,7 +81,8 @@ public class KafkaBundleWithConfigIT {
           config("kafka.brokers", KAFKA::getKafkaConnectString),
 
           // performance improvements in the tests
-          config("kafka.config.heartbeat\\.interval\\.ms", "250"));
+          config("kafka.config.heartbeat\\.interval\\.ms", "250"),
+          config("kafka.adminConfig.adminClientRequestTimeoutMs", "30000"));
 
   @ClassRule
   public static final TestRule CHAIN = RuleChain.outerRule(KAFKA).around(DROPWIZARD_APP_RULE);
@@ -453,9 +454,6 @@ public class KafkaBundleWithConfigIT {
                     record -> resultsString.add(record.value()),
                     new IgnoreAndProceedErrorHandler<>()))
             .build());
-
-    // empty topic before test
-    KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(topic);
 
     List<String> checkMessages = new ArrayList<>();
 

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
@@ -39,7 +39,12 @@ public class KafkaBundleWithSaslPlainIT {
   private static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           .registerListener(
-              new SaslPlainListener().withUsername("kafkaclient").withPassword("client-secret"));
+              new SaslPlainListener().withUsername("kafkaclient").withPassword("client-secret"))
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
 
   private static final DropwizardAppRule<KafkaTestConfiguration> DW =
       new DropwizardAppRule<>(

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
@@ -40,7 +40,12 @@ public class KafkaBundleWithSaslScramIT {
   private static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResourceScram()
           .registerListener(
-              new SaslScramListener().withUsername("kafkaclient").withPassword("client-secret"));
+              new SaslScramListener().withUsername("kafkaclient").withPassword("client-secret"))
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
 
   private static final DropwizardAppRule<KafkaTestConfiguration> DW =
       new DropwizardAppRule<>(

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslIT.java
@@ -37,7 +37,12 @@ public class KafkaBundleWithSslIT {
                   .withKeyStorePassword("password")
                   .withTrustStoreLocation(resourceFilePath("ssl/kafka.server.truststore.jks"))
                   .withTrustStorePassword("password")
-                  .withKeyPassword("password"));
+                  .withKeyPassword("password"))
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
 
   private static final DropwizardAppRule<KafkaTestConfiguration> DW =
       new DropwizardAppRule<>(

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslTruststoreIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslTruststoreIT.java
@@ -47,7 +47,12 @@ public class KafkaBundleWithSslTruststoreIT {
                   .withKeyStorePassword("password")
                   .withTrustStoreLocation(resourceFilePath("ssl/kafka.server.truststore.jks"))
                   .withTrustStorePassword("password")
-                  .withKeyPassword("password"));
+                  .withKeyPassword("password"))
+          // we only need one consumer offsets partition
+          .withBrokerProperty("offsets.topic.num.partitions", "1")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
 
   private static final DropwizardAppRule<KafkaTestConfiguration> DW =
       new DropwizardAppRule<>(

--- a/sda-commons-server-kafka/src/test/resources/test-config-default.yml
+++ b/sda-commons-server-kafka/src/test/resources/test-config-default.yml
@@ -7,3 +7,41 @@ server:
     port: 0
 kafka:
   brokers: ${BROKER_CONNECTION_STRING:-[]}
+
+  adminConfig:
+    adminClientRequestTimeoutMs: 2000
+
+  consumers:
+    consumer1:
+      group: default
+      clientId: consumer1
+      config:
+        key.deserializer: "org.apache.kafka.common.serialization.LongDeserializer"
+        value.deserializer: "org.apache.kafka.common.serialization.LongDeserializer"
+    consumer2:
+      clientId: c2
+
+  producers:
+    producer1:
+      config:
+        key.serializer: "org.apache.kafka.common.serialization.LongSerializer"
+        value.serializer: "org.apache.kafka.common.serialization.LongSerializer"
+    producer2:
+      clientId: p2
+
+  listenerConfig:
+    async:
+      topicMissingRetryMs: 40000
+
+  topics:
+    topicId1:
+      name: topic1
+      partitions: 2
+      replicationFactor: 2
+      config:
+        max.message.bytes: 1024
+        retention.ms: 60480000
+    topicId2:
+      name: topic2
+      partitions: 1
+      replicationFactor: 1

--- a/sda-commons-server-mongo-testing/README.md
+++ b/sda-commons-server-mongo-testing/README.md
@@ -32,20 +32,16 @@ public static final MongoDbRule RULE = MongoDbRule
 
 The test rule takes care to choose a free port for the database. You can access the database 
 servers address using `RULE.getHost()`.
-Often one need to pass the server address to the constructor of another rule, where the 
-[`LazyRule`](../sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/LazyRule.java) 
-can be handy:
+Often one need to pass the server address to the constructor of another rule:
 
 ```
 private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-private static final LazyRule<DropwizardAppRule<AppConfiguration>> DW =
-    new LazyRule<>(
-        () ->
-            new DropwizardAppRule<>(
-                MyApplication.class,
-                ResourceHelpers.resourceFilePath("test-config.yml"),
-                ConfigOverride.config("mongo.hosts", MONGODB.getHost())));
+private static final DropwizardAppRule<AppConfiguration> DW =
+    new DropwizardAppRule<>(
+        MyApplication.class,
+        ResourceHelpers.resourceFilePath("test-config.yml"),
+        ConfigOverride.config("mongo.hosts", () -> MONGODB.getHost()));
 
 @ClassRule
 public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia-example/README.md
+++ b/sda-commons-server-morphia-example/README.md
@@ -8,6 +8,6 @@ The [`CarsManager`](./src/main/java/org/sdase/commons/server/morphia/example/mon
 The example also shows how the datastore object (created within the bundle) can be used in other classes by dependency injection (WELD).
 
 The demonstration integration test [`MorphiaApplicationIT`](./src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java) shows
-how to use the `MongoDBRule` and the `LazyRule` to create a WELD capable Dropwizard application that uses a mongo database in a test case. 
+how to use the `MongoDBRule` to create a WELD capable Dropwizard application that uses a mongo database in a test case. 
 
 Note: The application is not meant to be started. It's only used for integration test purposes.

--- a/sda-commons-server-morphia-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-morphia-example/src/test/resources/test-config.yaml
@@ -5,5 +5,3 @@ server:
   adminConnectors:
   - type: http
     port: 0
-
-auth: ${AUTH_RULE}

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.MongoClient;
@@ -24,26 +26,18 @@ import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
 import org.sdase.commons.server.morphia.test.model.PhoneNumber;
 import org.sdase.commons.server.morphia.test.model.PhoneNumberConverter;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities can be added by exact definition. */
 public class MorphiaBundleCustomConverterIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -64,10 +58,9 @@ public class MorphiaBundleCustomConverterIT {
         new PhoneNumber().setCountryCode("0049").setAreaCode("0172").setNumber("123 456 789");
     Key<Person> johnDoe =
         datastore.save(new Person().setName("John Doe").setAge(42).setPhoneNumber(phoneNumber));
-    MongoClient mongoClient =
-        ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().mongoClient();
+    MongoClient mongoClient = DW.<MorphiaTestApp>getApplication().getMorphiaBundle().mongoClient();
     MongoDatabase database =
-        mongoClient.getDatabase(DW.getRule().getConfiguration().getMongo().getDatabase());
+        mongoClient.getDatabase(DW.getConfiguration().getMongo().getDatabase());
     MongoCollection<Document> peopleCollection = database.getCollection("people");
     List<String> phoneNumbers = new ArrayList<>();
     peopleCollection
@@ -85,7 +78,7 @@ public class MorphiaBundleCustomConverterIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -17,26 +19,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities can be added by exact definition. */
 public class MorphiaBundleDefinedClassIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -62,7 +56,7 @@ public class MorphiaBundleDefinedClassIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
@@ -22,26 +24,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities can be added by exact definition. */
 public class MorphiaBundleEnsureIndexesIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -110,7 +104,7 @@ public class MorphiaBundleEnsureIndexesIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -17,26 +19,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities can be added if they are not in the scanned package. */
 public class MorphiaBundleNoEntityDefinedIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -62,7 +56,7 @@ public class MorphiaBundleNoEntityDefinedIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.morphia.Datastore;
@@ -20,26 +22,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities can be added by exact definition. */
 public class MorphiaBundleTracingIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -88,11 +82,11 @@ public class MorphiaBundleTracingIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   private MockTracer getMockTracer() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMockTracer();
+    return DW.<MorphiaTestApp>getApplication().getMockTracer();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import dev.morphia.Datastore;
@@ -13,26 +15,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities are NOT validated if validation was disabled. */
 public class MorphiaBundleValidationDisabledIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -57,7 +51,7 @@ public class MorphiaBundleValidationDisabledIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.morphia;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import dev.morphia.Datastore;
@@ -14,26 +16,18 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
 import org.sdase.commons.server.morphia.test.Config;
 import org.sdase.commons.server.morphia.test.model.Person;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 /** Tests if entities are validated. */
 public class MorphiaBundleValidationIT {
 
   private static final MongoDbRule MONGODB = MongoDbRule.builder().build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getMongo()
-                              .setHosts(MONGODB.getHost())
-                              .setDatabase(MONGODB.getDatabase()))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          MorphiaTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);
 
@@ -54,7 +48,7 @@ public class MorphiaBundleValidationIT {
   }
 
   private Datastore getDatastore() {
-    return ((MorphiaTestApp) DW.getRule().getApplication()).getMorphiaBundle().datastore();
+    return DW.<MorphiaTestApp>getApplication().getMorphiaBundle().datastore();
   }
 
   public static class MorphiaTestApp extends Application<Config> {

--- a/sda-commons-server-morphia/src/test/resources/test-config.yaml
+++ b/sda-commons-server-morphia/src/test/resources/test-config.yaml
@@ -5,5 +5,3 @@ server:
   adminConnectors:
   - type: http
     port: 0
-
-auth: ${AUTH_RULE}

--- a/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
+++ b/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
@@ -7,11 +7,14 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.openapi.example.OpenApiExampleApplication;
 import org.sdase.commons.server.starter.SdaPlatformConfiguration;
 import org.sdase.commons.server.testing.DropwizardRuleHelper;
+import org.sdase.commons.server.testing.Retry;
+import org.sdase.commons.server.testing.RetryRule;
 
 // This is a simple integration test that checks whether the swagger documentation is produced at
 // the right path, however doesn't test the contents of the documentation.
@@ -34,7 +37,10 @@ public class OpenApiIT {
           .withConfigurationModifier(AUTH.applyConfig(SdaPlatformConfiguration::setAuth))
           .build();
 
+  @Rule public RetryRule retryRule = new RetryRule();
+
   @Test
+  @Retry(5)
   public void testAnswerOpenApiJson() {
     // given
 
@@ -46,6 +52,7 @@ public class OpenApiIT {
   }
 
   @Test
+  @Retry(5)
   public void testAnswerOpenApiYaml() {
     // given
 

--- a/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
+++ b/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.openapi.example.people.rest;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,10 +10,10 @@ import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.openapi.example.OpenApiExampleApplication;
 import org.sdase.commons.server.starter.SdaPlatformConfiguration;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
 
@@ -24,18 +25,16 @@ public class OpenApiIT {
   // Connect provider for the tests
   private static final AuthRule AUTH = AuthRule.builder().build();
 
-  @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
       // Setup a test instance of the application
-      DropwizardRuleHelper.dropwizardTestAppFrom(OpenApiExampleApplication.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          // use random ports so that tests can run in parallel
-          // and do not affect each other when one is not shutting down
-          .withRandomPorts()
-          // apply the auth config to the test instance of the application
-          // to verify incoming tokens correctly
-          .withConfigurationModifier(AUTH.applyConfig(SdaPlatformConfiguration::setAuth))
-          .build();
+      new DropwizardAppRule<>(
+          OpenApiExampleApplication.class,
+          // use the config file 'test-config.yaml' from the test resources folder
+          resourceFilePath("test-config.yaml"));
+
+  // apply the auth config to the test instance of the application
+  // to verify incoming tokens correctly
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(AUTH).around(DW);
 
   @Rule public RetryRule retryRule = new RetryRule();
 

--- a/sda-commons-server-openapi-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-openapi-example/src/test/resources/test-config.yaml
@@ -1,0 +1,12 @@
+# use random ports so that tests can run in parallel
+# and do not affect each other when one is not shutting down
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+
+# The configuration of the test auth bundle is injected here
+auth: ${AUTH_RULE}

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleFileIT.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleFileIT.java
@@ -13,9 +13,12 @@ import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.sdase.commons.server.openapi.apps.file.FromFileTestApp;
 import org.sdase.commons.server.openapi.test.OpenApiAssertions;
+import org.sdase.commons.server.testing.Retry;
+import org.sdase.commons.server.testing.RetryRule;
 
 public class OpenApiBundleFileIT {
   private static final String HOUSE_DEFINITION = "House";
@@ -23,6 +26,8 @@ public class OpenApiBundleFileIT {
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
       new DropwizardAppRule<>(FromFileTestApp.class, resourceFilePath("test-config.yaml"));
+
+  @Rule public RetryRule retryRule = new RetryRule();
 
   private static Builder getJsonRequest() {
     return DW.client()
@@ -45,6 +50,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldProvideSchemaCompliantJson() {
     try (Response response = getJsonRequest().get()) {
       assertThat(response.getStatus()).isEqualTo(OK_200);
@@ -55,6 +61,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldProvideValidYaml() {
     try (Response response = getYamlRequest().get()) {
       assertThat(response.getStatus()).isEqualTo(OK_200);
@@ -65,6 +72,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldHaveCORSWildcardJson() {
     try (Response response = getJsonRequest().header("Origin", "example.com").get()) {
       assertThat(response.getStatus()).isEqualTo(OK_200);
@@ -73,6 +81,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldHaveCORSWildcardYaml() {
     try (Response response = getYamlRequest().header("Origin", "example.com").get()) {
       assertThat(response.getStatus()).isEqualTo(OK_200);
@@ -81,6 +90,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldNotHaveCORSWildcardOnOtherPath() {
     try (Response response =
         DW.client()
@@ -97,6 +107,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludeInfo() {
     String response = getJsonRequest().get(String.class);
 
@@ -105,6 +116,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludeServerUrl() {
     String response = getJsonRequest().get(String.class);
 
@@ -115,6 +127,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludePaths() {
     String response = getJsonRequest().get(String.class);
 
@@ -127,6 +140,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludeSchemas() {
     String response = getJsonRequest().get(String.class);
 
@@ -142,6 +156,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldUseDescriptionFromAnnotation() {
     String response = getJsonRequest().get(String.class);
 
@@ -151,6 +166,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldNotIncludeAdditionalReturnCode() {
     String response = getJsonRequest().get(String.class);
 
@@ -160,6 +176,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludeEmbedParameterExistingEmbeddedProperty() {
     String response = getJsonRequest().get(String.class);
 
@@ -170,6 +187,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldIncludeEmbedParameterExistingEmbeddedAllOfProperty() {
     String response = getJsonRequest().get(String.class);
 
@@ -180,6 +198,7 @@ public class OpenApiBundleFileIT {
   }
 
   @Test
+  @Retry(5)
   public void shouldNotIncludeEmbedParameterExistingEmbeddedAnyOfProperty() {
     String response = getJsonRequest().get(String.class);
 

--- a/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
+++ b/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
@@ -28,22 +28,23 @@ import java.util.Map;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.opentracing.test.TraceTestApp;
 
 public class OpenTracingBundleTest {
 
-  @Rule
-  public final DropwizardAppRule<Configuration> dw =
+  @ClassRule
+  public static final DropwizardAppRule<Configuration> DW =
       new DropwizardAppRule<>(TraceTestApp.class, resourceFilePath("test-config.yaml"));
 
   private MockTracer tracer;
 
   @Before
   public void setUp() {
-    TraceTestApp app = dw.getApplication();
+    TraceTestApp app = DW.getApplication();
     tracer = app.getTracer();
+    tracer.reset();
   }
 
   @Test
@@ -171,7 +172,7 @@ public class OpenTracingBundleTest {
                       entry(COMPONENT.getKey(), "jaxrs"),
                       entry(
                           HTTP_URL.getKey(),
-                          "http://localhost:" + dw.getLocalPort() + "/respond/test"),
+                          "http://localhost:" + DW.getLocalPort() + "/respond/test"),
                       entry(HTTP_RESPONSE_HEADERS.getKey(), "[Content-Type = 'text/html']"));
               assertThat(tags).containsKey(HTTP_REQUEST_HEADERS.getKey());
             });
@@ -202,7 +203,7 @@ public class OpenTracingBundleTest {
                       entry(COMPONENT.getKey(), "java-web-servlet"),
                       entry(
                           HTTP_URL.getKey(),
-                          "http://localhost:" + dw.getLocalPort() + "/respond/test"));
+                          "http://localhost:" + DW.getLocalPort() + "/respond/test"));
               assertThat(tags).containsKey(HTTP_REQUEST_HEADERS.getKey());
               assertThat(tags).containsKey(HTTP_RESPONSE_HEADERS.getKey());
             });
@@ -307,10 +308,10 @@ public class OpenTracingBundleTest {
   }
 
   private WebTarget createClient() {
-    return dw.client().target("http://localhost:" + dw.getLocalPort());
+    return DW.client().target("http://localhost:" + DW.getLocalPort());
   }
 
   private WebTarget createAdminClient() {
-    return dw.client().target("http://localhost:" + dw.getAdminPort());
+    return DW.client().target("http://localhost:" + DW.getAdminPort());
   }
 }

--- a/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
+++ b/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.prometheus.example;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -7,7 +8,6 @@ import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.starter.SdaPlatformConfiguration;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,10 +17,7 @@ public class PrometheusMetricsIT {
 
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      DropwizardRuleHelper.dropwizardTestAppFrom(MetricExampleApp.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          .withRandomPorts()
-          .build();
+      new DropwizardAppRule<>(MetricExampleApp.class, resourceFilePath("test-config.yaml"));
 
   @Test
   public void produceGaugeMetric() {

--- a/sda-commons-server-prometheus-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-prometheus-example/src/test/resources/test-config.yaml
@@ -1,0 +1,9 @@
+# use random ports so that tests can run in parallel
+# and do not affect each other when one is not shutting down
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0

--- a/sda-commons-server-s3-testing/README.md
+++ b/sda-commons-server-s3-testing/README.md
@@ -27,22 +27,18 @@ public static final S3MockRule S3_MOCK = S3MockRule
 
 The test rule takes care to choose a free port for the endpoint. You can access the mock 
 URL using `RULE.getEndpoint()`.
-Often one need to pass the endpoint URL to the constructor of another rule, where the 
-[`LazyRule`](../sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/LazyRule.java) 
-can be handy:
+Often one need to pass the endpoint URL to the constructor of another rule:
 
 ```
 public static final S3MockRule S3_MOCK = S3MockRule
       .builder()
       .build();
 
-private static final LazyRule<DropwizardAppRule<AppConfiguration>> DW =
-    new LazyRule<>(
-        () ->
-            new DropwizardAppRule<>(
-                MyApplication.class,
-                ResourceHelpers.resourceFilePath("test-config.yml"),
-                ConfigOverride.config("objectstorage.endpoint", S3_MOCK.getEndpoint())));
+private static final DropwizardAppRule<AppConfiguration> DW =
+    new DropwizardAppRule<>(
+        MyApplication.class,
+        ResourceHelpers.resourceFilePath("test-config.yml"),
+        ConfigOverride.config("objectstorage.endpoint", () -> S3_MOCK.getEndpoint())));
 
 @ClassRule
 public static final RuleChain CHAIN = RuleChain.outerRule(S3_MOCK).around(DW);

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.s3;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -12,33 +14,25 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.s3.test.Config;
 import org.sdase.commons.server.s3.test.TestApp;
 import org.sdase.commons.server.s3.testing.S3MockRule;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
-import org.sdase.commons.server.testing.LazyRule;
 
 public class S3BundleTest {
 
   private static final S3MockRule S_3_MOCK_RULE =
       S3MockRule.builder().putObject("bucket", "key", "data").build();
 
-  private static final LazyRule<DropwizardAppRule<Config>> DW =
-      new LazyRule<>(
-          () ->
-              DropwizardRuleHelper.dropwizardTestAppFrom(TestApp.class)
-                  .withConfigFrom(Config::new)
-                  .withRandomPorts()
-                  .withConfigurationModifier(
-                      c ->
-                          c.getS3Config()
-                              .setEndpoint(S_3_MOCK_RULE.getEndpoint())
-                              .setAccessKey("access-key")
-                              .setSecretKey("secret-key"))
-                  .build());
+  private static final DropwizardAppRule<Config> DW =
+      new DropwizardAppRule<>(
+          TestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("s3Config.endpoint", S_3_MOCK_RULE::getEndpoint),
+          config("s3Config.accessKey", "access-key"),
+          config("s3Config.secretKey", "secret-key"));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(S_3_MOCK_RULE).around(DW);
 
   @Test()
   public void shouldProvideClient() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     S3Bundle bundle = app.getS3Bundle();
     AmazonS3 client = bundle.getClient();
 
@@ -47,7 +41,7 @@ public class S3BundleTest {
 
   @Test()
   public void shouldTraceCalls() {
-    TestApp app = DW.getRule().getApplication();
+    TestApp app = DW.getApplication();
     S3Bundle bundle = app.getS3Bundle();
     AmazonS3 client = bundle.getClient();
 

--- a/sda-commons-server-s3/src/test/resources/test-config.yaml
+++ b/sda-commons-server-s3/src/test/resources/test-config.yaml
@@ -5,5 +5,3 @@ server:
   adminConnectors:
   - type: http
     port: 0
-
-auth: ${AUTH_RULE}

--- a/sda-commons-server-starter-example/src/test/java/org/sdase/commons/server/starter/example/SdaPlatformExampleApplicationIT.java
+++ b/sda-commons-server-starter-example/src/test/java/org/sdase/commons/server/starter/example/SdaPlatformExampleApplicationIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.starter.example;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static java.util.Arrays.asList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,12 +14,12 @@ import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.starter.SdaPlatformConfiguration;
 import org.sdase.commons.server.starter.example.people.db.PersonEntity;
 import org.sdase.commons.server.starter.example.people.db.TestDataUtil;
 import org.sdase.commons.server.starter.example.people.rest.PersonResource;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 import org.sdase.commons.shared.tracing.ConsumerTracing;
 
 public class SdaPlatformExampleApplicationIT {
@@ -27,18 +28,16 @@ public class SdaPlatformExampleApplicationIT {
   // tests
   private static final AuthRule AUTH = AuthRule.builder().build();
 
-  @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
       // Setup a test instance of the application
-      DropwizardRuleHelper.dropwizardTestAppFrom(SdaPlatformExampleApplication.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          // use random ports so that tests can run in parallel
-          // and do not affect each other when one is not shutting down
-          .withRandomPorts()
-          // apply the auth config to the test instance of the application to verify incoming tokens
-          // correctly
-          .withConfigurationModifier(AUTH.applyConfig(SdaPlatformConfiguration::setAuth))
-          .build();
+      new DropwizardAppRule<>(
+          SdaPlatformExampleApplication.class,
+          // use the config file 'test-config.yaml' from the test resources folder
+          resourceFilePath("test-config.yaml"));
+
+  // apply the auth config to the test instance of the application
+  // to verify incoming tokens correctly
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(AUTH).around(DW);
 
   private static final String TEST_CONSUMER_TOKEN = "test-consumer";
 

--- a/sda-commons-server-starter-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-starter-example/src/test/resources/test-config.yaml
@@ -1,0 +1,12 @@
+# use random ports so that tests can run in parallel
+# and do not affect each other when one is not shutting down
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+
+# The configuration of the test auth bundle is injected here
+auth: ${AUTH_RULE}

--- a/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/FilterPriorityTest.java
+++ b/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/FilterPriorityTest.java
@@ -1,9 +1,9 @@
 package org.sdase.commons.server.starter;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jetty.http.HttpStatus.OK_200;
-import static org.sdase.commons.server.testing.DropwizardRuleHelper.dropwizardTestAppFrom;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
@@ -15,11 +15,7 @@ public class FilterPriorityTest {
 
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      dropwizardTestAppFrom(StarterApp.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          .withRandomPorts()
-          .withRootPath("/api/*")
-          .build();
+      new DropwizardAppRule<>(StarterApp.class, resourceFilePath("test-config.yaml"));
 
   @Test
   public void corsFromSwaggerHasHigherPriority() {

--- a/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/SdaPlatformBundleAppTest.java
+++ b/sda-commons-server-starter/src/test/java/org/sdase/commons/server/starter/SdaPlatformBundleAppTest.java
@@ -1,30 +1,26 @@
 package org.sdase.commons.server.starter;
 
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
-import static org.sdase.commons.server.testing.DropwizardRuleHelper.dropwizardTestAppFrom;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.Map;
 import javax.ws.rs.core.GenericType;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.auth.config.AuthConfig;
-import org.sdase.commons.server.cors.CorsConfiguration;
 import org.sdase.commons.server.starter.test.StarterApp;
 
 public class SdaPlatformBundleAppTest {
 
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      dropwizardTestAppFrom(StarterApp.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          .withRandomPorts()
-          .withConfigurationModifier(c -> c.setAuth(new AuthConfig().setDisableAuth(true)))
-          .withConfigurationModifier(c -> c.setCors(new CorsConfiguration()))
-          .withRootPath("/api/*")
-          .build();
+      new DropwizardAppRule<>(
+          StarterApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("auth.disableAuth", "true"));
 
   @Test
   public void pongForPing() {

--- a/sda-commons-server-starter/src/test/resources/test-config.yaml
+++ b/sda-commons-server-starter/src/test/resources/test-config.yaml
@@ -1,0 +1,8 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+  rootPath: "/api/*"

--- a/sda-commons-server-swagger-example/src/test/java/org/sdase/commons/server/swagger/example/people/rest/SwaggerIT.java
+++ b/sda-commons-server-swagger-example/src/test/java/org/sdase/commons/server/swagger/example/people/rest/SwaggerIT.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.swagger.example.people.rest;
 
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -8,10 +9,10 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.starter.SdaPlatformConfiguration;
 import org.sdase.commons.server.swagger.example.SwaggerExampleApplication;
-import org.sdase.commons.server.testing.DropwizardRuleHelper;
 
 // This is a simple integration test that checks whether the swagger documentation is produced at
 // the right path, however doesn't test the contents of the documentation.
@@ -21,18 +22,16 @@ public class SwaggerIT {
   // Connect provider for the tests
   private static final AuthRule AUTH = AuthRule.builder().build();
 
-  @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
       // Setup a test instance of the application
-      DropwizardRuleHelper.dropwizardTestAppFrom(SwaggerExampleApplication.class)
-          .withConfigFrom(SdaPlatformConfiguration::new)
-          // use random ports so that tests can run in parallel
-          // and do not affect each other when one is not shutting down
-          .withRandomPorts()
-          // apply the auth config to the test instance of the application
-          // to verify incoming tokens correctly
-          .withConfigurationModifier(AUTH.applyConfig(SdaPlatformConfiguration::setAuth))
-          .build();
+      new DropwizardAppRule<>(
+          SwaggerExampleApplication.class,
+          // use the config file 'test-config.yaml' from the test resources folder
+          resourceFilePath("test-config.yaml"));
+
+  // apply the auth config to the test instance of the application
+  // to verify incoming tokens correctly
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(AUTH).around(DW);
 
   @Test
   public void testAnswerSwaggerJson() {

--- a/sda-commons-server-swagger-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-swagger-example/src/test/resources/test-config.yaml
@@ -1,0 +1,12 @@
+# use random ports so that tests can run in parallel
+# and do not affect each other when one is not shutting down
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+
+# The configuration of the test auth bundle is injected here
+auth: ${AUTH_RULE}

--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleIT.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleIT.java
@@ -97,7 +97,7 @@ public class SwaggerBundleIT {
 
     assertThatJson(response)
         .inPath("$.info.title")
-        .isEqualTo(((SwaggerBundleTestApp) DW.getApplication()).getTitle());
+        .isEqualTo(DW.<SwaggerBundleTestApp>getApplication().getTitle());
     assertThatJson(response).inPath("$.info.version").asString().isEqualTo("1");
   }
 

--- a/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleMultipleApplicationsIT.java
+++ b/sda-commons-server-swagger/src/test/java/org/sdase/commons/server/swagger/SwaggerBundleMultipleApplicationsIT.java
@@ -34,7 +34,7 @@ public class SwaggerBundleMultipleApplicationsIT {
 
     assertThatJson(response)
         .inPath("$.info.title")
-        .isEqualTo(((SwaggerBundleTestApp) DW.getApplication()).getTitle());
+        .isEqualTo(DW.<SwaggerBundleTestApp>getApplication().getTitle());
     assertThatJson(response).inPath("$.info.version").asString().isEqualTo("1");
   }
 

--- a/sda-commons-server-testing/README.md
+++ b/sda-commons-server-testing/README.md
@@ -40,28 +40,6 @@ public class CustomIT {
 }
 ```
 
-### LazyRule
-
-The [`LazyRule`](./src/main/java/org/sdase/commons/server/testing/LazyRule.java) allows to wrap another 
-rule to defer the initialization of the rule till the rule is started the first time. 
-This allows to initialize a rule with parameters that are only available once another rule is 
-completely initialized. This is often required if one rule opens a random port that the other rule 
-want to connect to.
-
-```
-public class CustomIT {
-
-    private static final ServerRule SERVER = new ServerRule();
-    private static final LazyRule<ClientRule> CLIENT = new LazyRule<>(() -> new ClientRule(SERVER.getPort()));
-
-    @ClassRule
-    public static final RuleChain RULE_CHAIN = RuleChain.outerRule(SERVER).around(CLIENT);
-
-
-    // ...
-}
-```
-
 ## Provided helpers
 
 ### DropwizardRuleHelper

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/DropwizardRuleHelper.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/DropwizardRuleHelper.java
@@ -15,7 +15,21 @@ import org.sdase.commons.server.testing.builder.DropwizardRuleBuilders.PortBuild
  *
  * @param <C> the type of the {@link Configuration} used by the {@link Application}
  * @param <A> the type of the {@link Application} that bootstraps the service
+ * @deprecated Prefer the original {@link DropwizardAppRule} and a config file with the following
+ *     minimal content:
+ *     <pre>{@code
+ * # use random ports so that tests can run in parallel
+ * # and do not affect each other when one is not shutting down
+ * server:
+ *   applicationConnectors:
+ *   - type: http
+ *     port: 0
+ *   adminConnectors:
+ *   - type: http
+ *     port: 0
+ * }</pre>
  */
+@Deprecated
 public class DropwizardRuleHelper<C extends Configuration, A extends Application<C>>
     implements ConfigurationBuilder<C>, PortBuilder<C>, CustomizationBuilder<C> {
 

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/LazyRule.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/LazyRule.java
@@ -30,7 +30,25 @@ import org.junit.runners.model.Statement;
  *     &#64;ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
  *   }
  * </pre>
+ *
+ * @deprecated Use {@link io.dropwizard.testing.ConfigOverride#config(String, Supplier)} instead.
+ *     The above example can be written as:
+ *     <pre>
+ *   class MyTest {
+ *     private static final WireMockClassRule WIRE =
+ *         new WireMockClassRule(wireMockConfig().dynamicPort());
+ *     private static final DropwizardAppRule&#60;AppConfiguration&#62; DW =
+ *         new DropwizardAppRule&#60;&#62;(
+ *             TestApplication.class,
+ *             ResourceHelpers.resourceFilePath("test-config.yml"),
+ *             ConfigOverride.config("url", WIRE::baseUrl));
+ *             // or ConfigOverride.config("url", () -&#62; WIRE.baseUrl()));
+ *
+ *     &#64;ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
+ *   }
+ * </pre>
  */
+@Deprecated
 public class LazyRule<T extends TestRule> implements TestRule {
   private Supplier<T> ruleSupplier;
   private T rule;


### PR DESCRIPTION
I did change three things:
1. Deprecate the `LazyRule` and remove all usages in this repository.
2. Deprecate the `DropwizardRuleHelper` and remove all usages in this repository.
3. Try to improve the test stability.

## Reasoning

### `LazyRule`

We often have the following pattern in our services. This is necessary because `WIRE.baseUrl()` can only be accessed after WireMock has been started.

```java
class MyTest {
  private static final WireMockClassRule WIRE =
      new WireMockClassRule(wireMockConfig().dynamicPort());

  private static final LazyRule<DropwizardAppRule<AppConfiguration>> DW =
      new LazyRule<>(
          () ->
              new DropwizardAppRule<>(
                  TestApplication.class,
                  ResourceHelpers.resourceFilePath("test-config.yml"),
                  ConfigOverride.config("url", WIRE.baseUrl())));

  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
}
```

But the `DropwizardAppRule` already provides a solution for this: there is a `ConfigOverride.config(String key, Supplier<String> value)` variant, so it can be written without the `LazyRule`:

```diff
  class MyTest {
    private static final WireMockClassRule WIRE =
        new WireMockClassRule(wireMockConfig().dynamicPort());

    private static final DropwizardAppRule<AppConfiguration> DW =
-       new LazyRule<>(
-           () ->
        new DropwizardAppRule<>(
            TestApplication.class,
            ResourceHelpers.resourceFilePath("test-config.yml"),
-           ConfigOverride.config("url", WIRE.baseUrl())));
+           ConfigOverride.config("url", WIRE::baseUrl));

  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
}
```

This also allows more complex values like `config("url", () -> WIRE.path("anything"))`. We also have a test that requires such a feature from the `SystemPropertyRule`, so it has also been added there.

### `DropwizardRuleHelper`

This one is a bit trickier. This helper should make it easier to configure tests, because you don't need a config-file and can more easily setup a `withRandomPorts` behavior. But I would argue that we should try to stick to Dropwizard as near as possible since I hope that this would also make it easier to switch to JUnit 5 in the future. There were also cases where the creation of configuration objects in java was more verbose than the other approach (e.g. `KafkaBundleWithConfigIT`). Also, this is quite far from how one would configure the service for production usage.

I prefer the config-file + config-overrides way over the rule helper. But this might be up to taste.

With `DropwizardRuleHelper`:
```java
  private static final LazyRule<DropwizardAppRule<Config>> DW =
      new LazyRule<>(
          () ->
              DropwizardRuleHelper.dropwizardTestAppFrom(MorphiaTestApp.class)
                  .withConfigFrom(Config::new)
                  .withRandomPorts()
                  .withConfigurationModifier(
                      c ->
                          c.getMongo()
                              .setHosts(MONGODB.getHost())
                              .setDatabase(MONGODB.getDatabase()))
                  .build());
```

Without:
```yaml
server:
  applicationConnectors:
  - type: http
    port: 0
  adminConnectors:
  - type: http
    port: 0

```

```java
  private static final DropwizardAppRule<Config> DW =
      new DropwizardAppRule<>(
          MorphiaTestApp.class,
          resourceFilePath("test-config.yaml"),
          config("mongo.hosts", MONGODB::getHost),
          config("mongo.database", MONGODB::getDatabase));
```

### Tests

We have some flaky tests and I tried to make them more stable. There were some issues:

* Some tests used `@Rule` instead of `@ClassRule` without a good reason, which led to unnecessary application restarts. If used together with `@Retry`, tests always called cold-services and timeout issues can't be resolved on a highly-utilized build runner.
* There are some strange assertions regarding async operations (see `ApiClientTimeoutTest`).
* Reduce calls to things like `KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC_NAME)` since they can lead to timeout-errors and can delay the test-execution needlessly.

This doesn't mean that the tests are super stable from now on, but I hope this improves it a bit. There are still some issues around e.g. `createTopics`.