### PR TITLE
Provide annotations to suppress exceptions when using API clients

### DIFF
--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/ApiClientInvocationHandler.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/ApiClientInvocationHandler.java
@@ -3,14 +3,35 @@ package org.sdase.commons.client.jersey.proxy;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import org.codefetti.proxy.handler.InterfaceProxyBuilder;
 import org.sdase.commons.client.jersey.error.ClientRequestException;
+import org.sdase.commons.client.jersey.proxy.annotation.SuppressConnectTimeoutErrorsToNull;
+import org.sdase.commons.client.jersey.proxy.annotation.SuppressHttpErrorsToNull;
+import org.sdase.commons.client.jersey.proxy.annotation.SuppressProcessingErrorsToNull;
+import org.sdase.commons.client.jersey.proxy.annotation.SuppressReadTimeoutErrorsToNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ApiClientInvocationHandler implements InvocationHandler {
 
-  private Object delegate;
+  private static final Logger LOG = LoggerFactory.getLogger(ApiClientInvocationHandler.class);
+
+  private static final List<Integer> ALL_REDIRECT_ERRORS =
+      IntStream.rangeClosed(300, 399).boxed().collect(Collectors.toList());
+  private static final List<Integer> ALL_CLIENT_ERRORS =
+      IntStream.rangeClosed(400, 499).boxed().collect(Collectors.toList());
+  private static final List<Integer> ALL_SERVER_ERRORS =
+      IntStream.rangeClosed(500, 599).boxed().collect(Collectors.toList());
+
+  private final Object delegate;
 
   /**
    * Creates a proxy around the given {@code jerseyClientProxy} that wraps all {@link
@@ -39,12 +60,79 @@ public class ApiClientInvocationHandler implements InvocationHandler {
     } catch (InvocationTargetException invocationTargetException) {
       Throwable cause = invocationTargetException.getCause();
       if (cause instanceof WebApplicationException) {
-        throw new ClientRequestException(cause);
+        throwIfNotSuppressed(method, new ClientRequestException(cause));
       } else if (cause instanceof ProcessingException) {
-        throw new ClientRequestException(cause);
+        throwIfNotSuppressed(method, new ClientRequestException(cause));
       } else {
         throw cause;
       }
+      LOG.info(
+          "API client error '{}' suppressed to null when calling {}", cause.getMessage(), method);
+      return null;
     }
+  }
+
+  /**
+   * @throws ClientRequestException the given {@code exceptionToThrow} if not suppressed by
+   *     annotations of the {@code invokedMethod}.
+   */
+  private void throwIfNotSuppressed(Method invokedMethod, ClientRequestException exceptionToThrow) {
+    Optional<Integer> httpStatus = getHttpStatus(exceptionToThrow);
+    if (httpStatus.isPresent()) {
+      if (!isHttpStatusSuppressed(invokedMethod, httpStatus.get())) {
+        throw exceptionToThrow;
+      }
+    } else if (exceptionToThrow.isConnectTimeout()) {
+      if (!isConnectTimeoutErrorSuppressed(invokedMethod)) {
+        throw exceptionToThrow;
+      }
+    } else if (exceptionToThrow.isReadTimeout()) {
+      if (!isReadTimeoutErrorSuppressed(invokedMethod)) {
+        throw exceptionToThrow;
+      }
+    } else if (exceptionToThrow.isProcessingError()) {
+      if (!isProcessingErrorSuppressed(invokedMethod)) {
+        throw exceptionToThrow;
+      }
+    } else {
+      throw exceptionToThrow;
+    }
+    exceptionToThrow.close();
+  }
+
+  private Optional<Integer> getHttpStatus(ClientRequestException exceptionToThrow) {
+    return exceptionToThrow.getResponse().map(Response::getStatus);
+  }
+
+  private boolean isHttpStatusSuppressed(Method invokedMethod, int httStatusCode) {
+    SuppressHttpErrorsToNull suppressedHttpErrors =
+        invokedMethod.getDeclaredAnnotation(SuppressHttpErrorsToNull.class);
+    if (suppressedHttpErrors == null) {
+      return false;
+    }
+    Set<Integer> suppressedStatusCodes =
+        IntStream.of(suppressedHttpErrors.value()).boxed().collect(Collectors.toSet());
+    if (suppressedHttpErrors.allRedirectErrors()) {
+      suppressedStatusCodes.addAll(ALL_REDIRECT_ERRORS);
+    }
+    if (suppressedHttpErrors.allClientErrors()) {
+      suppressedStatusCodes.addAll(ALL_CLIENT_ERRORS);
+    }
+    if (suppressedHttpErrors.allServerErrors()) {
+      suppressedStatusCodes.addAll(ALL_SERVER_ERRORS);
+    }
+    return suppressedStatusCodes.contains(httStatusCode);
+  }
+
+  private boolean isProcessingErrorSuppressed(Method invokedMethod) {
+    return invokedMethod.isAnnotationPresent(SuppressProcessingErrorsToNull.class);
+  }
+
+  private boolean isConnectTimeoutErrorSuppressed(Method invokedMethod) {
+    return invokedMethod.isAnnotationPresent(SuppressConnectTimeoutErrorsToNull.class);
+  }
+
+  private boolean isReadTimeoutErrorSuppressed(Method invokedMethod) {
+    return invokedMethod.isAnnotationPresent(SuppressReadTimeoutErrorsToNull.class);
   }
 }

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressConnectTimeoutErrorsToNull.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressConnectTimeoutErrorsToNull.java
@@ -1,0 +1,32 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+/**
+ * Annotation used to suppress {@link ClientRequestException} caused by {@linkplain
+ * ClientRequestException#isConnectTimeout() connection timeout errors}. Instead of throwing an
+ * exception, {@code null} will be returned.
+ *
+ * <p>This annotation is only suitable for methods that do not return a {@link
+ * javax.ws.rs.core.Response}. This annotation is NOT suitable for declared default implementations.
+ *
+ * <p>Suppressing expected errors and not catching any exception can simplify consumer code, as
+ * other errors are automatically converted to a 500 Internal Server Error by the {@link
+ * org.sdase.commons.client.jersey.error.ClientRequestExceptionMapper} and the consumer code can
+ * easily check for a {@code null} value instead of catching and checking the exception. However,
+ * consumers may still catch the {@link ClientRequestException} to implement additional behaviour
+ * for not suppressed errors, e.g. passing a 401 to their client.
+ *
+ * @see SuppressReadTimeoutErrorsToNull
+ * @see SuppressHttpErrorsToNull
+ * @see SuppressProcessingErrorsToNull
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SuppressConnectTimeoutErrorsToNull {}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressHttpErrorsToNull.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressHttpErrorsToNull.java
@@ -1,0 +1,68 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+/**
+ * Annotation used to suppress {@link ClientRequestException} with a {@link
+ * javax.ws.rs.WebApplicationException} cause in API clients. Instead of throwing an exception,
+ * {@code null} will be returned.
+ *
+ * <p>This annotation is only suitable for methods that do not return a {@link
+ * javax.ws.rs.core.Response}. This annotation is NOT suitable for declared default implementations.
+ *
+ * <p>Suppressing expected errors (e.g. 404) and not catching any exception can simplify consumer
+ * code, as the exception of a not listed code is automatically converted to a 500 Internal Server
+ * Error by the {@link org.sdase.commons.client.jersey.error.ClientRequestExceptionMapper} and the
+ * consumer code can easily check for a {@code null} value instead of catching and checking the
+ * exception. However, consumers may still catch the {@link ClientRequestException} to implement
+ * additional behaviour for not suppressed errors, e.g. passing a 401 to their client.
+ *
+ * <p>In case a {@linkplain #value() defined error} occurs, the annotated method will return {@code
+ * null} instead of throwing a {@link ClientRequestException}.
+ *
+ * <p>{@link ClientRequestException}s will be thrown for HTTP errors that are not specified as if
+ * the method is not annotated.
+ *
+ * <p>By default no error is suppressed. Users may suppress {@linkplain #allRedirectErrors() all
+ * redirect errors (3xx)}, {@linkplain #allClientErrors() all client errors (4xx)}, {@linkplain
+ * #allServerErrors() all server errors (5xx)} or {@linkplain #value() specific error codes}.
+ *
+ * @see SuppressConnectTimeoutErrorsToNull
+ * @see SuppressReadTimeoutErrorsToNull
+ * @see SuppressProcessingErrorsToNull
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SuppressHttpErrorsToNull {
+
+  /**
+   * @return the <a href="https://en.wikipedia.org/wiki/List_of_HTTP_status_codes">HTTP status
+   *     codes</a> that should be suppressed. Exceptions of other status codes will not be
+   *     suppressed.
+   */
+  int[] value() default {};
+
+  /**
+   * @return {@code true}, if {@linkplain #value() the individually defined codes} are extended by
+   *     all redirect errors (3xx).
+   */
+  boolean allRedirectErrors() default false;
+
+  /**
+   * @return {@code true}, if {@linkplain #value() the individually defined codes} are extended by
+   *     all {@linkplain ClientRequestException#isClientError() client errors (4xx)}.
+   */
+  boolean allClientErrors() default false;
+
+  /**
+   * @return {@code true}, if {@linkplain #value() the individually defined codes} are extended by
+   *     all {@linkplain ClientRequestException#isServerError() server errors (5xx)}.
+   */
+  boolean allServerErrors() default false;
+}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressProcessingErrorsToNull.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressProcessingErrorsToNull.java
@@ -1,0 +1,32 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+/**
+ * Annotation used to suppress {@link ClientRequestException} caused by {@linkplain
+ * ClientRequestException#isProcessingError() processing errors}. Instead of throwing an exception,
+ * {@code null} will be returned.
+ *
+ * <p>This annotation is only suitable for methods that do not return a {@link
+ * javax.ws.rs.core.Response}. This annotation is NOT suitable for declared default implementations.
+ *
+ * <p>Suppressing expected errors and not catching any exception can simplify consumer code, as
+ * other errors are automatically converted to a 500 Internal Server Error by the {@link
+ * org.sdase.commons.client.jersey.error.ClientRequestExceptionMapper} and the consumer code can
+ * easily check for a {@code null} value instead of catching and checking the exception. However,
+ * consumers may still catch the {@link ClientRequestException} to implement additional behaviour
+ * for not suppressed errors, e.g. passing a 401 to their client.
+ *
+ * @see SuppressConnectTimeoutErrorsToNull
+ * @see SuppressReadTimeoutErrorsToNull
+ * @see SuppressHttpErrorsToNull
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SuppressProcessingErrorsToNull {}

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressReadTimeoutErrorsToNull.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressReadTimeoutErrorsToNull.java
@@ -1,0 +1,32 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+/**
+ * Annotation used to suppress {@link ClientRequestException} caused by {@linkplain
+ * ClientRequestException#isReadTimeout() read timeout errors}. Instead of throwing an exception,
+ * {@code null} will be returned.
+ *
+ * <p>This annotation is only suitable for methods that do not return a {@link
+ * javax.ws.rs.core.Response}. This annotation is NOT suitable for declared default implementations.
+ *
+ * <p>Suppressing expected errors and not catching any exception can simplify consumer code, as
+ * other errors are automatically converted to a 500 Internal Server Error by the {@link
+ * org.sdase.commons.client.jersey.error.ClientRequestExceptionMapper} and the consumer code can
+ * easily check for a {@code null} value instead of catching and checking the exception. However,
+ * consumers may still catch the {@link ClientRequestException} to implement additional behaviour
+ * for not suppressed errors, e.g. passing a 401 to their client.
+ *
+ * @see SuppressConnectTimeoutErrorsToNull
+ * @see SuppressHttpErrorsToNull
+ * @see SuppressProcessingErrorsToNull
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface SuppressReadTimeoutErrorsToNull {}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressConnectTimeoutErrorsToNullTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressConnectTimeoutErrorsToNullTest.java
@@ -1,0 +1,66 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.sdase.commons.client.jersey.proxy.ApiClientInvocationHandler.createProxy;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.junit.Test;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+public class SuppressConnectTimeoutErrorsToNullTest {
+
+  @Test
+  public void shouldSuppressForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new ConnectTimeoutException());
+            });
+    assertThat(given.suppressed()).isNull();
+  }
+
+  @Test
+  public void shouldNotSuppressReadTimeoutForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new SocketTimeoutException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressProcessingErrorForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new IOException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressHttpErrorForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new WebApplicationException(404);
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  public interface ProcessingErrorsSuppressed {
+
+    @SuppressConnectTimeoutErrorsToNull
+    Object suppressed();
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressHttpErrorsToNullTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressHttpErrorsToNullTest.java
@@ -1,0 +1,124 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sdase.commons.client.jersey.proxy.ApiClientInvocationHandler.createProxy;
+
+import java.util.Arrays;
+import java.util.Collection;
+import javax.ws.rs.WebApplicationException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.mockito.Mockito;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+@RunWith(Parameterized.class)
+public class SuppressHttpErrorsToNullTest<T extends SuppressHttpErrorsToNullTest.TestApi> {
+
+  private final TestApi testApiImpl;
+  private final boolean expectException;
+
+  public SuppressHttpErrorsToNullTest(
+      Class<T> testApi, int givenHttpError, boolean expectException) {
+    WebApplicationException error = new WebApplicationException(givenHttpError);
+    this.testApiImpl = createProxy(testApi, createDelegate(testApi, error));
+    this.expectException = expectException;
+  }
+
+  @Parameters(name = "{0}: {1}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {ClientErrorsSuppressed.class, 404, false},
+        new Object[] {ClientErrorsSuppressed.class, 500, true},
+        new Object[] {ServerErrorsSuppressed.class, 500, false},
+        new Object[] {ServerErrorsSuppressed.class, 400, true},
+        new Object[] {ServerErrorsAndNotFoundSuppressed.class, 500, false},
+        new Object[] {ServerErrorsAndNotFoundSuppressed.class, 404, false},
+        new Object[] {ServerErrorsAndNotFoundSuppressed.class, 400, true},
+        new Object[] {NotFoundAndForbiddenSuppressed.class, 403, false},
+        new Object[] {NotFoundAndForbiddenSuppressed.class, 404, false},
+        new Object[] {NotFoundAndForbiddenSuppressed.class, 400, true},
+        new Object[] {RedirectErrorsSuppressed.class, 303, false},
+        new Object[] {RedirectErrorsSuppressed.class, 400, true});
+  }
+
+  @Test
+  public void exceptionForObject() {
+    if (expectException) {
+      assertThatExceptionOfType(ClientRequestException.class).isThrownBy(testApiImpl::suppressed);
+    } else {
+      assertThat(testApiImpl.suppressed()).isNull();
+    }
+  }
+
+  @Test
+  public void exceptionForVoid() {
+    if (expectException) {
+      assertThatExceptionOfType(ClientRequestException.class)
+          .isThrownBy(testApiImpl::suppressedForVoid);
+    } else {
+      assertThatCode(testApiImpl::suppressedForVoid).doesNotThrowAnyException();
+    }
+  }
+
+  interface TestApi {
+    Object suppressed();
+
+    void suppressedForVoid();
+  }
+
+  public interface ClientErrorsSuppressed extends TestApi {
+    @SuppressHttpErrorsToNull(allClientErrors = true)
+    Object suppressed();
+
+    @SuppressHttpErrorsToNull(allClientErrors = true)
+    void suppressedForVoid();
+  }
+
+  public interface ServerErrorsSuppressed extends TestApi {
+    @SuppressHttpErrorsToNull(allServerErrors = true)
+    Object suppressed();
+
+    @SuppressHttpErrorsToNull(allServerErrors = true)
+    void suppressedForVoid();
+  }
+
+  public interface ServerErrorsAndNotFoundSuppressed extends TestApi {
+
+    @SuppressHttpErrorsToNull(value = 404, allServerErrors = true)
+    Object suppressed();
+
+    @SuppressHttpErrorsToNull(value = 404, allServerErrors = true)
+    void suppressedForVoid();
+  }
+
+  public interface NotFoundAndForbiddenSuppressed extends TestApi {
+
+    @SuppressHttpErrorsToNull(value = {403, 404})
+    Object suppressed();
+
+    @SuppressHttpErrorsToNull(value = {403, 404})
+    void suppressedForVoid();
+  }
+
+  public interface RedirectErrorsSuppressed extends TestApi {
+
+    @SuppressHttpErrorsToNull(allRedirectErrors = true)
+    Object suppressed();
+
+    @SuppressHttpErrorsToNull(allRedirectErrors = true)
+    void suppressedForVoid();
+  }
+
+  private T createDelegate(Class<T> testApi, WebApplicationException error) {
+    T mock = mock(testApi);
+    when(mock.suppressed()).thenThrow(error);
+    Mockito.doThrow(error).when(mock).suppressedForVoid();
+    return mock;
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressProcessingErrorsToNullTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressProcessingErrorsToNullTest.java
@@ -1,0 +1,66 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.sdase.commons.client.jersey.proxy.ApiClientInvocationHandler.createProxy;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.junit.Test;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+public class SuppressProcessingErrorsToNullTest {
+
+  @Test
+  public void shouldSuppressForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new IOException());
+            });
+    assertThat(given.suppressed()).isNull();
+  }
+
+  @Test
+  public void shouldNotSuppressReadTimeoutForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new SocketTimeoutException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressConnectTimeoutForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new ConnectTimeoutException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressHttpErrorForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new WebApplicationException(404);
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  public interface ProcessingErrorsSuppressed {
+
+    @SuppressProcessingErrorsToNull
+    Object suppressed();
+  }
+}

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressReadTimeoutErrorsToNullTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/proxy/annotation/SuppressReadTimeoutErrorsToNullTest.java
@@ -1,0 +1,66 @@
+package org.sdase.commons.client.jersey.proxy.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.sdase.commons.client.jersey.proxy.ApiClientInvocationHandler.createProxy;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.WebApplicationException;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.junit.Test;
+import org.sdase.commons.client.jersey.error.ClientRequestException;
+
+public class SuppressReadTimeoutErrorsToNullTest {
+
+  @Test
+  public void shouldSuppressForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new SocketTimeoutException());
+            });
+    assertThat(given.suppressed()).isNull();
+  }
+
+  @Test
+  public void shouldNotSuppressConnectTimeoutForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new ConnectTimeoutException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressProcessingErrorForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new ProcessingException(new IOException());
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  @Test
+  public void shouldNotSuppressHttpErrorForObjectReturnType() {
+    ProcessingErrorsSuppressed given =
+        createProxy(
+            ProcessingErrorsSuppressed.class,
+            () -> {
+              throw new WebApplicationException(404);
+            });
+    assertThatExceptionOfType(ClientRequestException.class).isThrownBy(given::suppressed);
+  }
+
+  public interface ProcessingErrorsSuppressed {
+
+    @SuppressReadTimeoutErrorsToNull
+    Object suppressed();
+  }
+}


### PR DESCRIPTION
We realized, that client errors are handled in only two ways very often:

- some errors are mitigated in the same way, weather it is a 404 or a 403
- all other errors are rethrown to produce a 500 for the caller

Therefore we wrote a lot of code to catch, verify and handle exceptions.
This code can be avoided with the new suppression annotations.
Consumers may still handle exceptions for technical reasons, e.g. do a retry on connection errors, but use the suppression feature for business implementation if for example 404 is an expected result.