### PR TITLE
Add dedicated config class for Api clients

### DIFF
--- a/sda-commons-client-jersey/README.md
+++ b/sda-commons-client-jersey/README.md
@@ -63,10 +63,11 @@ Clients for the SDA Platform have some magic added that clients for an external 
   SDA Platform clients can be configured to pass through the Authorization header of an incoming request context:
   
   ```java
-  clientFactory.platformClient()
+  // using ApiHttpClientConfiguration property from service config
+  clientFactory
+        .platformClient(configuration.getOtherSdaServiceClient()) 
         .enableAuthenticationPassThrough()
-        .api(OtherSdaServiceClient.class)
-        .atTarget("http://other-sda-service.sda.net/api");
+        .api(OtherSdaServiceClient.class);
   ```
 - _Consumer-Token_
   
@@ -81,10 +82,11 @@ Clients for the SDA Platform have some magic added that clients for an external 
   Then the clients can be configured to add a Consumer-Token header:
   
   ```java
-  clientFactory.platformClient()
+  // using ApiHttpClientConfiguration property from service config
+  clientFactory
+        .platformClient(configuration.getOtherSdaServiceClient()) 
         .enableConsumerToken()
-        .api(OtherSdaServiceClient.class)
-        .atTarget("http://other-sda-service.sda.net/api");
+        .api(OtherSdaServiceClient.class);
   ```
 
 
@@ -175,27 +177,30 @@ Each client can be configured with the standard
 Please note that this requires that there is a property in your Application's `Configuration` class. 
 
 ```java
-import org.sdase.commons.client.jersey.HttpClientConfiguration;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
 
 public class MyConfiguration extends Configuration {
-   private HttpClientConfiguration myClient = new HttpClientConfiguration();
+   private ApiHttpClientConfiguration myClient = new APiHttpClientConfiguration();
 
-   public HttpClientConfiguration getMyClient() {
+   public ApiHttpClientConfiguration getMyClient() {
      return myClient;
    }
 
-   public void setMyClient(HttpClientConfiguration myClient) {
+   public void setMyClient(ApiHttpClientConfiguration myClient) {
      this.myClient = myClient;
    }
 }
 ```
 
 ```java
-Client client = clientFactory.platformClient(configuration.getMyClient()).buildGenericClient("test");
+MyClientInterface client = clientFactory
+    .platformClient(configuration.getMyClient())
+    .api(MyClientInterface.class);
 ```
 
 ```yaml
 myClient:
+  apiBaseUrl: http://my-service:8080
   timeout: 500ms
   proxy:
     host: 192.168.52.11

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ApiHttpClientConfiguration.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ApiHttpClientConfiguration.java
@@ -1,0 +1,58 @@
+package org.sdase.commons.client.jersey;
+
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.dropwizard.util.Duration;
+
+/**
+ * A configuration class to be used for API clients that are created as Proxy from annotated
+ * interfaces.
+ */
+public class ApiHttpClientConfiguration extends JerseyClientConfiguration {
+  /**
+   * The default (read) timeout to wait for data in an established connection. 2 seconds is used as
+   * a trade between "fail fast" and "better return late than no result". The timeout may be changed
+   * according to the use case considering how long a user is willing to wait and how long backend
+   * operations need.
+   */
+  public static final int DEFAULT_TIMEOUT_MS = 2_000;
+
+  /**
+   * The default timeout to wait until a connection is established. 500ms should be suitable for all
+   * communication in the platform. Clients that request information from external services may
+   * extend this timeout if foreign services are usually slow.
+   */
+  public static final int DEFAULT_CONNECTION_TIMEOUT_MS = 500;
+
+  private String apiBaseUrl;
+
+  public ApiHttpClientConfiguration() {
+    // Chunked encoding is disabled by default, because in combination with the
+    // underlying Apache Http Client it breaks support for multipart/form-data
+    setChunkedEncodingEnabled(false);
+
+    // Gzip for request is disabled by default, because it breaks with some
+    // server implementations in combination with the Content-Encoding: gzip
+    // header if supplied accidentally to a GET request. This happen after
+    // calling a POST and receiving a SEE_OTHER response that is executed with
+    // the same headers as the POST request.
+    setGzipEnabledForRequests(false);
+
+    // override the default timeouts
+    setTimeout(Duration.milliseconds(DEFAULT_TIMEOUT_MS));
+    setConnectionTimeout(Duration.milliseconds(DEFAULT_CONNECTION_TIMEOUT_MS));
+  }
+
+  /** @return the base URL of the implemented API, e.g. {@code http://the-service:8080/api} */
+  public String getApiBaseUrl() {
+    return apiBaseUrl;
+  }
+
+  /**
+   * @param apiBaseUrl the base URL of the implemented API, e.g. {@code http://the-service:8080/api}
+   * @return this instance for fluent configuration
+   */
+  public ApiHttpClientConfiguration setApiBaseUrl(String apiBaseUrl) {
+    this.apiBaseUrl = apiBaseUrl;
+    return this;
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
@@ -2,7 +2,9 @@ package org.sdase.commons.client.jersey;
 
 import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
+import org.sdase.commons.client.jersey.builder.ExternalApiClientBuilder;
 import org.sdase.commons.client.jersey.builder.ExternalClientBuilder;
+import org.sdase.commons.client.jersey.builder.PlatformApiClientBuilder;
 import org.sdase.commons.client.jersey.builder.PlatformClientBuilder;
 
 /**
@@ -49,6 +51,21 @@ public class ClientFactory {
   }
 
   /**
+   * Starts creation of a client that calls APIs within the SDA SE Platform. This clients
+   * automatically send a {@code Trace-Token} from the incoming request or a new {@code Trace-Token}
+   * to the API resources and can optionally send a {@code Consumer-Token} or pass through the
+   * {@code Authorization} header from the incoming request.
+   *
+   * @param apiHttpClientConfiguration Allows to pass additional configuration for the http client.
+   * @return a builder to configure the client
+   */
+  public PlatformApiClientBuilder platformClient(
+      ApiHttpClientConfiguration apiHttpClientConfiguration) {
+    return new PlatformApiClientBuilder(
+        environment, apiHttpClientConfiguration, tracer, consumerToken);
+  }
+
+  /**
    * Starts creation of a client that calls APIs outside of the SDA SE Platform. This clients does
    * no header magic.
    *
@@ -69,5 +86,17 @@ public class ClientFactory {
    */
   public ExternalClientBuilder externalClient(HttpClientConfiguration httpClientConfiguration) {
     return new ExternalClientBuilder(environment, httpClientConfiguration, tracer);
+  }
+
+  /**
+   * Starts creation of a client that calls APIs outside of the SDA SE Platform. This clients does
+   * no header magic.
+   *
+   * @param apiHttpClientConfiguration Allows to pass additional configuration for the http client.
+   * @return a builder to configure the client
+   */
+  public ExternalApiClientBuilder externalClient(
+      ApiHttpClientConfiguration apiHttpClientConfiguration) {
+    return new ExternalApiClientBuilder(environment, apiHttpClientConfiguration, tracer);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractApiClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractApiClientBuilder.java
@@ -1,0 +1,86 @@
+package org.sdase.commons.client.jersey.builder;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.client.ClientRequestFilter;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+
+public class AbstractApiClientBuilder<T extends AbstractApiClientBuilder<T>> {
+
+  /**
+   * As default, the client will follow redirects so that redirect status codes are automatically
+   * resolved by the client.
+   */
+  private static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
+
+  private ApiHttpClientConfiguration apiHttpClientConfiguration;
+  private InternalJerseyClientFactory internalJerseyClientFactory;
+  private List<ClientRequestFilter> filters;
+  private boolean followRedirects;
+
+  AbstractApiClientBuilder(
+      Environment environment,
+      ApiHttpClientConfiguration apiHttpClientConfiguration,
+      Tracer tracer) {
+    this.apiHttpClientConfiguration = apiHttpClientConfiguration;
+    this.internalJerseyClientFactory =
+        new InternalJerseyClientFactory(new JerseyClientBuilder(environment), tracer);
+    this.filters = new ArrayList<>();
+    this.followRedirects = DEFAULT_FOLLOW_REDIRECTS;
+  }
+
+  /**
+   * Adds a request filter to the client.
+   *
+   * @param clientRequestFilter the filter to add
+   * @return this builder instance
+   */
+  public T addFilter(ClientRequestFilter clientRequestFilter) {
+    this.filters.add(clientRequestFilter);
+    //noinspection unchecked
+    return (T) this;
+  }
+
+  /**
+   * Set this client to not follow redirects and therewith automatically resolve 3xx status codes
+   *
+   * @return this builder instance
+   */
+  public T disableFollowRedirects() {
+    this.followRedirects = false;
+    //noinspection unchecked
+    return (T) this;
+  }
+
+  /**
+   * Creates a client proxy implementation for accessing another service.
+   *
+   * @param apiInterface the interface that declares the API using JAX-RS annotations.
+   * @param <A> the type of the api
+   * @return the client proxy implementing the client interface
+   */
+  public <A> A api(Class<A> apiInterface) {
+    return api(apiInterface, apiInterface.getSimpleName());
+  }
+
+  /**
+   * Creates a client proxy implementation for accessing another service. Allows to set a custom
+   * name if required, e.g. if you have multiple clients generated from the same interface.
+   *
+   * @param apiInterface the interface that declares the API using JAX-RS annotations.
+   * @param customName the custom name to use for the client. The name is used for the executor
+   *     service and metrics. Names have to be unique.
+   * @param <A> the type of the api
+   * @return the client proxy implementing the client interface
+   */
+  public <A> A api(Class<A> apiInterface, String customName) {
+    return new ApiClientBuilder<>(
+            apiInterface,
+            internalJerseyClientFactory.createClient(
+                customName, apiHttpClientConfiguration, filters, followRedirects))
+        .atTarget(apiHttpClientConfiguration.getApiBaseUrl());
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientRequestFilter;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
 import org.sdase.commons.client.jersey.HttpClientConfiguration;
 
 /**
@@ -134,7 +135,14 @@ abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>>
    * @param apiInterface the interface that declares the API using JAX-RS annotations.
    * @param <A> the type of the api
    * @return a builder to define the root path of the API for the proxy that is build
+   * @deprecated if API clients from interfaces are used, it is now preferred to move to the
+   *     {@linkplain org.sdase.commons.client.jersey.ApiHttpClientConfiguration dedicated config}
+   *     and start building the client with {@link
+   *     org.sdase.commons.client.jersey.ClientFactory#externalClient(ApiHttpClientConfiguration)}
+   *     or {@link
+   *     org.sdase.commons.client.jersey.ClientFactory#platformClient(ApiHttpClientConfiguration)}
    */
+  @Deprecated
   public <A> ApiClientBuilder<A> api(Class<A> apiInterface) {
     return api(apiInterface, apiInterface.getSimpleName());
   }
@@ -148,7 +156,14 @@ abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>>
    *     service and metrics. Names have to be unique.
    * @param <A> the type of the api
    * @return a builder to define the root path of the API for the proxy that is build
+   * @deprecated if API clients from interfaces are used, it is now preferred to move to the
+   *     {@linkplain org.sdase.commons.client.jersey.ApiHttpClientConfiguration dedicated config}
+   *     and start building the client with {@link
+   *     org.sdase.commons.client.jersey.ClientFactory#externalClient(ApiHttpClientConfiguration)}
+   *     or {@link
+   *     org.sdase.commons.client.jersey.ClientFactory#platformClient(ApiHttpClientConfiguration)}
    */
+  @Deprecated
   public <A> ApiClientBuilder<A> api(Class<A> apiInterface, String customName) {
     return new ApiClientBuilder<>(apiInterface, buildGenericClient(customName));
   }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> the type of the subclass
  */
-abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder> {
+abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractBaseClientBuilder.class);
   /**

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ExternalApiClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ExternalApiClientBuilder.java
@@ -1,0 +1,15 @@
+package org.sdase.commons.client.jersey.builder;
+
+import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+
+public class ExternalApiClientBuilder extends AbstractApiClientBuilder<ExternalApiClientBuilder> {
+
+  public ExternalApiClientBuilder(
+      Environment environment,
+      ApiHttpClientConfiguration apiHttpClientConfiguration,
+      Tracer tracer) {
+    super(environment, apiHttpClientConfiguration, tracer);
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/InternalJerseyClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/InternalJerseyClientFactory.java
@@ -1,0 +1,62 @@
+package org.sdase.commons.client.jersey.builder;
+
+import static org.sdase.commons.server.opentracing.client.ClientTracingUtil.registerTracing;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.opentracing.Tracer;
+import java.net.ProxySelector;
+import java.util.List;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientRequestFilter;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.glassfish.jersey.client.ClientProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class InternalJerseyClientFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InternalJerseyClientFactory.class);
+
+  private JerseyClientBuilder jerseyClientBuilder;
+  private Tracer tracer;
+
+  InternalJerseyClientFactory(JerseyClientBuilder jerseyClientBuilder, Tracer tracer) {
+    this.jerseyClientBuilder = jerseyClientBuilder;
+    this.tracer = tracer;
+  }
+
+  Client createClient(
+      String name,
+      JerseyClientConfiguration clientConfiguration,
+      List<ClientRequestFilter> filters,
+      boolean followRedirects) {
+    // a specific proxy configuration always overrides the system proxy
+    if (clientConfiguration.getProxyConfiguration() == null) {
+      // register a route planner that uses the default proxy variables (e.g. http.proxyHost)
+      this.jerseyClientBuilder.using(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
+    }
+    Client client = jerseyClientBuilder.using(clientConfiguration).build(name);
+    filters.forEach(client::register);
+    client.property(ClientProperties.FOLLOW_REDIRECTS, followRedirects);
+    registerMultiPartIfAvailable(client);
+    registerTracing(client, tracer);
+    return client;
+  }
+
+  private void registerMultiPartIfAvailable(Client client) {
+    try {
+      ClassLoader classLoader = this.getClass().getClassLoader();
+      Class<?> multiPartFeature =
+          classLoader.loadClass("org.glassfish.jersey.media.multipart.MultiPartFeature");
+      if (multiPartFeature != null) {
+        LOG.info("Registering MultiPartFeature for client.");
+        client.register(multiPartFeature);
+      }
+    } catch (ClassNotFoundException e) {
+      LOG.info("Not registering MultiPartFeature for client: Class is not available.");
+    } catch (Exception e) {
+      LOG.warn("Failed to register MultiPartFeature for client.");
+    }
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformApiClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformApiClientBuilder.java
@@ -1,0 +1,59 @@
+package org.sdase.commons.client.jersey.builder;
+
+import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+import org.sdase.commons.client.jersey.filter.AddRequestHeaderFilter;
+import org.sdase.commons.client.jersey.filter.AuthHeaderClientFilter;
+import org.sdase.commons.client.jersey.filter.TraceTokenClientFilter;
+import org.sdase.commons.shared.tracing.ConsumerTracing;
+
+public class PlatformApiClientBuilder extends AbstractApiClientBuilder<PlatformApiClientBuilder> {
+
+  private Supplier<Optional<String>> consumerTokenSupplier;
+
+  public PlatformApiClientBuilder(
+      Environment environment,
+      ApiHttpClientConfiguration apiHttpClientConfiguration,
+      Tracer tracer,
+      String consumerToken) {
+    super(environment, apiHttpClientConfiguration, tracer);
+    this.consumerTokenSupplier = () -> Optional.ofNullable(StringUtils.trimToNull(consumerToken));
+    addFilter(new TraceTokenClientFilter());
+  }
+
+  /**
+   * If authentication pass through is enabled, the JWT in the {@value
+   * javax.ws.rs.core.HttpHeaders#AUTHORIZATION} header of an incoming request will be added to the
+   * outgoing request.
+   *
+   * @return this builder instance
+   */
+  public PlatformApiClientBuilder enableAuthenticationPassThrough() {
+    return addFilter(new AuthHeaderClientFilter());
+  }
+
+  /**
+   * If consumer token is enabled, the client will create a configured consumer token and add it as
+   * header to the outgoing request.
+   *
+   * @return this builder instance
+   */
+  public PlatformApiClientBuilder enableConsumerToken() {
+    return addFilter(
+        new AddRequestHeaderFilter() {
+          @Override
+          public String getHeaderName() {
+            return ConsumerTracing.TOKEN_HEADER;
+          }
+
+          @Override
+          public Optional<String> getHeaderValue() {
+            return consumerTokenSupplier.get();
+          }
+        });
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
@@ -37,7 +37,7 @@ public class ApiClientConfigurationTest {
       new DropwizardAppRule<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),
-          config("mockBaseUrl", WIRE::baseUrl));
+          config("mockClient.apiBaseUrl", WIRE::baseUrl));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(WIRE).around(DW);
 

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ConfiguredApiClientTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ConfiguredApiClientTest.java
@@ -1,0 +1,650 @@
+package org.sdase.commons.client.jersey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.seeOther;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_SEE_OTHER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.sdase.commons.client.jersey.error.ClientErrorUtil.convertExceptions;
+import static org.sdase.commons.client.jersey.test.util.ClientRequestExceptionConditions.processingError;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.jetty9.JettyHttpServerFactory;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.assertj.core.util.Lists;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.client.jersey.error.ClientErrorUtil;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.client.jersey.test.MockApiClient;
+import org.sdase.commons.client.jersey.test.MockApiClient.Car;
+import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.shared.api.error.ApiException;
+
+public class ConfiguredApiClientTest {
+
+  @ClassRule
+  public static final WireMockClassRule WIRE =
+      new WireMockClassRule(
+          wireMockConfig().dynamicPort().httpServerFactory(new JettyHttpServerFactory()));
+
+  public static final Car LIGHT_BLUE_CAR =
+      new Car().setSign("HH XY 4321").setColor("light blue"); // NOSONAR
+  private static final ObjectMapper OM = new ObjectMapper();
+  private static final Car BRIGHT_BLUE_CAR =
+      new Car().setSign("HH XX 1234").setColor("bright blue"); // NOSONAR
+  private final DropwizardAppRule<ClientTestConfig> dw =
+      new DropwizardAppRule<>(ClientTestApp.class, resourceFilePath("test-config.yaml"));
+
+  @Rule
+  public final RuleChain rule =
+      RuleChain.outerRule(new EnvironmentRule().setEnv("MOCK_BASE_URL", WIRE.baseUrl())).around(dw);
+
+  private ClientTestApp app;
+
+  @Before
+  public void before() throws JsonProcessingException {
+    WIRE.resetAll();
+    app = dw.getApplication();
+
+    WIRE.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", equalTo("application/json")) // NOSONAR
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json") // NOSONAR
+                    .withBody(OM.writeValueAsBytes(asList(BRIGHT_BLUE_CAR, LIGHT_BLUE_CAR)))));
+    WIRE.stubFor(
+        post("/api/multi-part") // NOSONAR
+            .withHeader("Content-type", matching("multipart/form-data.*")) // NOSONAR
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json") // NOSONAR
+                    .withBody(OM.writeValueAsBytes(singletonMap("got", "it")))));
+    WIRE.stubFor(
+        post("/api/cars") // NOSONAR
+            .withHeader("Content-type", equalTo("application/json")) // NOSONAR
+            .withRequestBody(equalToJson("{\"sign\":\"HH AB 1234\", \"color\":\"white\"}"))
+            .willReturn(
+                aResponse().withStatus(201).withHeader("Location", "/api/cars/dummyId") // NOSONAR
+                ));
+    WIRE.stubFor(
+        get(urlMatching("/api/cars/HH%20XX%201234(\\?.*)?"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json")
+                    .withBody(OM.writeValueAsBytes(BRIGHT_BLUE_CAR))));
+    WIRE.stubFor(
+        get(urlMatching("/api/cars/HH%20XY%204321(\\?.*)?"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json")
+                    .withBody(OM.writeValueAsBytes(LIGHT_BLUE_CAR))));
+  }
+
+  @Test
+  public void sendMultipart() throws IOException {
+    try (FormDataMultiPart multiPart =
+        new FormDataMultiPart()
+            .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
+            .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
+      Response response =
+          app.getJerseyClientBundle()
+              .getClientFactory()
+              .platformClient()
+              .buildGenericClient("multi-part")
+              .target(WIRE.baseUrl())
+              .path("api")
+              .path("multi-part")
+              .register(MultiPartFeature.class)
+              .request(MediaType.APPLICATION_JSON)
+              .post(Entity.entity(multiPart, multiPart.getMediaType()));
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+
+      String contentType =
+          WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
+      String boundary = MediaType.valueOf(contentType).getParameters().get("boundary");
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/multi-part"))
+              .withHeader("Content-type", matching("multipart/form-data;boundary=.+"))
+              .withRequestBody(
+                  equalTo(
+                      "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + // NOSONAR
+                          "Content-Disposition: form-data; name=\"test\"\r\n"
+                          + "\r\n"
+                          + "test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"anotherTest\"\r\n"
+                          + "\r\n"
+                          + "another-test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "--\r\n")));
+    }
+  }
+
+  @Test
+  public void sendMultipartWithApiClient() throws IOException {
+    try (FormDataMultiPart multiPart =
+        new FormDataMultiPart()
+            .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
+            .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
+      Response response = createMockApiClient().sendMultiPart(multiPart);
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+
+      String contentType =
+          WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
+      String boundary = MediaType.valueOf(contentType).getParameters().get("boundary");
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/multi-part"))
+              .withHeader("Content-type", matching("multipart/form-data;boundary=.+"))
+              .withRequestBody(
+                  equalTo(
+                      "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"test\"\r\n"
+                          + "\r\n"
+                          + "test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"anotherTest\"\r\n"
+                          + "\r\n"
+                          + "another-test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "--\r\n")));
+    }
+  }
+
+  @Test
+  public void loadCars() {
+    List<Car> cars = createMockApiClient().getCars();
+
+    assertThat(cars)
+        .extracting(Car::getSign, Car::getColor)
+        .containsExactly(tuple("HH XX 1234", "bright blue"), tuple("HH XY 4321", "light blue"));
+  }
+
+  @Test
+  public void loadCarsWithResponseDetails() {
+    Response response = createMockApiClient().requestCars();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", matchingUuid()) // NOSONAR
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void addConsumerToken() {
+    Response response = createMockApiClient().requestCars();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Consumer-Token", equalTo("test-consumer")) // NOSONAR
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void postNewCar() {
+    try (Response response =
+        createMockApiClient().createCar(new Car().setSign("HH AB 1234").setColor("white"))) {
+
+      assertThat(response.getStatus()).isEqualTo(201);
+      assertThat(response.getLocation()).isEqualTo(URI.create("/api/cars/dummyId"));
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/cars"))
+              .withHeader("Content-type", equalTo("application/json")) // NOSONAR
+          );
+    }
+  }
+
+  @Test
+  public void notAddConsumerTokenIfAlreadySet() {
+    try (Response response =
+        createMockApiClient().requestCarsWithCustomConsumerToken("my-custom-consumer")) {
+
+      assertThat(response.getStatus()).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Consumer-Token", equalTo("my-custom-consumer"))
+              .withHeader("Consumer-Token", notMatching("test-consumer"))
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
+  }
+
+  @Test
+  public void addReceivedTraceTokenToHeadersToPlatformCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("cars")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Trace-Token", "test-trace-token-1")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", equalTo("test-trace-token-1"))
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void addReceivedAuthHeaderToPlatformCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsAuth")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Authorization", "custom-dummy-token")
+            .header("Trace-Token", "test-trace-token-3")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", equalTo("test-trace-token-3"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("custom-dummy-token")));
+  }
+
+  @Test
+  public void notAddingReceivedTraceTokenToHeadersOfExternalCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsExternal")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Trace-Token", "test-trace-token-2")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withoutHeader("Trace-Token"));
+  }
+
+  @Test
+  public void notAddingReceivedAuthorizationToHeadersOfExternalCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsExternal")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header(HttpHeaders.AUTHORIZATION, "BEARER dummy")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void loadSingleCar() {
+    Car car = createMockApiClient().getCar("HH XY 4321");
+    assertThat(car)
+        .extracting(Car::getSign, Car::getColor)
+        .containsExactly("HH XY 4321", "light blue");
+  }
+
+  @Test
+  public void loadSingleCarWithFieldFilterAllFields() {
+    createMockApiClient().getCarWithFilteredFields("HH XY 4321", asList("sign", "color"));
+    verify(
+        RequestPatternBuilder.newRequestPattern(
+            GET, urlEqualTo("/api/cars/HH%20XY%204321?fields=sign&fields=color")));
+  }
+
+  @Test
+  public void loadSingleCarWithFieldFilterOneField() {
+    createMockApiClient().getCarWithFilteredFields("HH XY 4321", singletonList("color"));
+    verify(
+        RequestPatternBuilder.newRequestPattern(
+            GET, urlEqualTo("/api/cars/HH%20XY%204321?fields=color")));
+  }
+
+  @Test
+  public void loadLightBlueCarThroughDefaultMethod() {
+    try (Response response = createMockApiClient().getLightBlueCar()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.readEntity(Car.class))
+          .extracting(Car::getSign, Car::getColor)
+          .containsExactly("HH XY 4321", "light blue");
+    }
+  }
+
+  @Test
+  public void handle404ErrorInDefaultMethod() {
+    WIRE.stubFor(
+        get("/api/cars/UNKNOWN")
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{}")));
+    assertThat(createMockApiClient().getCarOrHandleError("UNKNOWN")).isNull();
+  }
+
+  @Test
+  public void handleClientErrorInDefaultMethod() {
+    WIRE.stubFor(
+        get("/api/cars/UNKNOWN")
+            .willReturn(
+                aResponse()
+                    .withStatus(500)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{}")));
+    MockApiClient mockApiClient = createMockApiClient();
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> mockApiClient.getCarOrHandleError("UNKNOWN"))
+        .withCauseInstanceOf(ClientRequestException.class);
+  }
+
+  @Test
+  public void failOnLoadingMissingCar() {
+    MockApiClient mockApiClient = createMockApiClient();
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(() -> mockApiClient.getCar("HH AA 4444"))
+        .withCauseInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  public void demonstrateToCloseException() {
+    WIRE.stubFor(
+        get("/api/cars/HH%20AA%204444")
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ 'message': 'car is unknown' }")));
+
+    try {
+      createMockApiClient().getCar("HH AA 4444");
+    } catch (ClientRequestException e) {
+      assertThat(e.getResponse().map(Response::getStatus)).isPresent().hasValue(404);
+      assertThat(e.getResponse().map(Response::hasEntity)).isPresent().hasValue(true);
+      e.close(); // important if exception is not rethrown
+    }
+  }
+
+  @Test
+  public void return404ForMissingCar() {
+    try (Response response = createMockApiClient().getCarResponse("HH AA 5555")) {
+      assertThat(response.getStatus()).isEqualTo(404);
+    }
+  }
+
+  @Test
+  public void return404ForMissingCarWithGenericClient() {
+    try (Response response =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .externalClient()
+            .buildGenericClient("foo")
+            .target(WIRE.baseUrl())
+            .path("api")
+            .path("cars")
+            .path("HH AA 7777")
+            .request(MediaType.APPLICATION_JSON)
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+    }
+  }
+
+  @Test
+  public void return500ForDelegatedMissingCar() {
+    try (Response response =
+        dwClient()
+            .path("api")
+            .path("cars")
+            .path("HH AA 7777")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(ClientErrorUtil.readErrorBody(response, new GenericType<Map<String, Object>>() {}))
+          .containsExactly(
+              entry(
+                  "title",
+                  "Request could not be fulfilled: Received status '404' from another service."),
+              entry("invalidParams", Lists.emptyList()));
+    }
+  }
+
+  @Test
+  public void addCustomFiltersToPlatformClient() {
+    MockApiClient mockApiClient =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .platformClient(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .addFilter(
+                requestContext -> requestContext.getHeaders().add("Hello", "World")) // NOSONAR
+            .addFilter(requestContext -> requestContext.getHeaders().add("Foo", "Bar"))
+            .api(MockApiClient.class);
+
+    mockApiClient.getCars();
+
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Hello", equalTo("World"))
+            .withHeader("Foo", equalTo("Bar")));
+  }
+
+  @Test
+  public void addCustomFiltersToExternalClient() {
+    MockApiClient mockApiClient =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .externalClient(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .addFilter(requestContext -> requestContext.getHeaders().add("Hello", "World"))
+            .addFilter(requestContext -> requestContext.getHeaders().add("Foo", "Bar"))
+            .api(MockApiClient.class);
+
+    mockApiClient.getCars();
+
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Hello", equalTo("World"))
+            .withHeader("Foo", equalTo("Bar")));
+  }
+
+  @Test
+  public void failOnReadJsonWithGenericClient() {
+
+    WIRE.stubFor(
+        get("/badJsonResponse")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"xyz\"")));
+
+    Client client =
+        app.getJerseyClientBundle().getClientFactory().externalClient().buildGenericClient("test");
+
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(
+            () ->
+                // receives invalid json
+                convertExceptions(
+                    () ->
+                        client
+                            .target(WIRE.baseUrl())
+                            .path("badJsonResponse")
+                            .request()
+                            .get(Car.class)))
+        .is(processingError());
+  }
+
+  @Test
+  public void failOnReadJsonWithApiClient() {
+
+    WIRE.stubFor(
+        get("/api/cars/123")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"xyz\"")));
+
+    MockApiClient client =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .externalClient(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .api(MockApiClient.class);
+
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(() -> client.getCar("123"))
+        .is(processingError());
+  }
+
+  @Test
+  public void seeOtherAfterPost() {
+    WIRE.stubFor(
+        post("/api/cars")
+            .withRequestBody(
+                equalToJson("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")) // NOSONAR
+            .willReturn(seeOther(WIRE.url("/api/cars/HH%20XY%201234")))); // NOSONAR
+    WIRE.stubFor(
+        get("/api/cars/HH%20XY%201234")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")));
+
+    // This test requires that gzip for request bodies is disabled, otherwise
+    // the automatic GET request after the see others fails as the
+    // content-encoding from the post request is also used for the GET
+    // request. However neither Dropwizard nor Wiremock does handle this well
+    // for GET requests.
+    MockApiClient client = createMockApiClient();
+
+    try (Response r =
+        client.createCar(new Car().setSign("HH XY 1234").setColor("yellow"))) { // NOSONAR
+      assertThat(r.getStatus()).isEqualTo(SC_OK);
+      Car car = r.readEntity(Car.class);
+      assertThat(car)
+          .extracting(Car::getSign, Car::getColor)
+          .containsExactly("HH XY 1234", "yellow");
+    }
+  }
+
+  @Test
+  public void disableRedirectsForSeeOther() {
+    WIRE.stubFor(
+        post("/api/cars")
+            .withRequestBody(equalToJson("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }"))
+            .willReturn(seeOther(WIRE.url("/api/cars/HH%20XY%201234"))));
+    WIRE.stubFor(
+        get("/api/cars/HH%20XY%201234")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")));
+
+    MockApiClient client = createMockApiClientWithoutFollowRedirects();
+
+    try (Response r = client.createCar(new Car().setSign("HH XY 1234").setColor("yellow"))) {
+      assertThat(r.getStatus()).isEqualTo(SC_SEE_OTHER);
+      assertThat(r.getHeaderString(HttpHeaders.LOCATION))
+          .isEqualTo(WIRE.url("/api/cars/HH%20XY%201234"));
+      WIRE.verify(
+          0, RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars/HH%20XY%201234")));
+    }
+  }
+
+  private MockApiClient createMockApiClientWithoutFollowRedirects() {
+    return app.getJerseyClientBundle()
+        .getClientFactory()
+        .platformClient(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+        .disableFollowRedirects()
+        .enableConsumerToken()
+        .api(MockApiClient.class);
+  }
+
+  private MockApiClient createMockApiClient() {
+    return app.getJerseyClientBundle()
+        .getClientFactory()
+        .platformClient(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+        .enableConsumerToken()
+        .api(MockApiClient.class);
+  }
+
+  private WebTarget dwClient() {
+    return dw.client().target("http://localhost:" + dw.getLocalPort());
+  }
+
+  private StringValuePattern matchingUuid() {
+    return matching(
+        "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}");
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestApp.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestApp.java
@@ -39,7 +39,7 @@ public class ClientTestApp extends Application<ClientTestConfig> {
         .jersey()
         .register(
             new ClientTestEndPoint(
-                jerseyClientBundle.getClientFactory(), configuration.getMockBaseUrl()));
+                jerseyClientBundle.getClientFactory(), configuration.getMockClient()));
   }
 
   public JerseyClientBundle<ClientTestConfig> getJerseyClientBundle() {

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestConfig.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestConfig.java
@@ -1,6 +1,7 @@
 package org.sdase.commons.client.jersey.test;
 
 import io.dropwizard.Configuration;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
 import org.sdase.commons.client.jersey.HttpClientConfiguration;
 
 @SuppressWarnings("WeakerAccess")
@@ -8,9 +9,9 @@ public class ClientTestConfig extends Configuration {
 
   private String consumerToken;
 
-  private String mockBaseUrl;
-
   private HttpClientConfiguration client = new HttpClientConfiguration();
+
+  private ApiHttpClientConfiguration mockClient;
 
   public String getConsumerToken() {
     return consumerToken;
@@ -21,21 +22,21 @@ public class ClientTestConfig extends Configuration {
     return this;
   }
 
-  public String getMockBaseUrl() {
-    return mockBaseUrl;
-  }
-
-  public ClientTestConfig setMockBaseUrl(String mockBaseUrl) {
-    this.mockBaseUrl = mockBaseUrl;
-    return this;
-  }
-
   public HttpClientConfiguration getClient() {
     return client;
   }
 
   public ClientTestConfig setClient(HttpClientConfiguration client) {
     this.client = client;
+    return this;
+  }
+
+  public ApiHttpClientConfiguration getMockClient() {
+    return mockClient;
+  }
+
+  public ClientTestConfig setMockClient(ApiHttpClientConfiguration mockClient) {
+    this.mockClient = mockClient;
     return this;
   }
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestEndPoint.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTestEndPoint.java
@@ -6,6 +6,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
 import org.sdase.commons.client.jersey.ClientFactory;
 import org.sdase.commons.client.jersey.test.MockApiClient.Car;
 
@@ -15,23 +16,21 @@ public class ClientTestEndPoint {
   private MockApiClient externalMockApiClient;
   private MockApiClient authMockApiClient;
 
-  ClientTestEndPoint(ClientFactory clientFactory, String baseUrl) {
+  ClientTestEndPoint(
+      ClientFactory clientFactory, ApiHttpClientConfiguration apiHttpClientConfiguration) {
     mockApiClient =
         clientFactory
-            .platformClient()
-            .api(MockApiClient.class, "MockApiClientWithoutAuth")
-            .atTarget(baseUrl);
+            .platformClient(apiHttpClientConfiguration)
+            .api(MockApiClient.class, "MockApiClientWithoutAuth");
     authMockApiClient =
         clientFactory
-            .platformClient()
+            .platformClient(apiHttpClientConfiguration)
             .enableAuthenticationPassThrough()
-            .api(MockApiClient.class, "MockApiClientWithAuth")
-            .atTarget(baseUrl);
+            .api(MockApiClient.class, "MockApiClientWithAuth");
     externalMockApiClient =
         clientFactory
-            .externalClient()
-            .api(MockApiClient.class, "MockApiClientExternal")
-            .atTarget(baseUrl);
+            .externalClient(apiHttpClientConfiguration)
+            .api(MockApiClient.class, "MockApiClientExternal");
   }
 
   @GET

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientWithoutConsumerTokenTestApp.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientWithoutConsumerTokenTestApp.java
@@ -33,7 +33,7 @@ public class ClientWithoutConsumerTokenTestApp extends Application<ClientTestCon
         .jersey()
         .register(
             new ClientTestEndPoint(
-                jerseyClientBundle.getClientFactory(), configuration.getMockBaseUrl()));
+                jerseyClientBundle.getClientFactory(), configuration.getMockClient()));
   }
 
   public JerseyClientBundle getJerseyClientBundle() {

--- a/sda-commons-client-jersey/src/test/resources/test-config.yaml
+++ b/sda-commons-client-jersey/src/test/resources/test-config.yaml
@@ -6,5 +6,9 @@ server:
   - type: http
     port: 0
 
-mockBaseUrl: ${MOCK_BASE_URL}
 consumerToken: test-consumer
+
+mockClient:
+  apiBaseUrl: ${MOCK_BASE_URL}
+  timeout: ${MOCK_READ_TIMEOUT:-2000ms}
+  connectionTimeout: ${MOCK_CONNECT_TIMEOUT:-500ms}


### PR DESCRIPTION
In many service we had to extend the HttpClientConfiguration to add a base url of the API which is required for API clients based on interfaces.
This commit provides a built in approach to simplify configuration and creation of API clients.
The downside is that there are some classes partially duplicated due to the builder pattern.
But that gives the opportunity to get rid of the deprecated timeout settings of the previous fluent configuration.