### PR TITLE
Add dedicated config class for api clients and new entrypoint in the ClientFactory

### DIFF
--- a/sda-commons-client-jersey/README.md
+++ b/sda-commons-client-jersey/README.md
@@ -63,10 +63,13 @@ Clients for the SDA Platform have some magic added that clients for an external 
   SDA Platform clients can be configured to pass through the Authorization header of an incoming request context:
   
   ```java
-  clientFactory.platformClient()
+  // using ApiHttpClientConfiguration property from service config
+  clientFactory
+        .apiClient(OtherSdaServiceClient.class)
+        .withConfiguration(configuration.getOtherSdaServiceClient())
+        .enablePlatformFeatures() 
         .enableAuthenticationPassThrough()
-        .api(OtherSdaServiceClient.class)
-        .atTarget("http://other-sda-service.sda.net/api");
+        .build();
   ```
 - _Consumer-Token_
   
@@ -81,10 +84,13 @@ Clients for the SDA Platform have some magic added that clients for an external 
   Then the clients can be configured to add a Consumer-Token header:
   
   ```java
-  clientFactory.platformClient()
+  // using ApiHttpClientConfiguration property from service config
+  clientFactory
+        .apiClient(OtherSdaServiceClient.class)
+        .withConfiguration(configuration.getOtherSdaServiceClient())
+        .enablePlatformFeatures() 
         .enableConsumerToken()
-        .api(OtherSdaServiceClient.class)
-        .atTarget("http://other-sda-service.sda.net/api");
+        .build();
   ```
 
 
@@ -175,27 +181,32 @@ Each client can be configured with the standard
 Please note that this requires that there is a property in your Application's `Configuration` class. 
 
 ```java
-import org.sdase.commons.client.jersey.HttpClientConfiguration;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
 
 public class MyConfiguration extends Configuration {
-   private HttpClientConfiguration myClient = new HttpClientConfiguration();
+   private ApiHttpClientConfiguration myClient = new APiHttpClientConfiguration();
 
-   public HttpClientConfiguration getMyClient() {
+   public ApiHttpClientConfiguration getMyClient() {
      return myClient;
    }
 
-   public void setMyClient(HttpClientConfiguration myClient) {
+   public void setMyClient(ApiHttpClientConfiguration myClient) {
      this.myClient = myClient;
    }
 }
 ```
 
 ```java
-Client client = clientFactory.platformClient(configuration.getMyClient()).buildGenericClient("test");
+MyClientInterface client = clientFactory
+    .apiClient(MyClientInterface.class)
+    .withConfiguration(myConfiguration.getMyClient())
+    .enablePlatformFeatures()
+    .build;
 ```
 
 ```yaml
 myClient:
+  apiBaseUrl: http://my-service:8080
   timeout: 500ms
   proxy:
     host: 192.168.52.11

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ApiHttpClientConfiguration.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ApiHttpClientConfiguration.java
@@ -1,0 +1,23 @@
+package org.sdase.commons.client.jersey;
+
+/**
+ * A configuration class to be used for API clients that are created as Proxy from annotated
+ * interfaces.
+ */
+public class ApiHttpClientConfiguration extends HttpClientConfiguration {
+  private String apiBaseUrl;
+
+  /** @return the base URL of the implemented API, e.g. {@code http://the-service:8080/api} */
+  public String getApiBaseUrl() {
+    return apiBaseUrl;
+  }
+
+  /**
+   * @param apiBaseUrl the base URL of the implemented API, e.g. {@code http://the-service:8080/api}
+   * @return this instance for fluent configuration
+   */
+  public ApiHttpClientConfiguration setApiBaseUrl(String apiBaseUrl) {
+    this.apiBaseUrl = apiBaseUrl;
+    return this;
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/ClientFactory.java
@@ -3,13 +3,15 @@ package org.sdase.commons.client.jersey;
 import io.dropwizard.setup.Environment;
 import io.opentracing.Tracer;
 import org.sdase.commons.client.jersey.builder.ExternalClientBuilder;
+import org.sdase.commons.client.jersey.builder.FluentApiClientBuilder;
+import org.sdase.commons.client.jersey.builder.FluentApiClientFactory;
 import org.sdase.commons.client.jersey.builder.PlatformClientBuilder;
 
 /**
  * A {@code ClientFactory} creates Http clients to access services within the SDA Platform or
  * external services.
  */
-public class ClientFactory {
+public class ClientFactory implements FluentApiClientBuilder {
 
   private final Environment environment;
   private final String consumerToken;
@@ -69,5 +71,10 @@ public class ClientFactory {
    */
   public ExternalClientBuilder externalClient(HttpClientConfiguration httpClientConfiguration) {
     return new ExternalClientBuilder(environment, httpClientConfiguration, tracer);
+  }
+
+  @Override
+  public <A> ApiClientInstanceConfigurationBuilder<A> apiClient(Class<A> apiInterface) {
+    return new FluentApiClientFactory<>(apiInterface, environment, consumerToken, tracer);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientRequestFilter;
+import org.glassfish.jersey.client.ClientProperties;
 import org.sdase.commons.client.jersey.HttpClientConfiguration;
 
 /**
@@ -20,7 +21,11 @@ abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>>
 
   /**
    * As default, the client will follow redirects so that redirect status codes are automatically
-   * resolved by the client.
+   * resolved by the client. Automatically following redirects only works well for 303 See Other
+   * although the {@linkplain ClientProperties#FOLLOW_REDIRECTS documentation} describes 3xx
+   * redirects. It is required to keep {@linkplain
+   * HttpClientConfiguration#setGzipEnabledForRequests(boolean) GZIP disabled for requests} which is
+   * the default of the {@link HttpClientConfiguration}.
    */
   private static final boolean DEFAULT_FOLLOW_REDIRECTS = true;
 

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
@@ -139,7 +139,16 @@ abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>>
    * @param apiInterface the interface that declares the API using JAX-RS annotations.
    * @param <A> the type of the api
    * @return a builder to define the root path of the API for the proxy that is build
+   * @deprecated a {@linkplain org.sdase.commons.client.jersey.ClientFactory#apiClient(Class) new
+   *     API} with a dedicated {@linkplain
+   *     org.sdase.commons.client.jersey.ApiHttpClientConfiguration configuration class} is
+   *     available to configure API clients based on interfaces. The new {@link
+   *     FluentApiClientBuilder} API provides the same features as this builder but uses all
+   *     configurable options in a the dedicated {@link
+   *     org.sdase.commons.client.jersey.ApiHttpClientConfiguration} and therefore enforces to have
+   *     all configuration options (like proxy settings) available for operators who need them.
    */
+  @Deprecated
   public <A> ApiClientBuilder<A> api(Class<A> apiInterface) {
     return api(apiInterface, apiInterface.getSimpleName());
   }
@@ -153,7 +162,16 @@ abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>>
    *     service and metrics. Names have to be unique.
    * @param <A> the type of the api
    * @return a builder to define the root path of the API for the proxy that is build
+   * @deprecated a {@linkplain org.sdase.commons.client.jersey.ClientFactory#apiClient(Class) new
+   *     API} with a dedicated {@linkplain
+   *     org.sdase.commons.client.jersey.ApiHttpClientConfiguration configuration class} is
+   *     available to configure API clients based on interfaces. The new {@link
+   *     FluentApiClientBuilder} API provides the same features as this builder but uses all
+   *     configurable options in a the dedicated {@link
+   *     org.sdase.commons.client.jersey.ApiHttpClientConfiguration} and therefore enforces to have
+   *     all configuration options (like proxy settings) available for operators who need them.
    */
+  @Deprecated
   public <A> ApiClientBuilder<A> api(Class<A> apiInterface, String customName) {
     return new ApiClientBuilder<>(apiInterface, buildGenericClient(customName));
   }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/AbstractBaseClientBuilder.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param <T> the type of the subclass
  */
-abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder> {
+abstract class AbstractBaseClientBuilder<T extends AbstractBaseClientBuilder<T>> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractBaseClientBuilder.class);
   /**

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ApiClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/ApiClientBuilder.java
@@ -9,7 +9,15 @@ import org.glassfish.jersey.client.proxy.WebResourceFactory;
  * Builder to create clients from JAX-RS annotated interfaces.
  *
  * @param <A> the client interface
+ * @deprecated a {@linkplain org.sdase.commons.client.jersey.ClientFactory#apiClient(Class) new API}
+ *     with a dedicated {@linkplain org.sdase.commons.client.jersey.ApiHttpClientConfiguration
+ *     configuration class} is available to configure API clients based on interfaces. The new
+ *     {@link FluentApiClientBuilder} API provides the same features as this builder but uses all
+ *     configurable options in a the dedicated {@link
+ *     org.sdase.commons.client.jersey.ApiHttpClientConfiguration} and therefore enforces to have
+ *     all configuration options (like proxy settings) available for operators who need them.
  */
+@Deprecated
 public class ApiClientBuilder<A> {
 
   private Class<A> apiClass;

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/FluentApiClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/FluentApiClientBuilder.java
@@ -1,0 +1,142 @@
+package org.sdase.commons.client.jersey.builder;
+
+import javax.ws.rs.client.ClientRequestFilter;
+import org.glassfish.jersey.client.ClientProperties;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+
+/**
+ * Entrypoint to the creation of API clients based on annotated interfaces.
+ *
+ * <p>This interfaces and it's inner interfaces describe the fluent API to create clients.
+ *
+ * <p>As default, the client will follow redirects so that redirect status codes are automatically
+ * resolved by the client. Automatically following redirects only works well for 303 See Other
+ * although the {@linkplain ClientProperties#FOLLOW_REDIRECTS documentation} describes 3xx
+ * redirects. It is required to keep {@linkplain
+ * io.dropwizard.client.JerseyClientConfiguration#setGzipEnabledForRequests(boolean) GZIP disabled
+ * for requests} which is the default of the {@link ApiHttpClientConfiguration}.
+ *
+ * <p>Example usages:
+ *
+ * <pre>
+ *   <code>
+ *
+ *     // backward compatible
+ *     clientBuilder.platformClient(). // … as before
+ *     clientBuilder.externalClient(). // … as before
+ *
+ *     // NEW direct access to api clients for platform use
+ *     clientBuilder.apiClient(PlatformServiceApi.class)
+ *         .withConfiguration(new ApiHttpClientConfiguration())
+ *         .disableFollowRedirects() // optional
+ *         .addFilter(myClientRequestFilter) // optional
+ *         .withPlatformFeatures()
+ *         .enableAuthenticationPassThrough() // optional
+ *         .enableConsumerToken() // optional
+ *         .build(); // or .build("my-custom-client-name")
+ *
+ *     // NEW direct access to api clients for external use
+ *     clientBuilder.apiClient(PlatformServiceApi.class)
+ *         .withConfiguration(new ApiHttpClientConfiguration())
+ *         .disableFollowRedirects() // optional
+ *         .addFilter(myClientRequestFilter) // optional
+ *         .build(); // or .build("my-custom-client-name")
+ *   </code>
+ * </pre>
+ */
+public interface FluentApiClientBuilder {
+
+  /**
+   * Starts creation of a client based on an annotated interface.
+   *
+   * @param apiInterface the annotated interface that describes the API
+   * @param <A> the type of the client interface
+   * @return a builder to configure the API client
+   */
+  <A> ApiClientInstanceConfigurationBuilder<A> apiClient(Class<A> apiInterface);
+
+  interface ApiClientInstanceConfigurationBuilder<A> {
+
+    /**
+     * Configures the client.
+     *
+     * @param apiHttpClientConfiguration the configuration of the client, usually referenced in the
+     *     app configuration
+     * @return a builder for implementation specific configuration
+     */
+    ApiClientCommonConfigurationBuilder<A> withConfiguration(
+        ApiHttpClientConfiguration apiHttpClientConfiguration);
+  }
+
+  interface ApiClientCommonConfigurationBuilder<A> extends ApiClientFinalBuilder<A> {
+
+    /**
+     * Adds a request filter to the client.
+     *
+     * @param clientRequestFilter the filter to add
+     * @return this builder instance
+     */
+    ApiClientCommonConfigurationBuilder<A> addFilter(ClientRequestFilter clientRequestFilter);
+
+    /**
+     * Set this client to not follow redirects and therewith automatically resolve 3xx status codes.
+     *
+     * @return this builder instance
+     */
+    ApiClientCommonConfigurationBuilder<A> disableFollowRedirects();
+
+    /**
+     * The created client is used to call APIs within the SDA SE Platform. This client automatically
+     * send a {@code Trace-Token} from the incoming request or a new {@code Trace-Token} to the API
+     * resources and can optionally send a {@code Consumer-Token} or pass through the {@code
+     * Authorization} header from the incoming request.
+     *
+     * <p>These features shall never be enabled for clients that access APIs outside the same SDA
+     * Platform instance where this service is deployed.
+     *
+     * @return a builder to configure the client
+     */
+    ApiPlatformClientConfigurationBuilder<A> enablePlatformFeatures();
+  }
+
+  interface ApiPlatformClientConfigurationBuilder<A> extends ApiClientFinalBuilder<A> {
+
+    /**
+     * If authentication pass through is enabled, the JWT in the {@value
+     * javax.ws.rs.core.HttpHeaders#AUTHORIZATION} header of an incoming request will be added to
+     * the outgoing request.
+     *
+     * @return this builder instance
+     */
+    ApiPlatformClientConfigurationBuilder<A> enableAuthenticationPassThrough();
+
+    /**
+     * If consumer token is enabled, the client will create a configured consumer token and add it
+     * as header to the outgoing request.
+     *
+     * @return this builder instance
+     */
+    ApiPlatformClientConfigurationBuilder<A> enableConsumerToken();
+  }
+
+  interface ApiClientFinalBuilder<A> {
+
+    /**
+     * Builds the client with a default name for metrics and thread names derived from the API
+     * interface. If multiple clients of the same API interface are used, a {@linkplain
+     * #build(String) a unique custom name} must be used.
+     *
+     * @return the client
+     */
+    A build();
+
+    /**
+     * Builds the client with a custom name for metrics and thread names.
+     *
+     * @param customName the name used for metrics and thread names must be unique across all
+     *     clients of the application
+     * @return the client
+     */
+    A build(String customName);
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/FluentApiClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/FluentApiClientFactory.java
@@ -1,0 +1,101 @@
+package org.sdase.commons.client.jersey.builder;
+
+import static org.sdase.commons.client.jersey.proxy.ApiClientInvocationHandler.createProxy;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.setup.Environment;
+import io.opentracing.Tracer;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.WebTarget;
+import org.glassfish.jersey.client.proxy.WebResourceFactory;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+import org.sdase.commons.client.jersey.filter.AuthHeaderClientFilter;
+import org.sdase.commons.client.jersey.filter.ConsumerTokenHeaderFilter;
+import org.sdase.commons.client.jersey.filter.TraceTokenClientFilter;
+
+public class FluentApiClientFactory<A>
+    implements FluentApiClientBuilder.ApiClientInstanceConfigurationBuilder<A>,
+        FluentApiClientBuilder.ApiPlatformClientConfigurationBuilder<A>,
+        FluentApiClientBuilder.ApiClientCommonConfigurationBuilder<A>,
+        FluentApiClientBuilder.ApiClientFinalBuilder<A> {
+
+  private final Class<A> api;
+  private final InternalJerseyClientFactory internalJerseyClientFactory;
+  private final String consumerToken;
+  private final List<ClientRequestFilter> filters = new ArrayList<>();
+  private ApiHttpClientConfiguration apiHttpClientConfiguration;
+  private boolean followRedirects = true;
+
+  public FluentApiClientFactory(
+      Class<A> api, Environment environment, String consumerToken, Tracer tracer) {
+    this.api = api;
+    this.consumerToken = consumerToken;
+    this.internalJerseyClientFactory =
+        new InternalJerseyClientFactory(new JerseyClientBuilder(environment), tracer);
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiClientCommonConfigurationBuilder<A> withConfiguration(
+      ApiHttpClientConfiguration apiHttpClientConfiguration) {
+    this.apiHttpClientConfiguration = apiHttpClientConfiguration;
+    return this;
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiPlatformClientConfigurationBuilder<A> enablePlatformFeatures() {
+    this.filters.add(0, new TraceTokenClientFilter());
+    return this;
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiClientCommonConfigurationBuilder<A> addFilter(
+      ClientRequestFilter clientRequestFilter) {
+    this.filters.add(clientRequestFilter);
+    return this;
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiClientCommonConfigurationBuilder<A> disableFollowRedirects() {
+    this.followRedirects = false;
+    return this;
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiPlatformClientConfigurationBuilder<A>
+      enableAuthenticationPassThrough() {
+    if (isFilterMissing(AuthHeaderClientFilter.class)) {
+      this.filters.add(new AuthHeaderClientFilter());
+    }
+    return this;
+  }
+
+  @Override
+  public FluentApiClientBuilder.ApiPlatformClientConfigurationBuilder<A> enableConsumerToken() {
+    if (isFilterMissing(ConsumerTokenHeaderFilter.class)) {
+      this.filters.add(new ConsumerTokenHeaderFilter(consumerToken));
+    }
+    return this;
+  }
+
+  @Override
+  public A build() {
+    return build(api.getSimpleName());
+  }
+
+  @Override
+  public A build(String customName) {
+    Client client =
+        internalJerseyClientFactory.createClient(
+            customName, this.apiHttpClientConfiguration, this.filters, this.followRedirects);
+    WebTarget webTarget = client.target(apiHttpClientConfiguration.getApiBaseUrl());
+    A clientProxy = WebResourceFactory.newResource(this.api, webTarget);
+    return createProxy(this.api, clientProxy);
+  }
+
+  private boolean isFilterMissing(Class<? extends ClientRequestFilter> filterType) {
+    return this.filters.stream().map(Object::getClass).noneMatch(filterType::equals);
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/InternalJerseyClientFactory.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/InternalJerseyClientFactory.java
@@ -1,0 +1,62 @@
+package org.sdase.commons.client.jersey.builder;
+
+import static org.sdase.commons.server.opentracing.client.ClientTracingUtil.registerTracing;
+
+import io.dropwizard.client.JerseyClientBuilder;
+import io.dropwizard.client.JerseyClientConfiguration;
+import io.opentracing.Tracer;
+import java.net.ProxySelector;
+import java.util.List;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientRequestFilter;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
+import org.glassfish.jersey.client.ClientProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class InternalJerseyClientFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InternalJerseyClientFactory.class);
+
+  private JerseyClientBuilder jerseyClientBuilder;
+  private Tracer tracer;
+
+  InternalJerseyClientFactory(JerseyClientBuilder jerseyClientBuilder, Tracer tracer) {
+    this.jerseyClientBuilder = jerseyClientBuilder;
+    this.tracer = tracer;
+  }
+
+  Client createClient(
+      String name,
+      JerseyClientConfiguration clientConfiguration,
+      List<ClientRequestFilter> filters,
+      boolean followRedirects) {
+    // a specific proxy configuration always overrides the system proxy
+    if (clientConfiguration.getProxyConfiguration() == null) {
+      // register a route planner that uses the default proxy variables (e.g. http.proxyHost)
+      this.jerseyClientBuilder.using(new SystemDefaultRoutePlanner(ProxySelector.getDefault()));
+    }
+    Client client = jerseyClientBuilder.using(clientConfiguration).build(name);
+    filters.forEach(client::register);
+    client.property(ClientProperties.FOLLOW_REDIRECTS, followRedirects);
+    registerMultiPartIfAvailable(client);
+    registerTracing(client, tracer);
+    return client;
+  }
+
+  private void registerMultiPartIfAvailable(Client client) {
+    try {
+      ClassLoader classLoader = this.getClass().getClassLoader();
+      Class<?> multiPartFeature =
+          classLoader.loadClass("org.glassfish.jersey.media.multipart.MultiPartFeature");
+      if (multiPartFeature != null) {
+        LOG.info("Registering MultiPartFeature for client.");
+        client.register(multiPartFeature);
+      }
+    } catch (ClassNotFoundException e) {
+      LOG.info("Not registering MultiPartFeature for client: Class is not available.");
+    } catch (Exception e) {
+      LOG.warn("Failed to register MultiPartFeature for client.");
+    }
+  }
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformClientBuilder.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/builder/PlatformClientBuilder.java
@@ -6,14 +6,13 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
 import org.sdase.commons.client.jersey.HttpClientConfiguration;
-import org.sdase.commons.client.jersey.filter.AddRequestHeaderFilter;
 import org.sdase.commons.client.jersey.filter.AuthHeaderClientFilter;
+import org.sdase.commons.client.jersey.filter.ConsumerTokenHeaderFilter;
 import org.sdase.commons.client.jersey.filter.TraceTokenClientFilter;
-import org.sdase.commons.shared.tracing.ConsumerTracing;
 
 public class PlatformClientBuilder extends AbstractBaseClientBuilder<PlatformClientBuilder> {
 
-  private Supplier<Optional<String>> consumerTokenSupplier;
+  private final Supplier<Optional<String>> consumerTokenSupplier;
 
   public PlatformClientBuilder(
       Environment environment,
@@ -43,17 +42,6 @@ public class PlatformClientBuilder extends AbstractBaseClientBuilder<PlatformCli
    * @return this builder instance
    */
   public PlatformClientBuilder enableConsumerToken() {
-    return addFilter(
-        new AddRequestHeaderFilter() {
-          @Override
-          public String getHeaderName() {
-            return ConsumerTracing.TOKEN_HEADER;
-          }
-
-          @Override
-          public Optional<String> getHeaderValue() {
-            return consumerTokenSupplier.get();
-          }
-        });
+    return addFilter(new ConsumerTokenHeaderFilter(consumerTokenSupplier));
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/filter/AuthHeaderClientFilter.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/filter/AuthHeaderClientFilter.java
@@ -21,7 +21,8 @@ public class AuthHeaderClientFilter implements AddRequestHeaderFilter {
 
   @Override
   public Optional<String> getHeaderValue() {
-    return currentRequestContext()
+    final Optional<ContainerRequestContext> containerRequestContext = currentRequestContext();
+    return containerRequestContext
         .map(ContainerRequestContext::getHeaders)
         .map(h -> h.getFirst(HttpHeaders.AUTHORIZATION));
   }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/filter/ConsumerTokenHeaderFilter.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/filter/ConsumerTokenHeaderFilter.java
@@ -1,0 +1,31 @@
+package org.sdase.commons.client.jersey.filter;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.sdase.commons.shared.tracing.ConsumerTracing;
+
+/**
+ * A client filter that adds the {@value ConsumerTracing#TOKEN_HEADER} header to the client request.
+ */
+public class ConsumerTokenHeaderFilter implements AddRequestHeaderFilter {
+
+  private final Supplier<Optional<String>> consumerTokenSupplier;
+
+  public ConsumerTokenHeaderFilter(String consumerToken) {
+    this.consumerTokenSupplier = () -> Optional.ofNullable(consumerToken);
+  }
+
+  public ConsumerTokenHeaderFilter(Supplier<Optional<String>> consumerTokenSupplier) {
+    this.consumerTokenSupplier = consumerTokenSupplier;
+  }
+
+  @Override
+  public String getHeaderName() {
+    return ConsumerTracing.TOKEN_HEADER;
+  }
+
+  @Override
+  public Optional<String> getHeaderValue() {
+    return consumerTokenSupplier.get();
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ConfiguredApiClientTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ConfiguredApiClientTest.java
@@ -1,0 +1,659 @@
+package org.sdase.commons.client.jersey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.seeOther;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.http.RequestMethod.GET;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.apache.http.HttpStatus.SC_SEE_OTHER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.sdase.commons.client.jersey.error.ClientErrorUtil.convertExceptions;
+import static org.sdase.commons.client.jersey.test.util.ClientRequestExceptionConditions.processingError;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.jetty9.JettyHttpServerFactory;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.github.tomakehurst.wiremock.matching.StringValuePattern;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.assertj.core.util.Lists;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.client.jersey.error.ClientErrorUtil;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.client.jersey.test.MockApiClient;
+import org.sdase.commons.client.jersey.test.MockApiClient.Car;
+import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.shared.api.error.ApiException;
+
+public class ConfiguredApiClientTest {
+
+  @ClassRule
+  public static final WireMockClassRule WIRE =
+      new WireMockClassRule(
+          wireMockConfig().dynamicPort().httpServerFactory(new JettyHttpServerFactory()));
+
+  public static final Car LIGHT_BLUE_CAR =
+      new Car().setSign("HH XY 4321").setColor("light blue"); // NOSONAR
+  private static final ObjectMapper OM = new ObjectMapper();
+  private static final Car BRIGHT_BLUE_CAR =
+      new Car().setSign("HH XX 1234").setColor("bright blue"); // NOSONAR
+  private final DropwizardAppRule<ClientTestConfig> dw =
+      new DropwizardAppRule<>(ClientTestApp.class, resourceFilePath("test-config.yaml"));
+
+  @Rule
+  public final RuleChain rule =
+      RuleChain.outerRule(new EnvironmentRule().setEnv("MOCK_BASE_URL", WIRE.baseUrl())).around(dw);
+
+  private ClientTestApp app;
+
+  @Before
+  public void before() throws JsonProcessingException {
+    WIRE.resetAll();
+    app = dw.getApplication();
+
+    WIRE.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", equalTo("application/json")) // NOSONAR
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json") // NOSONAR
+                    .withBody(OM.writeValueAsBytes(asList(BRIGHT_BLUE_CAR, LIGHT_BLUE_CAR)))));
+    WIRE.stubFor(
+        post("/api/multi-part") // NOSONAR
+            .withHeader("Content-type", matching("multipart/form-data.*")) // NOSONAR
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json") // NOSONAR
+                    .withBody(OM.writeValueAsBytes(singletonMap("got", "it")))));
+    WIRE.stubFor(
+        post("/api/cars") // NOSONAR
+            .withHeader("Content-type", equalTo("application/json")) // NOSONAR
+            .withRequestBody(equalToJson("{\"sign\":\"HH AB 1234\", \"color\":\"white\"}"))
+            .willReturn(
+                aResponse().withStatus(201).withHeader("Location", "/api/cars/dummyId") // NOSONAR
+                ));
+    WIRE.stubFor(
+        get(urlMatching("/api/cars/HH%20XX%201234(\\?.*)?"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json")
+                    .withBody(OM.writeValueAsBytes(BRIGHT_BLUE_CAR))));
+    WIRE.stubFor(
+        get(urlMatching("/api/cars/HH%20XY%204321(\\?.*)?"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json")
+                    .withBody(OM.writeValueAsBytes(LIGHT_BLUE_CAR))));
+  }
+
+  @Test
+  public void sendMultipart() throws IOException {
+    try (FormDataMultiPart multiPart =
+        new FormDataMultiPart()
+            .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
+            .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
+      Response response =
+          app.getJerseyClientBundle()
+              .getClientFactory()
+              .platformClient()
+              .buildGenericClient("multi-part")
+              .target(WIRE.baseUrl())
+              .path("api")
+              .path("multi-part")
+              .register(MultiPartFeature.class)
+              .request(MediaType.APPLICATION_JSON)
+              .post(Entity.entity(multiPart, multiPart.getMediaType()));
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+
+      String contentType =
+          WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
+      String boundary = MediaType.valueOf(contentType).getParameters().get("boundary");
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/multi-part"))
+              .withHeader("Content-type", matching("multipart/form-data;boundary=.+"))
+              .withRequestBody(
+                  equalTo(
+                      "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + // NOSONAR
+                          "Content-Disposition: form-data; name=\"test\"\r\n"
+                          + "\r\n"
+                          + "test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"anotherTest\"\r\n"
+                          + "\r\n"
+                          + "another-test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "--\r\n")));
+    }
+  }
+
+  @Test
+  public void sendMultipartWithApiClient() throws IOException {
+    try (FormDataMultiPart multiPart =
+        new FormDataMultiPart()
+            .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
+            .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
+      Response response = createMockApiClient().sendMultiPart(multiPart);
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+
+      String contentType =
+          WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
+      String boundary = MediaType.valueOf(contentType).getParameters().get("boundary");
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/multi-part"))
+              .withHeader("Content-type", matching("multipart/form-data;boundary=.+"))
+              .withRequestBody(
+                  equalTo(
+                      "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"test\"\r\n"
+                          + "\r\n"
+                          + "test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "\r\n"
+                          + "Content-Type: text/plain\r\n"
+                          + "Content-Disposition: form-data; name=\"anotherTest\"\r\n"
+                          + "\r\n"
+                          + "another-test-value\r\n"
+                          + "--"
+                          + boundary
+                          + "--\r\n")));
+    }
+  }
+
+  @Test
+  public void loadCars() {
+    List<Car> cars = createMockApiClient().getCars();
+
+    assertThat(cars)
+        .extracting(Car::getSign, Car::getColor)
+        .containsExactly(tuple("HH XX 1234", "bright blue"), tuple("HH XY 4321", "light blue"));
+  }
+
+  @Test
+  public void loadCarsWithResponseDetails() {
+    Response response = createMockApiClient().requestCars();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", matchingUuid()) // NOSONAR
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void addConsumerToken() {
+    Response response = createMockApiClient().requestCars();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Consumer-Token", equalTo("test-consumer")) // NOSONAR
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void postNewCar() {
+    try (Response response =
+        createMockApiClient().createCar(new Car().setSign("HH AB 1234").setColor("white"))) {
+
+      assertThat(response.getStatus()).isEqualTo(201);
+      assertThat(response.getLocation()).isEqualTo(URI.create("/api/cars/dummyId"));
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(RequestMethod.POST, urlEqualTo("/api/cars"))
+              .withHeader("Content-type", equalTo("application/json")) // NOSONAR
+          );
+    }
+  }
+
+  @Test
+  public void notAddConsumerTokenIfAlreadySet() {
+    try (Response response =
+        createMockApiClient().requestCarsWithCustomConsumerToken("my-custom-consumer")) {
+
+      assertThat(response.getStatus()).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Consumer-Token", equalTo("my-custom-consumer"))
+              .withHeader("Consumer-Token", notMatching("test-consumer"))
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
+  }
+
+  @Test
+  public void addReceivedTraceTokenToHeadersToPlatformCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("cars")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Trace-Token", "test-trace-token-1")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", equalTo("test-trace-token-1"))
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void addReceivedAuthHeaderToPlatformCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsAuth")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Authorization", "custom-dummy-token")
+            .header("Trace-Token", "test-trace-token-3")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Trace-Token", equalTo("test-trace-token-3"))
+            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("custom-dummy-token")));
+  }
+
+  @Test
+  public void notAddingReceivedTraceTokenToHeadersOfExternalCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsExternal")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header("Trace-Token", "test-trace-token-2")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withoutHeader("Trace-Token"));
+  }
+
+  @Test
+  public void notAddingReceivedAuthorizationToHeadersOfExternalCall() {
+    int status =
+        dwClient()
+            .path("api")
+            .path("carsExternal")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .header(HttpHeaders.AUTHORIZATION, "BEARER dummy")
+            .get()
+            .getStatus();
+
+    assertThat(status).isEqualTo(200);
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void loadSingleCar() {
+    Car car = createMockApiClient().getCar("HH XY 4321");
+    assertThat(car)
+        .extracting(Car::getSign, Car::getColor)
+        .containsExactly("HH XY 4321", "light blue");
+  }
+
+  @Test
+  public void loadSingleCarWithFieldFilterAllFields() {
+    createMockApiClient().getCarWithFilteredFields("HH XY 4321", asList("sign", "color"));
+    verify(
+        RequestPatternBuilder.newRequestPattern(
+            GET, urlEqualTo("/api/cars/HH%20XY%204321?fields=sign&fields=color")));
+  }
+
+  @Test
+  public void loadSingleCarWithFieldFilterOneField() {
+    createMockApiClient().getCarWithFilteredFields("HH XY 4321", singletonList("color"));
+    verify(
+        RequestPatternBuilder.newRequestPattern(
+            GET, urlEqualTo("/api/cars/HH%20XY%204321?fields=color")));
+  }
+
+  @Test
+  public void loadLightBlueCarThroughDefaultMethod() {
+    try (Response response = createMockApiClient().getLightBlueCar()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.readEntity(Car.class))
+          .extracting(Car::getSign, Car::getColor)
+          .containsExactly("HH XY 4321", "light blue");
+    }
+  }
+
+  @Test
+  public void handle404ErrorInDefaultMethod() {
+    WIRE.stubFor(
+        get("/api/cars/UNKNOWN")
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{}")));
+    assertThat(createMockApiClient().getCarOrHandleError("UNKNOWN")).isNull();
+  }
+
+  @Test
+  public void handleClientErrorInDefaultMethod() {
+    WIRE.stubFor(
+        get("/api/cars/UNKNOWN")
+            .willReturn(
+                aResponse()
+                    .withStatus(500)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{}")));
+    MockApiClient mockApiClient = createMockApiClient();
+    assertThatExceptionOfType(ApiException.class)
+        .isThrownBy(() -> mockApiClient.getCarOrHandleError("UNKNOWN"))
+        .withCauseInstanceOf(ClientRequestException.class);
+  }
+
+  @Test
+  public void failOnLoadingMissingCar() {
+    MockApiClient mockApiClient = createMockApiClient();
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(() -> mockApiClient.getCar("HH AA 4444"))
+        .withCauseInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  public void demonstrateToCloseException() {
+    WIRE.stubFor(
+        get("/api/cars/HH%20AA%204444")
+            .willReturn(
+                aResponse()
+                    .withStatus(404)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ 'message': 'car is unknown' }")));
+
+    try {
+      createMockApiClient().getCar("HH AA 4444");
+    } catch (ClientRequestException e) {
+      assertThat(e.getResponse().map(Response::getStatus)).isPresent().hasValue(404);
+      assertThat(e.getResponse().map(Response::hasEntity)).isPresent().hasValue(true);
+      e.close(); // important if exception is not rethrown
+    }
+  }
+
+  @Test
+  public void return404ForMissingCar() {
+    try (Response response = createMockApiClient().getCarResponse("HH AA 5555")) {
+      assertThat(response.getStatus()).isEqualTo(404);
+    }
+  }
+
+  @Test
+  public void return404ForMissingCarWithGenericClient() {
+    try (Response response =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .externalClient()
+            .buildGenericClient("foo")
+            .target(WIRE.baseUrl())
+            .path("api")
+            .path("cars")
+            .path("HH AA 7777")
+            .request(MediaType.APPLICATION_JSON)
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+    }
+  }
+
+  @Test
+  public void return500ForDelegatedMissingCar() {
+    try (Response response =
+        dwClient()
+            .path("api")
+            .path("cars")
+            .path("HH AA 7777")
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(ClientErrorUtil.readErrorBody(response, new GenericType<Map<String, Object>>() {}))
+          .containsExactly(
+              entry(
+                  "title",
+                  "Request could not be fulfilled: Received status '404' from another service."),
+              entry("invalidParams", Lists.emptyList()));
+    }
+  }
+
+  @Test
+  public void addCustomFiltersToPlatformClient() {
+    MockApiClient mockApiClient =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .apiClient(MockApiClient.class)
+            .withConfiguration(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .addFilter(
+                requestContext -> requestContext.getHeaders().add("Hello", "World")) // NOSONAR
+            .addFilter(requestContext -> requestContext.getHeaders().add("Foo", "Bar"))
+            .enablePlatformFeatures()
+            .build();
+
+    mockApiClient.getCars();
+
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Hello", equalTo("World"))
+            .withHeader("Foo", equalTo("Bar")));
+  }
+
+  @Test
+  public void addCustomFiltersToExternalClient() {
+    MockApiClient mockApiClient =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .apiClient(MockApiClient.class)
+            .withConfiguration(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .addFilter(requestContext -> requestContext.getHeaders().add("Hello", "World"))
+            .addFilter(requestContext -> requestContext.getHeaders().add("Foo", "Bar"))
+            .build();
+
+    mockApiClient.getCars();
+
+    WIRE.verify(
+        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+            .withHeader("Hello", equalTo("World"))
+            .withHeader("Foo", equalTo("Bar")));
+  }
+
+  @Test
+  public void failOnReadJsonWithGenericClient() {
+
+    WIRE.stubFor(
+        get("/badJsonResponse")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"xyz\"")));
+
+    Client client =
+        app.getJerseyClientBundle().getClientFactory().externalClient().buildGenericClient("test");
+
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(
+            () ->
+                // receives invalid json
+                convertExceptions(
+                    () ->
+                        client
+                            .target(WIRE.baseUrl())
+                            .path("badJsonResponse")
+                            .request()
+                            .get(Car.class)))
+        .is(processingError());
+  }
+
+  @Test
+  public void failOnReadJsonWithApiClient() {
+
+    WIRE.stubFor(
+        get("/api/cars/123")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"xyz\"")));
+
+    MockApiClient client =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .apiClient(MockApiClient.class)
+            .withConfiguration(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+            .build();
+
+    assertThatExceptionOfType(ClientRequestException.class)
+        .isThrownBy(() -> client.getCar("123"))
+        .is(processingError());
+  }
+
+  @Test
+  public void seeOtherAfterPost() {
+    WIRE.stubFor(
+        post("/api/cars")
+            .withRequestBody(
+                equalToJson("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")) // NOSONAR
+            .willReturn(seeOther(WIRE.url("/api/cars/HH%20XY%201234")))); // NOSONAR
+    WIRE.stubFor(
+        get("/api/cars/HH%20XY%201234")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")));
+
+    // This test requires that gzip for request bodies is disabled, otherwise
+    // the automatic GET request after the see others fails as the
+    // content-encoding from the post request is also used for the GET
+    // request. However neither Dropwizard nor Wiremock does handle this well
+    // for GET requests.
+    MockApiClient client = createMockApiClient();
+
+    try (Response r =
+        client.createCar(new Car().setSign("HH XY 1234").setColor("yellow"))) { // NOSONAR
+      assertThat(r.getStatus()).isEqualTo(SC_OK);
+      Car car = r.readEntity(Car.class);
+      assertThat(car)
+          .extracting(Car::getSign, Car::getColor)
+          .containsExactly("HH XY 1234", "yellow");
+    }
+  }
+
+  @Test
+  public void disableRedirectsForSeeOther() {
+    WIRE.stubFor(
+        post("/api/cars")
+            .withRequestBody(equalToJson("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }"))
+            .willReturn(seeOther(WIRE.url("/api/cars/HH%20XY%201234"))));
+    WIRE.stubFor(
+        get("/api/cars/HH%20XY%201234")
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+                    .withBody("{ \"sign\": \"HH XY 1234\", \"color\": \"yellow\" }")));
+
+    MockApiClient client = createMockApiClientWithoutFollowRedirects();
+
+    try (Response r = client.createCar(new Car().setSign("HH XY 1234").setColor("yellow"))) {
+      assertThat(r.getStatus()).isEqualTo(SC_SEE_OTHER);
+      assertThat(r.getHeaderString(HttpHeaders.LOCATION))
+          .isEqualTo(WIRE.url("/api/cars/HH%20XY%201234"));
+      WIRE.verify(
+          0, RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars/HH%20XY%201234")));
+    }
+  }
+
+  private MockApiClient createMockApiClientWithoutFollowRedirects() {
+    return app.getJerseyClientBundle()
+        .getClientFactory()
+        .apiClient(MockApiClient.class)
+        .withConfiguration(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+        .disableFollowRedirects()
+        .enablePlatformFeatures()
+        .enableConsumerToken()
+        .build();
+  }
+
+  private MockApiClient createMockApiClient() {
+    return app.getJerseyClientBundle()
+        .getClientFactory()
+        .apiClient(MockApiClient.class)
+        .withConfiguration(new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl()))
+        .enablePlatformFeatures()
+        .enableConsumerToken()
+        .enableAuthenticationPassThrough()
+        .build();
+  }
+
+  private WebTarget dwClient() {
+    return dw.client().target("http://localhost:" + dw.getLocalPort());
+  }
+
+  private StringValuePattern matchingUuid() {
+    return matching(
+        "[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{12}");
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/builder/FluentApiClientFactoryTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/builder/FluentApiClientFactoryTest.java
@@ -1,0 +1,231 @@
+package org.sdase.commons.client.jersey.builder;
+
+import static com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder.okForJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.seeOther;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import org.glassfish.jersey.internal.util.collection.MultivaluedStringMap;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.sdase.commons.client.jersey.ApiHttpClientConfiguration;
+import org.sdase.commons.client.jersey.ClientFactory;
+import org.sdase.commons.client.jersey.filter.AddRequestHeaderFilter;
+import org.sdase.commons.client.jersey.filter.ContainerRequestContextHolder;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.client.jersey.test.MockApiClient;
+import org.sdase.commons.shared.tracing.ConsumerTracing;
+
+public class FluentApiClientFactoryTest {
+
+  private static final AtomicInteger CLIENT_COUNTER = new AtomicInteger();
+
+  private static final WireMockClassRule WIRE = new WireMockClassRule(0);
+
+  private static final DropwizardAppRule<ClientTestConfig> DW =
+      new DropwizardAppRule<>(
+          ClientTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          ConfigOverride.config("mockBaseUrl", WIRE::baseUrl));
+
+  @ClassRule public static final TestRule RULE_CHAIN = RuleChain.outerRule(WIRE).around(DW);
+
+  private final ApiHttpClientConfiguration apiClientConfig =
+      new ApiHttpClientConfiguration().setApiBaseUrl(WIRE.baseUrl());
+  private ClientFactory clientFactory;
+
+  @Before
+  public void initSuccessfulResponseForCarsEndpoint() {
+    WIRE.resetAll();
+    WIRE.addStubMapping(get("/api/cars").willReturn(okForJson(new ArrayList<>())).build());
+  }
+
+  @Before
+  public void selectClientFactoryFromApplication() {
+    ClientTestApp application = DW.getApplication();
+    this.clientFactory = application.getJerseyClientBundle().getClientFactory();
+  }
+
+  @Test
+  public void shouldPassThroughAuthentication() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .enablePlatformFeatures()
+            .enableAuthenticationPassThrough()
+            .build(uniqueClientName());
+
+    inRequestContextWithAuthentication(client::getCars);
+
+    WIRE.verify(
+        WireMock.getRequestedFor(WireMock.urlEqualTo("/api/cars"))
+            .withHeader(HttpHeaders.AUTHORIZATION, matching("^Bearer .*$")));
+  }
+
+  @Test
+  public void shouldNotPassThroughAuthentication() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .enablePlatformFeatures()
+            // not enableAuthenticationPassThrough
+            .build(uniqueClientName());
+
+    inRequestContextWithAuthentication(client::getCars);
+
+    WIRE.verify(
+        WireMock.getRequestedFor(WireMock.urlEqualTo("/api/cars"))
+            .withoutHeader(HttpHeaders.AUTHORIZATION));
+  }
+
+  @Test
+  public void shouldSendConsumerToken() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .enablePlatformFeatures()
+            .enableConsumerToken()
+            .build(uniqueClientName());
+
+    client.getCars();
+
+    WIRE.verify(
+        WireMock.getRequestedFor(WireMock.urlEqualTo("/api/cars"))
+            .withHeader(ConsumerTracing.TOKEN_HEADER, matching("^.+$")));
+  }
+
+  @Test
+  public void shouldNotSendConsumerToken() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .enablePlatformFeatures()
+            // not enableConsumerToken
+            .build(uniqueClientName());
+
+    client.getCars();
+
+    WIRE.verify(
+        WireMock.getRequestedFor(WireMock.urlEqualTo("/api/cars"))
+            .withoutHeader(ConsumerTracing.TOKEN_HEADER));
+  }
+
+  @Test
+  public void shouldUseCustomFilter() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .addFilter(
+                new AddRequestHeaderFilter() {
+                  @Override
+                  public String getHeaderName() {
+                    return "Custom-Header";
+                  }
+
+                  @Override
+                  public Optional<String> getHeaderValue() {
+                    return Optional.of("example");
+                  }
+                })
+            .build(uniqueClientName());
+
+    client.getCars();
+
+    WIRE.verify(
+        WireMock.getRequestedFor(WireMock.urlEqualTo("/api/cars"))
+            .withHeader("Custom-Header", equalTo("example")));
+  }
+
+  @Test
+  public void shouldFollowRedirectsByDefault() {
+    MockApiClient.Car testCar = new MockApiClient.Car().setColor("blue").setSign("HH AB 1234");
+
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            // not disableFollowRedirects
+            .build(uniqueClientName());
+
+    WIRE.addStubMapping(
+        post("/api/cars").willReturn(seeOther(WIRE.baseUrl() + "/api/cars/HH-AB-1234")).build());
+    WIRE.addStubMapping(get("/api/cars/HH-AB-1234").willReturn(okForJson(testCar)).build());
+
+    try (Response r = client.createCar(testCar)) {
+      assertThat(r.getStatus()).isEqualTo(200);
+      MockApiClient.Car car = r.readEntity(MockApiClient.Car.class);
+      assertThat(car)
+          .extracting(MockApiClient.Car::getSign, MockApiClient.Car::getColor)
+          .containsExactly("HH AB 1234", "blue");
+    }
+  }
+
+  @Test
+  public void shouldNotFollowRedirects() {
+    MockApiClient client =
+        clientFactory
+            .apiClient(MockApiClient.class)
+            .withConfiguration(apiClientConfig)
+            .disableFollowRedirects()
+            .build(uniqueClientName());
+
+    WIRE.addStubMapping(
+        post("/api/cars").willReturn(seeOther(WIRE.baseUrl() + "/api/cars/HH-AB-1234")).build());
+
+    try (Response r =
+        client.createCar(new MockApiClient.Car().setColor("blue").setSign("HH AB 1234"))) {
+      assertThat(r.getStatus()).isEqualTo(303);
+    }
+  }
+
+  private void inRequestContextWithAuthentication(Runnable r) {
+    ContainerRequestContextHolder containerRequestContextHolder =
+        new ContainerRequestContextHolder();
+    try {
+      ContainerRequestContext containerRequestContextMock =
+          mock(ContainerRequestContext.class, RETURNS_DEEP_STUBS);
+      MultivaluedMap<String, String> headers = new MultivaluedStringMap();
+      headers.add(HttpHeaders.AUTHORIZATION, "Bearer ey.ey.sig");
+      when(containerRequestContextMock.getHeaders()).thenReturn(headers);
+      containerRequestContextHolder.filter(containerRequestContextMock);
+      r.run();
+    } finally {
+      containerRequestContextHolder.filter(null, null);
+    }
+  }
+
+  private String uniqueClientName() {
+    return MockApiClient.class.getSimpleName()
+        + "-"
+        + getClass().getSimpleName()
+        + "-"
+        + CLIENT_COUNTER.incrementAndGet();
+  }
+}


### PR DESCRIPTION
In many service we had to extend the HttpClientConfiguration to add a base url of the API which is required for API clients based on interfaces.
This commit provides a built in approach to simplify configuration and creation of API clients.

A new entry point gives access to the builder that creates API clients. This way no existing configuration is affected.

With this new entrypoint the old fluent API to create clients is deprecated for API clients based on annotated interfaces.