### PR TITLE
fix(deps): align json-unit-core in all dependencies

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -14,7 +14,7 @@ ext {
   swaggerCoreV3Version = '2.1.5'
   weldVersion = '3.1.5.Final'
   openTracingUtilVersion = '0.33.0'
-  jsonUnitVersion = '2.19.0'
+  jsonUnitVersion = '2.21.0'
   scalaVersion = '2.12.8' // Always prefer the version from kafka_2.12. Make sure that the major version is always aligned with kafka, s3mock, and mbknor-jackson-jsonschema.
   kafkaVersion = '2.2.1' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
 }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -14,6 +14,7 @@ ext {
   swaggerCoreV3Version = '2.1.5'
   weldVersion = '3.1.5.Final'
   openTracingUtilVersion = '0.33.0'
+  jsonUnitVersion = '2.19.0'
   scalaVersion = '2.12.8' // Always prefer the version from kafka_2.12. Make sure that the major version is always aligned with kafka, s3mock, and mbknor-jackson-jsonschema.
   kafkaVersion = '2.2.1' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
 }
@@ -41,6 +42,9 @@ dependencies {
     }
     api "org.yaml:snakeyaml:1.26", {
       because "conflict between com.github.ftrossbach:club-topicana-core and com.github.database-rider:rider-core and com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+    }
+    api "net.javacrumbs.json-unit:json-unit-core:$jsonUnitVersion", {
+      because "conflict between com.github.tomakehurst:wiremock-jre8 and net.javacrumbs.json-unit:json-unit-assertj"
     }
 
     // overall testing dependencies
@@ -114,7 +118,7 @@ dependencies {
 
     // sda-commons-server-swagger
     api "com.github.java-json-tools:json-schema-validator:2.2.10"
-    api "net.javacrumbs.json-unit:json-unit-assertj:2.19.0"
+    api "net.javacrumbs.json-unit:json-unit-assertj:$jsonUnitVersion"
 
     // sda-commons-server-testing
     api "org.hamcrest:hamcrest:2.2", {


### PR DESCRIPTION
We get dependency conflicts when an application uses both wiremock and json-unit-assertj in the same classpath. We currently don't get a conflict in sda-dropwizard-commons since json-unit-assertj is only included as a test dependency.

I'm not sure if this is a smart decision. Feel free to comment 😄 