### PR TITLE
feat(starter): implement a new starter bundle with OpenApi 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Latest Release](https://img.shields.io/github/v/release/sda-se/sda-dropwizard-commons?label=latest)](https://github.com/SDA-SE/sda-dropwizard-commons/releases/latest)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.sdase.commons/sda-commons-server-starter/badge.svg)](https://search.maven.org/search?q=org.sdase.commons)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.sdase.commons/sda-commons-starter/badge.svg)](https://search.maven.org/search?q=org.sdase.commons)
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-bom/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/)
 [![Java CI](https://github.com/SDA-SE/sda-dropwizard-commons/workflows/Java%20CI/badge.svg)](https://github.com/SDA-SE/sda-dropwizard-commons/actions?query=branch%3Amaster+workflow%3A%22Java+CI%22)
 [![Publish Release to Maven Central](https://github.com/SDA-SE/sda-dropwizard-commons/workflows/Publish%20Release%20to%20Maven%20Central/badge.svg)](https://github.com/SDA-SE/sda-dropwizard-commons/actions?query=workflow%3A%22Publish+Release+to+Maven+Central%22)
@@ -71,10 +71,10 @@ The main server modules help to bootstrap and test a Dropwizard application with
 
 ##### Starter
 
-The module [`sda-commons-server-starter`](./sda-commons-server-starter/README.md) provides all basics required to build 
+The module [`sda-commons-starter`](./sda-commons-starter/README.md) provides all basics required to build 
 a service for the SDA Platform with Dropwizard.
 
-The module [`sda-commons-server-starter-example`](./sda-commons-server-starter-example/README.md) gives a small example 
+The module [`sda-commons-starter-example`](./sda-commons-starter-example/README.md) gives a small example 
 on starting an application using defaults for the SDA Platform.
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,8 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
   sonarqube {
     properties {
       property "sonar.coverage.jacoco.xmlReportPaths", '../build/reports/jacoco/report.xml'
+      // TODO: Cleanup after sda-commons-server-starter is removed.
+      property "sonar.cpd.exclusions", '**/sdase/commons/server/starter/**'
     }
   }
 

--- a/sda-commons-bom/README.md
+++ b/sda-commons-bom/README.md
@@ -16,7 +16,7 @@ Example for your `build.gradle`:
 dependencies {
     compile enforcedPlatform("org.sdase.commons:sda-commons-bom:$sdaCommonsVersion")
     compile enforcedPlatform("org.sdase.commons:sda-commons-dependencies:$sdaCommonsVersion")
-    compile "org.sdase.commons:sda-commons-server-starter"
+    compile "org.sdase.commons:sda-commons-starter"
     compile "org.sdase.commons:sda-commons-server-morphia"
     compile "org.sdase.commons:sda-commons-server-kafka"
     compile "org.sdase.commons:sda-commons-server-s3"
@@ -30,7 +30,7 @@ or if you prefer Gradle's `implementation`:
 dependencies {
     implementation enforcedPlatform("org.sdase.commons:sda-commons-bom:$sdaCommonsVersion")
     implementation enforcedPlatform("org.sdase.commons:sda-commons-dependencies:$sdaCommonsVersion")
-    implementation "org.sdase.commons:sda-commons-server-starter"
+    implementation "org.sdase.commons:sda-commons-starter"
     ...
 }
 ```

--- a/sda-commons-dependency-check/build.gradle
+++ b/sda-commons-dependency-check/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile project(':sda-commons-shared-forms')
   compile project(':sda-commons-shared-tracing')
   compile project(':sda-commons-shared-yaml')
+  compile project(':sda-commons-starter')
 }
 
 /**

--- a/sda-commons-server-auth/README.md
+++ b/sda-commons-server-auth/README.md
@@ -288,7 +288,7 @@ public class SecureEndPoint {
 To activate the OPA integration in an application, the bundle has to be added to the application. The Kubernetes file of the 
 service must also be adjusted to start OPA as sidecar.
 
-> If you use the SdaPlatformBundle, there is a [more convenient way to enable OPA support](../sda-commons-server-starter).
+> If you use the SdaPlatformBundle, there is a [more convenient way to enable OPA support](../sda-commons-starter).
 
 ```java
 public class MyApplication extends Application<MyConfiguration> {

--- a/sda-commons-server-openapi-example/README.md
+++ b/sda-commons-server-openapi-example/README.md
@@ -5,7 +5,7 @@ This example module shows an
 [`OpenApiBundle`](../sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiBundle.java)
 to describe REST endpoints with a OpenApi 3 documentation.
 
-Beside the initialization of the bundle via the [`SdaPlatformBundle`](../sda-commons-server-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java),
+Beside the initialization of the bundle via the [`SdaPlatformBundle`](../sda-commons-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java),
 it includes a [`PersonService`](src/main/java/org/sdase/commons/server/openapi/example/people/rest/PersonService.java) 
 and a [`PersonResource`](src/main/java/org/sdase/commons/server/openapi/example/people/rest/PersonResource.java)
 to demonstrate some cases of API documentation.

--- a/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
+++ b/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
@@ -3,10 +3,9 @@ package org.sdase.commons.server.openapi.example;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.sdase.commons.server.openapi.OpenApiBundle;
 import org.sdase.commons.server.openapi.example.people.rest.PersonEndpoint;
-import org.sdase.commons.server.starter.SdaPlatformBundle;
-import org.sdase.commons.server.starter.SdaPlatformConfiguration;
+import org.sdase.commons.starter.SdaPlatformBundle;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
 
 /** Example application to show how to document a REST api using swagger for the SDA platform. */
 public class OpenApiExampleApplication extends Application<SdaPlatformConfiguration> {
@@ -21,14 +20,11 @@ public class OpenApiExampleApplication extends Application<SdaPlatformConfigurat
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
             .withRequiredConsumerToken()
-            // disable the swagger integration until a replacement for the SdaPlatformBundle is
-            // present
-            .withoutSwagger()
+            // The following part configures the OpenApi bundle. It is required that the resource
+            // package
+            // class is configured.
+            .addOpenApiResourcePackageClass(getClass())
             .build());
-
-    // The following part configures the OpenApi bundle. It is required that the resource package
-    // class is configured.
-    bootstrap.addBundle(OpenApiBundle.builder().addResourcePackageClass(getClass()).build());
   }
 
   @Override

--- a/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
+++ b/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
@@ -19,10 +19,8 @@ public class OpenApiExampleApplication extends Application<SdaPlatformConfigurat
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             // The following part configures the OpenApi bundle. It is required that the resource
-            // package
-            // class is configured.
+            // package class is configured.
             .addOpenApiResourcePackageClass(getClass())
             .build());
   }

--- a/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
+++ b/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
@@ -13,9 +13,9 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.AuthRule;
 import org.sdase.commons.server.openapi.example.OpenApiExampleApplication;
-import org.sdase.commons.server.starter.SdaPlatformConfiguration;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
 
 // This is a simple integration test that checks whether the swagger documentation is produced at
 // the right path, however doesn't test the contents of the documentation.

--- a/sda-commons-server-openapi/README.md
+++ b/sda-commons-server-openapi/README.md
@@ -57,14 +57,6 @@ OpenApiBundle.builder()
     .addResourcePackage("my.package.containing.resources")
 ```
 
-The `embed` functionality is automatically documented to operations that return embeddable resources. This can be disabled if needed:
-
-```java
-OpenApiBundle.builder()
-//...
-    .disableEmbedParameter()
-```
-
 ## Further Information
 
 [Swagger-Core Annotations](https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations)

--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiBundle.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiBundle.java
@@ -219,13 +219,6 @@ public final class OpenApiBundle implements ConfiguredBundle<Configuration> {
   }
 
   public interface FinalBuilder extends InitialBuilder {
-    /**
-     * Disables automatic addition of the embed query parameter if embeddable resources are
-     * discovered.
-     *
-     * @return the builder.
-     */
-    FinalBuilder disableEmbedParameter();
 
     OpenApiBundle build();
   }
@@ -241,12 +234,6 @@ public final class OpenApiBundle implements ConfiguredBundle<Configuration> {
       addResourcePackageClass(HalLinkDescriptionModifier.class);
       addResourcePackageClass(EmbedParameterModifier.class);
       addResourcePackageClass(OpenAPISorter.class);
-    }
-
-    @Override
-    public FinalBuilder disableEmbedParameter() {
-      this.resourcePackages.remove(getResourcePackage(EmbedParameterModifier.class));
-      return this;
     }
 
     @Override

--- a/sda-commons-server-prometheus-example/build.gradle
+++ b/sda-commons-server-prometheus-example/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':sda-commons-server-starter')
+  compile project(':sda-commons-starter')
 
   testCompile project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
+++ b/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
@@ -3,9 +3,12 @@ package org.sdase.commons.server.prometheus.example;
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-import org.sdase.commons.server.starter.SdaPlatformBundle;
-import org.sdase.commons.server.starter.SdaPlatformConfiguration;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.sdase.commons.starter.SdaPlatformBundle;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
 
+@OpenAPIDefinition(info = @Info(title = "Metric Example App"))
 public class MetricExampleApp extends Application<SdaPlatformConfiguration> {
 
   public static void main(String[] args) throws Exception {
@@ -18,8 +21,7 @@ public class MetricExampleApp extends Application<SdaPlatformConfiguration> {
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
             .withRequiredConsumerToken()
-            .withSwaggerInfoTitle("Metric Example App")
-            .addSwaggerResourcePackageClass(this.getClass())
+            .addOpenApiResourcePackageClass(this.getClass())
             .build());
   }
 

--- a/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
+++ b/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
@@ -20,7 +20,6 @@ public class MetricExampleApp extends Application<SdaPlatformConfiguration> {
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build());
   }

--- a/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
+++ b/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
@@ -7,7 +7,7 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.starter.SdaPlatformConfiguration;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/sda-commons-starter-example/README.md
+++ b/sda-commons-starter-example/README.md
@@ -1,0 +1,25 @@
+# SDA Commons Starter Example
+
+This example module shows an 
+[application](./src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java) that uses the 
+[`SdaPlatformBundle`](../sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java)
+to bootstrap a Dropwizard application for use in the SDA Platform.
+
+Beside the initialization of the bundle, it includes a 
+[REST endpoint](./src/main/java/org/sdase/commons/starter/example/people/rest/PersonEndpoint.java) to demonstrate
+registration of endpoints to map resources.
+
+The 
+[integration test](./src/test/java/org/sdase/commons/serr/starter/example/SdaPlatformExampleApplicationIT.java) 
+shows how the application is bootstrapped in tests. The tests show the capabilities of a standard platform application.
+
+The provided [`local-config.yaml`](./local-config.yaml) allows to start the 
+[application](./src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java) without the 
+need for authentication locally using a run configuration of the favourite IDE that defines the program arguments 
+`server sda-commons-starter-example/local-config.yaml`. Note that there will be no data available and the example
+application does not provide POST endpoints. All that is available is an empty array at `GET /people` and the simple
+Swagger documentation at `GET /swagger.json` or `GET /swagger.yaml`
+
+The [`config.yaml`](./config.yaml) is an example how the application can be started in production. Such file should be 
+copied in the Docker container so that the variables can be populated using the environment configured by the 
+orchestration tool (e.g. Kubernetes).   

--- a/sda-commons-starter-example/build.gradle
+++ b/sda-commons-starter-example/build.gradle
@@ -3,4 +3,6 @@ dependencies {
 
   testCompile project(':sda-commons-server-testing')
   testCompile project(':sda-commons-server-auth-testing')
+
+  testCompile 'org.assertj:assertj-core'
 }

--- a/sda-commons-starter-example/config.yaml
+++ b/sda-commons-starter-example/config.yaml
@@ -1,0 +1,6 @@
+auth:
+  leeway: ${AUTH_LEEWAY:-0}
+  keys: ${AUTH_KEYS:-[]}
+
+cors:
+  allowedOrigins: ${CORS_ALLOWED_ORIGINS:-[]}

--- a/sda-commons-starter-example/config.yaml
+++ b/sda-commons-starter-example/config.yaml
@@ -2,5 +2,11 @@ auth:
   leeway: ${AUTH_LEEWAY:-0}
   keys: ${AUTH_KEYS:-[]}
 
+opa:
+  disableOpa: ${OPA_DISABLE:-false}
+  baseUrl: ${OPA_URL:-http://localhost:8181}
+  policyPackage: ${OPA_POLICY_PACKAGE:-<your_package>}
+  readTimeout: ${OPA_READ_TIMEOUT:-500}
+
 cors:
   allowedOrigins: ${CORS_ALLOWED_ORIGINS:-[]}

--- a/sda-commons-starter-example/local-config.yaml
+++ b/sda-commons-starter-example/local-config.yaml
@@ -1,0 +1,6 @@
+auth:
+  disableAuth: true
+
+cors:
+  allowedOrigins:
+  - "*"

--- a/sda-commons-starter-example/local-config.yaml
+++ b/sda-commons-starter-example/local-config.yaml
@@ -1,6 +1,9 @@
 auth:
   disableAuth: true
 
+opa:
+  disableOpa: true
+
 cors:
   allowedOrigins:
   - "*"

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
@@ -55,13 +55,8 @@ public class SdaPlatformExampleApplication extends Application<SdaPlatformConfig
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             // Use all defaults provided by the Server Starter module. OPA authorization is enabled
-            // automatically
-            //
+            // by default
             .usingSdaPlatformConfiguration()
-            // Require a consumer token from the client. Only swagger.json/yaml is always
-            // accessible.
-            // (from sda-commons-server-consumer)
-            .withRequiredConsumerToken()
             // Additional Swagger documentation properties may be set here until
             // the packages that should be scanned for Swagger documentation annotations are defined
             .addOpenApiResourcePackageClass(this.getClass())

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
@@ -1,0 +1,78 @@
+package org.sdase.commons.starter.example;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.sdase.commons.starter.SdaPlatformBundle;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
+import org.sdase.commons.starter.example.people.db.PersonManager;
+import org.sdase.commons.starter.example.people.rest.PersonEndpoint;
+
+/**
+ * Example application to show an easy approach to bootstrap a microservice for the SDA platform.
+ */
+@OpenAPIDefinition(
+    info =
+        @Info(
+            title = "SDA Platform Example Application",
+            description =
+                "This application is an example to show a developer how to create a SDA Dropwizard application",
+            version = "1.1.1",
+            contact =
+                @Contact(name = "John Doe", email = "info@example.com", url = "j.doe@example.com")))
+public class SdaPlatformExampleApplication extends Application<SdaPlatformConfiguration> {
+
+  public static void main(String[] args) throws Exception {
+    new SdaPlatformExampleApplication().run(args);
+  }
+
+  @Override
+  public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
+    // Add the starter bundle with minimal configuration includes
+    //   - Support for environment variables in config files
+    //     (from sda-commons-server-dropwizard)
+    //   - Adding a trace token to log messages
+    //     (from sda-commons-server-trace)
+    //   - CORS for Domains as defined in the configuration (may be none)
+    //     (from sda-commons-server-cors)
+    //   - Tolerant Jackson configuration
+    //     (from sda-commons-server-jackson)
+    //   - Custom error mappers for SDA compliant error messages
+    //     (from sda-commons-server-jackson)
+    //   - Support for Json responses with reduced properties by /myResource?fields=id,...
+    //     (from sda-commons-server-jackson)
+    //   - HAL support
+    //     (from sda-commons-server-jackson)
+    //   - Security checks at startup
+    //     (from sda-commons-server-security)
+    //   - Prometheus metrics
+    //     (from sda-commons-server-prometheus)
+    //   - OpenID Connect authentication (use @PermitAll to allow only access for identified users)
+    //     (from sda-commons-server-auth)
+    bootstrap.addBundle(
+        SdaPlatformBundle.builder()
+            // Use all defaults provided by the Server Starter module
+            .usingSdaPlatformConfiguration()
+            // Require a consumer token from the client. Only swagger.json/yaml is always
+            // accessible.
+            // (from sda-commons-server-consumer)
+            .withRequiredConsumerToken()
+            // Additional Swagger documentation properties may be set here until
+            // the packages that should be scanned for Swagger documentation annotations are defined
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build());
+  }
+
+  @Override
+  public void run(SdaPlatformConfiguration configuration, Environment environment) {
+    // build endpoint with it's dependencies
+    PersonManager personManager = new PersonManager();
+    PersonEndpoint personEndpoint = new PersonEndpoint(personManager);
+
+    // register endpoint to map the resources
+    environment.jersey().register(personEndpoint);
+  }
+}

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
@@ -54,7 +54,9 @@ public class SdaPlatformExampleApplication extends Application<SdaPlatformConfig
     //     (from sda-commons-server-auth)
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
-            // Use all defaults provided by the Server Starter module
+            // Use all defaults provided by the Server Starter module. OPA authorization is enabled
+            // automatically
+            //
             .usingSdaPlatformConfiguration()
             // Require a consumer token from the client. Only swagger.json/yaml is always
             // accessible.

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/db/PersonEntity.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/db/PersonEntity.java
@@ -1,0 +1,42 @@
+package org.sdase.commons.starter.example.people.db;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Example persistent entity holding information about a person. */
+public class PersonEntity {
+
+  private String id;
+
+  private String firstName;
+  private String lastName;
+
+  private List<PersonEntity> children = new ArrayList<>();
+  private List<PersonEntity> parents = new ArrayList<>();
+
+  PersonEntity(String id, String firstName, String lastName) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public List<PersonEntity> getChildren() {
+    return children;
+  }
+
+  public List<PersonEntity> getParents() {
+    return parents;
+  }
+}

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/db/PersonManager.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/db/PersonManager.java
@@ -1,0 +1,25 @@
+package org.sdase.commons.starter.example.people.db;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Mock implementation of a database manager for {@link PersonEntity}. */
+public class PersonManager {
+
+  /**
+   * The mock of the underlying people database contains the family Jane, John and Jasmine Doe
+   * initially. It is not private in this example to initialize test data. Usually a data base rule
+   * for the used db will be used to populate test data.
+   */
+  static final Map<String, PersonEntity> peopleDatabase = new LinkedHashMap<>();
+
+  public List<PersonEntity> findAll() {
+    return new ArrayList<>(peopleDatabase.values());
+  }
+
+  public PersonEntity findById(String id) {
+    return peopleDatabase.get(id);
+  }
+}

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/rest/PersonEndpoint.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/rest/PersonEndpoint.java
@@ -1,0 +1,111 @@
+package org.sdase.commons.starter.example.people.rest;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.UriInfo;
+import org.sdase.commons.server.dropwizard.ContextAwareEndpoint;
+import org.sdase.commons.starter.example.people.db.PersonEntity;
+import org.sdase.commons.starter.example.people.db.PersonManager;
+
+/** Example endpoint for getting information about people. */
+@Path("people") // define the base path of this endpoint
+@Produces({
+  APPLICATION_JSON,
+  "application/hal+json"
+}) // should be set to produce 406 for other accept headers
+@Consumes({APPLICATION_JSON}) // should be set to produce 406 for other accept headers
+@PermitAll // Require authentication for this endpoint
+public class PersonEndpoint implements ContextAwareEndpoint {
+
+  /**
+   * Information about the requested URI. Jersey will inject a Proxy of {@code UriInfo} that is
+   * aware of the request scope.
+   */
+  @Context private UriInfo uriInfo;
+
+  private PersonManager personManager;
+
+  public PersonEndpoint(PersonManager personManager) {
+    this.personManager = personManager;
+  }
+
+  @GET // maps to "GET /people"
+  public List<PersonResource> findAllPeople() {
+    return personManager.findAll().stream().map(this::toResource).collect(Collectors.toList());
+  }
+
+  @GET
+  @Path("{personId}") // maps to "GET /people/{personId}, e.g. "GET /people/john-doe"
+  public PersonResource findPersonById(@PathParam("personId") String personId) {
+    PersonEntity personEntity = personManager.findById(personId);
+    if (personEntity == null) {
+      throw new NotFoundException();
+    }
+    return toResource(personEntity);
+  }
+
+  /**
+   * Creates a {@link PersonResource} representing the given {@link PersonEntity}. We do not want to
+   * expose the underlying entities to our consumers. This way our API is independent from the
+   * internal model which may be changed with an appropriate migration at any time. Especially when
+   * using HAL resources, we have the {@code _links} as dynamic content that is not persisted with
+   * our entity.
+   *
+   * @param personEntity the entity that should be exposed as {@link PersonResource}
+   * @return the {@link PersonResource} containing links to the {@linkplain
+   *     PersonEntity#getChildren() children} and {@linkplain PersonEntity#getParents() parents} of
+   *     the {@code personEntity} instead of embedding all the data.
+   */
+  private PersonResource toResource(PersonEntity personEntity) {
+    String id = personEntity.getId();
+    PersonResource personResource =
+        new PersonResource()
+            .setFirstName(personEntity.getFirstName())
+            .setLastName(personEntity.getLastName())
+            .setSelfLink(new HALLink.Builder(personLocation(id)).build());
+    if (personEntity.getChildren() != null && !personEntity.getChildren().isEmpty()) {
+      personResource.setChildrenLinks(
+          personEntity.getChildren().stream()
+              .map(PersonEntity::getId)
+              .map(this::personLocation)
+              .map(HALLink.Builder::new)
+              .map(HALLink.Builder::build)
+              .collect(Collectors.toList()));
+    }
+    if (personEntity.getParents() != null && !personEntity.getParents().isEmpty()) {
+      personResource.setParentsLinks(
+          personEntity.getParents().stream()
+              .map(PersonEntity::getId)
+              .map(this::personLocation)
+              .map(HALLink.Builder::new)
+              .map(HALLink.Builder::build)
+              .collect(Collectors.toList()));
+    }
+    return personResource;
+  }
+
+  /**
+   * Creates the location to the {@link PersonEntity} with the given {@code id}. The location is
+   * based on the base URI of the request context and therefore will contain the same protocol, host
+   * and port the client used in the current request.
+   *
+   * @param id the {@linkplain PersonEntity#getId() id} of the {@link PersonEntity} the link should
+   *     be created for.
+   * @return the location of the {@link PersonEntity} in the context of the current request.
+   */
+  private URI personLocation(String id) {
+    return uriInfo.getBaseUriBuilder().path(PersonEndpoint.class).path(id).build();
+  }
+}

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/rest/PersonResource.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/people/rest/PersonResource.java
@@ -1,0 +1,72 @@
+package org.sdase.commons.starter.example.people.rest;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.annotation.Link;
+import io.openapitools.jackson.dataformat.hal.annotation.Resource;
+import java.util.List;
+import org.sdase.commons.starter.example.people.db.PersonEntity;
+
+/** Example resource representing {@link PersonEntity} in the REST API */
+@Resource
+public class PersonResource {
+
+  @Link("self")
+  private HALLink selfLink;
+
+  @Link("children")
+  private List<HALLink> childrenLinks;
+
+  @Link("parents")
+  private List<HALLink> parentsLinks;
+
+  private String firstName;
+  private String lastName;
+
+  @SuppressWarnings("unused") // required for jackson
+  public HALLink getSelfLink() {
+    return selfLink;
+  }
+
+  PersonResource setSelfLink(HALLink selfLink) {
+    this.selfLink = selfLink;
+    return this;
+  }
+
+  @SuppressWarnings("unused") // required for jackson
+  public String getFirstName() {
+    return firstName;
+  }
+
+  PersonResource setFirstName(String firstName) {
+    this.firstName = firstName;
+    return this;
+  }
+
+  @SuppressWarnings("unused") // required for jackson
+  public String getLastName() {
+    return lastName;
+  }
+
+  PersonResource setLastName(String lastName) {
+    this.lastName = lastName;
+    return this;
+  }
+
+  @SuppressWarnings("unused") // required for jackson
+  public List<HALLink> getChildrenLinks() {
+    return childrenLinks;
+  }
+
+  void setChildrenLinks(List<HALLink> childrenLinks) {
+    this.childrenLinks = childrenLinks;
+  }
+
+  @SuppressWarnings("unused") // required for jackson
+  public List<HALLink> getParentsLinks() {
+    return parentsLinks;
+  }
+
+  void setParentsLinks(List<HALLink> parentsLinks) {
+    this.parentsLinks = parentsLinks;
+  }
+}

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
@@ -1,0 +1,150 @@
+package org.sdase.commons.starter.example;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.Arrays.asList;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import java.util.List;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.auth.testing.AuthRule;
+import org.sdase.commons.shared.tracing.ConsumerTracing;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
+import org.sdase.commons.starter.example.people.db.PersonEntity;
+import org.sdase.commons.starter.example.people.db.TestDataUtil;
+import org.sdase.commons.starter.example.people.rest.PersonResource;
+
+public class SdaPlatformExampleApplicationIT {
+
+  // create a dummy authentication provider that works as a local OpenId Connect provider for the
+  // tests
+  private static final AuthRule AUTH = AuthRule.builder().build();
+
+  public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
+      // Setup a test instance of the application
+      new DropwizardAppRule<>(
+          SdaPlatformExampleApplication.class,
+          // use the config file 'test-config.yaml' from the test resources folder
+          resourceFilePath("test-config.yaml"));
+
+  // apply the auth config to the test instance of the application
+  // to verify incoming tokens correctly
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(AUTH).around(DW);
+
+  private static final String TEST_CONSUMER_TOKEN = "test-consumer";
+
+  @Before
+  public void setupTestData() {
+    TestDataUtil.clearTestData();
+    PersonEntity john = TestDataUtil.addPersonEntity("john-doe", "John", "Doe");
+    PersonEntity jane = TestDataUtil.addPersonEntity("jane-doe", "Jane", "Doe");
+    TestDataUtil.addPersonEntity("jasmine-doe", "Jasmine", "Doe", asList(john, jane));
+  }
+
+  @Test
+  public void accessSwaggerWithoutAuthentication() {
+    Response response = baseUrlWebTarget().path("openapi.json").request(APPLICATION_JSON).get();
+
+    assertThat(response).extracting(Response::getStatus).isEqualTo(200);
+  }
+
+  @Test
+  public void rejectApiRequestWithoutAuthentication() {
+    Response response =
+        baseUrlWebTarget()
+            .path("people")
+            .request(APPLICATION_JSON) // NOSONAR
+            .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+
+  @Test
+  public void rejectApiRequestWithoutConsumerToken() {
+    Response response =
+        baseUrlWebTarget()
+            .path("people")
+            .request(APPLICATION_JSON)
+            .headers(AUTH.auth().buildAuthHeader())
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(401);
+  }
+
+  @Test
+  public void accessApiWithAuthenticationAndConsumerToken() {
+    Response response =
+        baseUrlWebTarget()
+            .path("people")
+            .request(APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, AUTH.auth().buildHeaderValue())
+            .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(200);
+  }
+
+  @Test
+  public void respond404ForUnknownPerson() {
+    Response response =
+        baseUrlWebTarget()
+            .path("people")
+            .path("jamie-doe")
+            .request(APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, AUTH.auth().buildHeaderValue())
+            .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
+            .get();
+
+    assertThat(response).extracting(Response::getStatus).isEqualTo(404);
+  }
+
+  @Test
+  public void provideSelfLinkInPersonResource() {
+    PersonResource personResource =
+        baseUrlWebTarget()
+            .path("people")
+            .path("john-doe")
+            .request(APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, AUTH.auth().buildHeaderValue())
+            .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
+            .get(PersonResource.class);
+
+    String expectedSelfUri = baseUrlWebTarget().getUri().toASCIIString() + "/people/john-doe";
+    HALLink actualSelf = personResource.getSelfLink();
+    assertThat(actualSelf).extracting(HALLink::getHref).isEqualTo(expectedSelfUri);
+  }
+
+  @Test
+  public void provideRelationLinksInPersonResource() {
+    PersonResource personResource =
+        baseUrlWebTarget()
+            .path("people")
+            .path("jasmine-doe")
+            .request(APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, AUTH.auth().buildHeaderValue())
+            .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
+            .get(PersonResource.class);
+
+    String expectedJohnUri = baseUrlWebTarget().getUri().toASCIIString() + "/people/john-doe";
+    String expectedJaneUri = baseUrlWebTarget().getUri().toASCIIString() + "/people/jane-doe";
+    List<HALLink> actualParentsLinks = personResource.getParentsLinks();
+    assertThat(actualParentsLinks)
+        .extracting(HALLink::getHref)
+        .containsExactlyInAnyOrder(expectedJohnUri, expectedJaneUri);
+    List<HALLink> actualChildrenLinks = personResource.getChildrenLinks();
+    assertThat(actualChildrenLinks).isNullOrEmpty();
+  }
+
+  private WebTarget baseUrlWebTarget() {
+    return DW.client().target(String.format("http://localhost:%d", DW.getLocalPort()));
+  }
+}

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
@@ -75,18 +75,6 @@ public class SdaPlatformExampleApplicationIT {
   }
 
   @Test
-  public void rejectApiRequestWithoutConsumerToken() {
-    Response response =
-        baseUrlWebTarget()
-            .path("people")
-            .request(APPLICATION_JSON)
-            .headers(AUTH.auth().buildAuthHeader())
-            .get();
-
-    assertThat(response.getStatus()).isEqualTo(401);
-  }
-
-  @Test
   public void accessApiWithAuthenticationAndConsumerToken() {
     OPA.mock(onAnyRequest().allow());
     Response response =

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/people/db/TestDataUtil.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/people/db/TestDataUtil.java
@@ -1,0 +1,29 @@
+package org.sdase.commons.starter.example.people.db;
+
+import java.util.List;
+
+public class TestDataUtil {
+
+  private TestDataUtil() {
+    // utility class
+  }
+
+  public static void clearTestData() {
+    PersonManager.peopleDatabase.clear();
+  }
+
+  public static PersonEntity addPersonEntity(String id, String firstName, String lastName) {
+    return addPersonEntity(id, firstName, lastName, null);
+  }
+
+  public static PersonEntity addPersonEntity(
+      String id, String firstName, String lastName, List<PersonEntity> parents) {
+    PersonEntity entity = new PersonEntity(id, firstName, lastName);
+    if (parents != null) {
+      entity.getParents().addAll(parents);
+      parents.forEach(parent -> parent.getChildren().add(entity));
+    }
+    PersonManager.peopleDatabase.put(id, entity);
+    return entity;
+  }
+}

--- a/sda-commons-starter-example/src/test/resources/test-config.yaml
+++ b/sda-commons-starter-example/src/test/resources/test-config.yaml
@@ -1,0 +1,12 @@
+# use random ports so that tests can run in parallel
+# and do not affect each other when one is not shutting down
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+
+# The configuration of the test auth bundle is injected here
+auth: ${AUTH_RULE}

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -1,0 +1,116 @@
+# SDA Commons Starter
+
+[![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-starter/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-starter)
+
+The module `sda-commons-starter` provides all basics required to build a service for the SDA Platform with
+Dropwizard.
+
+Apps built with the [`SdaPlatformBundle`](./src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java)
+automatically contain
+
+- [Support for environment variables in configuration files and default console appender configuration](../sda-commons-server-dropwizard/README.md)
+- [Trace Token support](../sda-commons-server-trace/README.md)
+- [a tolerant `ObjectMapper`, HAL support and a field filter](../sda-commons-server-jackson/README.md)
+- [Security checks on startup](../sda-commons-server-security/README.md)
+- [Authentication support](../sda-commons-server-auth/README.md)
+- [Prometheus metrics](../sda-commons-server-prometheus/README.md)
+- [OpenApi documentation](../sda-commons-server-openapi/README.md)
+- [Open Tracing](../sda-commons-server-opentracing/README.md) and [Jaeger](../sda-commons-server-jaeger/README.md)
+
+They may be configured easily to
+
+- [require a Consumer token from clients](../sda-commons-server-consumer/README.md)
+- [allow cross origin resource sharing](../sda-commons-server-cors/README.md)
+- [use the Open Policy Agent for authorization](../sda-commons-server-auth/README.md)
+
+Using the [`SdaPlatformBundle`](./src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java) is the easiest
+and fastest way to create a service for the SDA Platform.
+
+To bootstrap a Dropwizard application for the SDA Platform only the 
+[`SdaPlatformBundle`](./src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java) has to be added. The 
+API should be documented with Swagger annotations: 
+
+```java
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import SdaPlatformBundle;
+import SdaPlatformConfiguration;
+
+@OpenAPIDefinition(info = @Info(
+    title = "My First App",
+    description =
+        "The description of my first application",
+    version = "1.0.0",
+    contact =
+    @Contact(
+        name = "John Doe",
+        email = "info@example.com",
+        url = "j.doe@example.com"),
+    license = @License(name = "Sample License")))
+public class MyFirstApp extends Application<SdaPlatformConfiguration> {
+
+   public static void main(String[] args) throws Exception {
+      new MyFirstApp().run(args);
+   }
+
+   @Override
+   public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
+      bootstrap.addBundle(SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            // more Swagger data that may also be added with annotations
+            .addSwaggerResourcePackageClass(this.getClass())
+            // or use an existing OpenApi definition
+            .withExistingOpenAPI("openApiJsonOrYaml")
+            .build());
+   }
+
+   @Override
+   public void run(SdaPlatformConfiguration configuration, Environment environment) {
+      environment.jersey().register(MyFirstEndpoint.class);
+   }
+
+}
+```
+
+The [`SdaPlatformConfiguration`](./src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java) may be
+extended to add application specific configuration properties.
+
+The `config.yaml` of the 
+[`SdaPlatformConfiguration`](./src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java) supports
+configuration of [authentication](../sda-commons-server-auth/README.md) and [CORS](../sda-commons-server-cors/README.md)
+additionally to the defaults of Dropwizard's `Configuration`:
+
+```yaml
+
+# See sda-commons-server-auth
+auth:
+  disableAuth: ${DISABLE_AUTH:-false}
+  leeway: ${AUTH_LEEWAY:-0}
+  keys: ${AUTH_KEYS:-[]}
+
+# See sda-commons-server-cors
+cors:
+  # List of origins that are allowed to use the service. "*" allows all origins
+  allowedOrigins:
+    - "*"
+  # Alternative: If the origins should be restricted, you should add the pattern
+  # allowedOrigins:
+  #    - https://*.sdase.com
+  #    - https://*test.sdase.com
+  # To use configurable patterns per environment the Json in Yaml syntax may be used with an environment placeholder:
+  # allowedOrigins: ${CORS_ALLOWED_ORIGINS:-["*"]}
+```
+
+Instead of `.usingSdaPlatformConfiguration()`, the configuration may be fully customized using 
+`.usingCustomConfig(MyCustomConfiguration.class)` to support configurations that do not extend 
+[`SdaPlatformConfiguration`](./src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java). This may 
+also be needed to disable some features of the starter module or add special features such as
+Authorization.
+
+Please note that `.withOpaAuthorization(MyConfiguration::getAuth, MyConfiguration::getOpa)`
+will configure the `AuthBundle` to use `.withExternalAuthorization()`. Please read the 
+[documentation of the Auth Bundle](../sda-commons-server-auth/README.md) carefully before
+using this option.

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -91,6 +91,12 @@ auth:
   leeway: ${AUTH_LEEWAY:-0}
   keys: ${AUTH_KEYS:-[]}
 
+opa:
+  disableOpa: ${OPA_DISABLE:-false}
+  baseUrl: ${OPA_URL:-http://localhost:8181}
+  policyPackage: ${OPA_POLICY_PACKAGE:-<your_package>}
+  readTimeout: ${OPA_READ_TIMEOUT:-500}
+
 # See sda-commons-server-cors
 cors:
   # List of origins that are allowed to use the service. "*" allows all origins
@@ -104,7 +110,10 @@ cors:
   # allowedOrigins: ${CORS_ALLOWED_ORIGINS:-["*"]}
 ```
 
-Instead of `.usingSdaPlatformConfiguration()`, the configuration may be fully customized using 
+By using `.usingSdaPlatformConfiguration()` or `.usingSdaPlatformConfiguration(MyCustomConfiguration.class)` 
+the authorization including the open policy agent are automatically enabled as well as the cors settings. 
+
+Instead of `.usingSdaPlatformConfiguration()` and `.usingSdaPlatformConfiguration(MyCustomConfiguration.class)`, the configuration may be fully customized using 
 `.usingCustomConfig(MyCustomConfiguration.class)` to support configurations that do not extend 
 [`SdaPlatformConfiguration`](./src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java). This may 
 also be needed to disable some features of the starter module or add special features such as

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -2,6 +2,11 @@
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-starter/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-starter)
 
+> #### ⚠️ Experimental ⚠
+>
+> Please be aware that this API is in an early stage and might change in the future.
+>
+
 The module `sda-commons-starter` provides all basics required to build a service for the SDA Platform with
 Dropwizard.
 
@@ -58,8 +63,8 @@ public class MyFirstApp extends Application<SdaPlatformConfiguration> {
    public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
       bootstrap.addBundle(SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            // more Swagger data that may also be added with annotations
-            .addSwaggerResourcePackageClass(this.getClass())
+            // more Open API data that may also be added with annotations
+            .addOpenApiResourcePackageClass(this.getClass())
             // or use an existing OpenApi definition
             .withExistingOpenAPI("openApiJsonOrYaml")
             .build());

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -19,7 +19,6 @@ automatically contain
 
 They may be configured easily to
 
-- [require a Consumer token from clients](../sda-commons-server-consumer/README.md)
 - [allow cross origin resource sharing](../sda-commons-server-cors/README.md)
 - [use the Open Policy Agent for authorization](../sda-commons-server-auth/README.md)
 
@@ -59,7 +58,6 @@ public class MyFirstApp extends Application<SdaPlatformConfiguration> {
    public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
       bootstrap.addBundle(SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             // more Swagger data that may also be added with annotations
             .addSwaggerResourcePackageClass(this.getClass())
             // or use an existing OpenApi definition

--- a/sda-commons-starter/build.gradle
+++ b/sda-commons-starter/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   compile project(':sda-commons-server-trace')
 
   testCompile project(':sda-commons-server-testing')
+  testCompile project(':sda-commons-server-auth-testing')
 }
 
 test {

--- a/sda-commons-starter/build.gradle
+++ b/sda-commons-starter/build.gradle
@@ -1,0 +1,21 @@
+dependencies {
+  compile project(':sda-commons-server-auth')
+  compile project(':sda-commons-server-consumer')
+  compile project(':sda-commons-server-cors')
+  compile project(':sda-commons-server-dropwizard')
+  compile project(':sda-commons-server-healthcheck')
+  compile project(':sda-commons-server-jackson')
+  compile project(':sda-commons-server-jaeger')
+  compile project(':sda-commons-server-openapi')
+  compile project(':sda-commons-server-opentracing')
+  compile project(':sda-commons-server-prometheus')
+  compile project(':sda-commons-server-security')
+  compile project(':sda-commons-server-trace')
+
+  testCompile project(':sda-commons-server-testing')
+}
+
+test {
+  // We need to disable this property, otherwise Jersey doesn't allow to set the Origin header
+  systemProperty "sun.net.http.allowRestrictedHeaders", "true"
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
@@ -150,8 +150,14 @@ public class SdaPlatformBundle<C extends Configuration> implements ConfiguredBun
 
     @Override
     public ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration() {
-      return usingCustomConfig(SdaPlatformConfiguration.class)
-          .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
+      return usingSdaPlatformConfiguration(SdaPlatformConfiguration.class);
+    }
+
+    @Override
+    public <T extends SdaPlatformConfiguration>
+        ConsumerTokenConfigBuilder<T> usingSdaPlatformConfiguration(Class<T> configurationClass) {
+      return usingCustomConfig(configurationClass)
+          .withOpaAuthorization(SdaPlatformConfiguration::getAuth, SdaPlatformConfiguration::getOpa)
           .withCorsConfigProvider(SdaPlatformConfiguration::getCors);
     }
 

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
@@ -1,0 +1,346 @@
+package org.sdase.commons.starter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import org.sdase.commons.server.auth.AuthBundle;
+import org.sdase.commons.server.auth.config.AuthConfigProvider;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle.ConsumerTokenConfigProvider;
+import org.sdase.commons.server.consumer.ConsumerTokenConfig;
+import org.sdase.commons.server.cors.CorsBundle;
+import org.sdase.commons.server.cors.CorsConfigProvider;
+import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
+import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBundle;
+import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
+import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
+import org.sdase.commons.server.jaeger.JaegerBundle;
+import org.sdase.commons.server.opa.OpaBundle;
+import org.sdase.commons.server.opa.OpaBundle.OpaBuilder;
+import org.sdase.commons.server.opa.config.OpaConfigProvider;
+import org.sdase.commons.server.openapi.OpenApiBundle;
+import org.sdase.commons.server.opentracing.OpenTracingBundle;
+import org.sdase.commons.server.prometheus.PrometheusBundle;
+import org.sdase.commons.server.security.SecurityBundle;
+import org.sdase.commons.server.trace.TraceTokenBundle;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenRequiredConfigInitialBuilder;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.CorsConfigProviderBuilder;
+import org.sdase.commons.starter.builder.InitialPlatformBundleBuilder;
+import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiFinalBuilder;
+import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
+import org.sdase.commons.starter.builder.PlatformBundleBuilder;
+
+/**
+ * A {@link ConfiguredBundle} that configures the application with the basics required for a SDA
+ * platform compatible microservice.
+ */
+public class SdaPlatformBundle<C extends Configuration> implements ConfiguredBundle<C> {
+
+  private SecurityBundle.Builder securityBundleBuilder;
+  private JacksonConfigurationBundle.Builder jacksonConfigurationBundleBuilder;
+  private AuthBundle.AuthBuilder<C> authBundleBuilder;
+  private OpaBuilder<C> opaBundleBuilder;
+  private CorsBundle.FinalBuilder<C> corsBundleBuilder;
+  private ConsumerTokenBundle.FinalBuilder<C> consumerTokenBundleBuilder;
+  private OpenApiBundle.FinalBuilder openApiBundleBuilder;
+
+  private SdaPlatformBundle(
+      SecurityBundle.Builder securityBundleBuilder,
+      JacksonConfigurationBundle.Builder jacksonConfigurationBundleBuilder,
+      AuthBundle.AuthBuilder<C> authBundleBuilder,
+      OpaBundle.OpaBuilder<C> opaBundleBuilder,
+      CorsBundle.FinalBuilder<C> corsBundleBuilder,
+      ConsumerTokenBundle.FinalBuilder<C> consumerTokenBundleBuilder,
+      OpenApiBundle.FinalBuilder openApiBundleBuilder) {
+    this.securityBundleBuilder = securityBundleBuilder;
+    this.jacksonConfigurationBundleBuilder = jacksonConfigurationBundleBuilder;
+    this.authBundleBuilder = authBundleBuilder;
+    this.opaBundleBuilder = opaBundleBuilder;
+    this.corsBundleBuilder = corsBundleBuilder;
+    this.consumerTokenBundleBuilder = consumerTokenBundleBuilder;
+    this.openApiBundleBuilder = openApiBundleBuilder;
+  }
+
+  public static InitialPlatformBundleBuilder builder() {
+    return new InitialBuilder<>();
+  }
+
+  @Override
+  public void initialize(Bootstrap<?> bootstrap) {
+
+    // add normal bundles
+    bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build());
+    bootstrap.addBundle(DefaultLoggingConfigurationBundle.builder().build());
+    bootstrap.addBundle(InternalHealthCheckEndpointBundle.builder().build());
+    bootstrap.addBundle(JaegerBundle.builder().build());
+    bootstrap.addBundle(OpenTracingBundle.builder().build());
+    bootstrap.addBundle(PrometheusBundle.builder().build());
+    bootstrap.addBundle(TraceTokenBundle.builder().build());
+
+    // add configured bundles
+    List<ConfiguredBundle<? super C>> configuredBundles = new ArrayList<>();
+    configuredBundles.add(jacksonConfigurationBundleBuilder.build());
+    configuredBundles.add(securityBundleBuilder.build());
+    configuredBundles.add(openApiBundleBuilder.build());
+    if (authBundleBuilder != null) {
+      configuredBundles.add(authBundleBuilder.build());
+    }
+    if (opaBundleBuilder != null) {
+      configuredBundles.add(opaBundleBuilder.build());
+    }
+    if (corsBundleBuilder != null) {
+      configuredBundles.add(corsBundleBuilder.build());
+    }
+    if (consumerTokenBundleBuilder != null) {
+      configuredBundles.add(consumerTokenBundleBuilder.build());
+    }
+    configuredBundles.stream().map(b -> (ConfiguredBundle) b).forEach(bootstrap::addBundle);
+  }
+
+  @Override
+  public void run(C configuration, Environment environment) {
+    // not needed for the platform bundle, created bundles are added in initialize
+  }
+
+  public static class InitialBuilder<C extends Configuration>
+      implements InitialPlatformBundleBuilder,
+          AuthConfigProviderBuilder<C>,
+          CorsConfigProviderBuilder<C>,
+          ConsumerTokenConfigBuilder<C>,
+          ConsumerTokenRequiredConfigInitialBuilder<C>,
+          OpenApiInitialBuilder<C>,
+          OpenApiFinalBuilder<C>,
+          PlatformBundleBuilder<C> {
+
+    private AuthBundle.AuthBuilder<C> authBundleBuilder;
+    private OpaBundle.OpaBuilder<C> opaBundleBuilder;
+    private ConsumerTokenConfig consumerTokenConfig;
+    private ConsumerTokenBundle.FinalBuilder<C> consumerTokenBundleBuilder;
+    private SecurityBundle.Builder securityBundleBuilder = SecurityBundle.builder();
+    private JacksonConfigurationBundle.Builder jacksonBundleBuilder =
+        JacksonConfigurationBundle.builder();
+    private CorsBundle.FinalBuilder<C> corsBundleBuilder;
+    private OpenApiBundle.FinalBuilder openApiBundleBuilder;
+
+    private InitialBuilder() {}
+
+    // Final step
+
+    @Override
+    public SdaPlatformBundle<C> build() {
+      return new SdaPlatformBundle<>(
+          securityBundleBuilder,
+          jacksonBundleBuilder,
+          authBundleBuilder,
+          opaBundleBuilder,
+          corsBundleBuilder,
+          consumerTokenBundleBuilder,
+          openApiBundleBuilder);
+    }
+
+    // InitialBuilder
+
+    @Override
+    public ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration() {
+      return usingCustomConfig(SdaPlatformConfiguration.class)
+          .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
+          .withCorsConfigProvider(SdaPlatformConfiguration::getCors);
+    }
+
+    @Override
+    public <T extends Configuration> AuthConfigProviderBuilder<T> usingCustomConfig(
+        Class<T> configurationClass) {
+      return new InitialBuilder<>();
+    }
+
+    // CustomConfigurationProviders and follow up configuration providers
+
+    @Override
+    public CorsConfigProviderBuilder<C> withoutAuthentication() {
+      return this;
+    }
+
+    @Override
+    public CorsConfigProviderBuilder<C> withAuthConfigProvider(
+        AuthConfigProvider<C> authConfigProvider) {
+      this.authBundleBuilder =
+          AuthBundle.builder()
+              .withAuthConfigProvider(authConfigProvider)
+              .withAnnotatedAuthorization();
+      return this;
+    }
+
+    @Override
+    public CorsConfigProviderBuilder<C> withOpaAuthorization(
+        AuthConfigProvider<C> authConfigProvider, OpaConfigProvider<C> opaConfigProvider) {
+      this.authBundleBuilder =
+          AuthBundle.builder()
+              .withAuthConfigProvider(authConfigProvider)
+              .withExternalAuthorization();
+      this.opaBundleBuilder = OpaBundle.builder().withOpaConfigProvider(opaConfigProvider);
+      return this;
+    }
+
+    @Override
+    public ConsumerTokenConfigBuilder<C> withoutCorsSupport() {
+      return this;
+    }
+
+    @Override
+    public ConsumerTokenConfigBuilder<C> withCorsConfigProvider(
+        CorsConfigProvider<C> corsConfigProvider) {
+      this.corsBundleBuilder = CorsBundle.builder().withCorsConfigProvider(corsConfigProvider);
+      return this;
+    }
+
+    @Override
+    public OpenApiInitialBuilder<C> withoutConsumerTokenSupport() {
+      return this;
+    }
+
+    @Override
+    public OpenApiInitialBuilder<C> withOptionalConsumerToken() {
+      consumerTokenConfig = new ConsumerTokenConfig();
+      consumerTokenConfig.setOptional(true);
+      this.consumerTokenBundleBuilder =
+          ConsumerTokenBundle.builder().withConfigProvider(c -> consumerTokenConfig);
+      return this;
+    }
+
+    @Override
+    public ConsumerTokenRequiredConfigInitialBuilder<C> withRequiredConsumerToken() {
+      consumerTokenConfig = new ConsumerTokenConfig();
+      consumerTokenConfig.setOptional(false);
+      this.consumerTokenBundleBuilder =
+          ConsumerTokenBundle.builder().withConfigProvider(c -> consumerTokenConfig);
+      return this;
+    }
+
+    @Override
+    public OpenApiInitialBuilder<C> withConsumerTokenConfigProvider(
+        ConsumerTokenConfigProvider<C> consumerTokenConfigProvider) {
+      this.consumerTokenBundleBuilder =
+          ConsumerTokenBundle.builder().withConfigProvider(consumerTokenConfigProvider);
+      return this;
+    }
+
+    @Override
+    public OpenApiInitialBuilder<C> withExcludePatternsForRequiredConsumerToken(String... regex) {
+      if (this.consumerTokenConfig == null) {
+        throw new IllegalStateException(
+            "ConsumerToken support can't be configured because it is disabled.");
+      }
+      this.consumerTokenConfig.getExcludePatterns().addAll(Arrays.asList(regex));
+      return this;
+    }
+
+    // PlatformBundleBuilder contains programmatic configuration
+
+    @Override
+    public PlatformBundleBuilder<C> disableBufferLimitValidationSecurityFeature() {
+      this.securityBundleBuilder = SecurityBundle.builder().disableBufferLimitValidation();
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withCorsAllowedMethods(String... httpMethods) {
+      validateConfigureCors();
+      this.corsBundleBuilder.withAllowedMethods(httpMethods);
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withCorsAdditionalAllowedHeaders(
+        String... additionalAllowedHeaders) {
+      validateConfigureCors();
+      this.corsBundleBuilder.withAdditionalAllowedHeaders(additionalAllowedHeaders);
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withCorsAdditionalExposedHeaders(
+        String... additionalExposedHeaders) {
+      validateConfigureCors();
+      this.corsBundleBuilder.withAdditionalExposedHeaders(additionalExposedHeaders);
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withoutHalSupport() {
+      this.jacksonBundleBuilder.withoutHalSupport();
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withoutFieldFilter() {
+      this.jacksonBundleBuilder.withoutFieldFilter();
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> withObjectMapperCustomization(
+        Consumer<ObjectMapper> customizer) {
+      this.jacksonBundleBuilder.withCustomization(customizer);
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> alwaysWriteZonedDateTimeWithMillisInJson() {
+      this.jacksonBundleBuilder.alwaysWriteZonedDateTimeWithMillis();
+      return this;
+    }
+
+    @Override
+    public PlatformBundleBuilder<C> alwaysWriteZonedDateTimeWithoutMillisInJson() {
+      this.jacksonBundleBuilder.alwaysWriteZonedDateTimeWithoutMillis();
+      return this;
+    }
+
+    @Override
+    public OpenApiFinalBuilder<C> withExistingOpenAPI(String openApiJsonOrYaml) {
+      this.openApiBundleBuilder = getOpenApiBuilder().withExistingOpenAPI(openApiJsonOrYaml);
+      return this;
+    }
+
+    @Override
+    public OpenApiFinalBuilder<C> withExistingOpenAPIFromClasspathResource(String path) {
+      this.openApiBundleBuilder =
+          getOpenApiBuilder().withExistingOpenAPIFromClasspathResource(path);
+      return this;
+    }
+
+    @Override
+    public OpenApiFinalBuilder<C> addOpenApiResourcePackage(String resourcePackage) {
+      this.openApiBundleBuilder = getOpenApiBuilder().addResourcePackage(resourcePackage);
+      return this;
+    }
+
+    @Override
+    public OpenApiFinalBuilder<C> addOpenApiResourcePackageClass(Class<?> swaggerResourcePackage) {
+      this.openApiBundleBuilder =
+          getOpenApiBuilder().addResourcePackageClass(swaggerResourcePackage);
+      return this;
+    }
+
+    // helper
+
+    private OpenApiBundle.InitialBuilder getOpenApiBuilder() {
+      return openApiBundleBuilder != null ? openApiBundleBuilder : OpenApiBundle.builder();
+    }
+
+    private void validateConfigureCors() {
+      if (this.corsBundleBuilder == null) {
+        throw new IllegalStateException(
+            "Attempt to configure CORS details, but CORS is not active.");
+      }
+    }
+  }
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
@@ -1,0 +1,60 @@
+package org.sdase.commons.starter;
+
+import io.dropwizard.Configuration;
+import org.sdase.commons.server.auth.config.AuthConfig;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle;
+import org.sdase.commons.server.consumer.ConsumerTokenConfig;
+import org.sdase.commons.server.cors.CorsConfiguration;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
+
+/** Default configuration for the {@link SdaPlatformBundle}. */
+public class SdaPlatformConfiguration extends Configuration {
+
+  /** Configuration of authentication. */
+  private AuthConfig auth = new AuthConfig();
+
+  /** Configuration of the CORS filter. */
+  private CorsConfiguration cors = new CorsConfiguration();
+
+  /**
+   * Configuration of the consumer token. This configuration only affects the consumer token bundle,
+   * if it is explicitly added using {@link
+   * ConsumerTokenConfigBuilder#withConsumerTokenConfigProvider(ConsumerTokenBundle.ConsumerTokenConfigProvider)}:
+   *
+   * <pre>{@code
+   * SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+   *     SdaPlatformBundle.builder()
+   *         .usingSdaPlatformConfiguration()
+   *         .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
+   *         // ...
+   * }</pre>
+   */
+  private ConsumerTokenConfig consumerToken = new ConsumerTokenConfig();
+
+  public AuthConfig getAuth() {
+    return auth;
+  }
+
+  public SdaPlatformConfiguration setAuth(AuthConfig auth) {
+    this.auth = auth;
+    return this;
+  }
+
+  public CorsConfiguration getCors() {
+    return cors;
+  }
+
+  public SdaPlatformConfiguration setCors(CorsConfiguration cors) {
+    this.cors = cors;
+    return this;
+  }
+
+  public ConsumerTokenConfig getConsumerToken() {
+    return consumerToken;
+  }
+
+  public SdaPlatformConfiguration setConsumerToken(ConsumerTokenConfig consumerToken) {
+    this.consumerToken = consumerToken;
+    return this;
+  }
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
@@ -2,11 +2,8 @@ package org.sdase.commons.starter;
 
 import io.dropwizard.Configuration;
 import org.sdase.commons.server.auth.config.AuthConfig;
-import org.sdase.commons.server.consumer.ConsumerTokenBundle;
-import org.sdase.commons.server.consumer.ConsumerTokenConfig;
 import org.sdase.commons.server.cors.CorsConfiguration;
 import org.sdase.commons.server.opa.config.OpaConfig;
-import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
 
 /** Default configuration for the {@link SdaPlatformBundle}. */
 public class SdaPlatformConfiguration extends Configuration {
@@ -19,21 +16,6 @@ public class SdaPlatformConfiguration extends Configuration {
 
   /** Configuration of the CORS filter. */
   private CorsConfiguration cors = new CorsConfiguration();
-
-  /**
-   * Configuration of the consumer token. This configuration only affects the consumer token bundle,
-   * if it is explicitly added using {@link
-   * ConsumerTokenConfigBuilder#withConsumerTokenConfigProvider(ConsumerTokenBundle.ConsumerTokenConfigProvider)}:
-   *
-   * <pre>{@code
-   * SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-   *     SdaPlatformBundle.builder()
-   *         .usingSdaPlatformConfiguration()
-   *         .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-   *         // ...
-   * }</pre>
-   */
-  private ConsumerTokenConfig consumerToken = new ConsumerTokenConfig();
 
   public AuthConfig getAuth() {
     return auth;
@@ -50,15 +32,6 @@ public class SdaPlatformConfiguration extends Configuration {
 
   public SdaPlatformConfiguration setCors(CorsConfiguration cors) {
     this.cors = cors;
-    return this;
-  }
-
-  public ConsumerTokenConfig getConsumerToken() {
-    return consumerToken;
-  }
-
-  public SdaPlatformConfiguration setConsumerToken(ConsumerTokenConfig consumerToken) {
-    this.consumerToken = consumerToken;
     return this;
   }
 

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
@@ -5,6 +5,7 @@ import org.sdase.commons.server.auth.config.AuthConfig;
 import org.sdase.commons.server.consumer.ConsumerTokenBundle;
 import org.sdase.commons.server.consumer.ConsumerTokenConfig;
 import org.sdase.commons.server.cors.CorsConfiguration;
+import org.sdase.commons.server.opa.config.OpaConfig;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
 
 /** Default configuration for the {@link SdaPlatformBundle}. */
@@ -12,6 +13,9 @@ public class SdaPlatformConfiguration extends Configuration {
 
   /** Configuration of authentication. */
   private AuthConfig auth = new AuthConfig();
+
+  /** Configuration of the open policy agent. */
+  private OpaConfig opa = new OpaConfig();
 
   /** Configuration of the CORS filter. */
   private CorsConfiguration cors = new CorsConfiguration();
@@ -55,6 +59,15 @@ public class SdaPlatformConfiguration extends Configuration {
 
   public SdaPlatformConfiguration setConsumerToken(ConsumerTokenConfig consumerToken) {
     this.consumerToken = consumerToken;
+    return this;
+  }
+
+  public OpaConfig getOpa() {
+    return opa;
+  }
+
+  public SdaPlatformConfiguration setOpa(OpaConfig opa) {
+    this.opa = opa;
     return this;
   }
 }

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CorsCustomizer.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CorsCustomizer.java
@@ -1,0 +1,49 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+import javax.ws.rs.HttpMethod;
+import org.sdase.commons.server.cors.CorsBundle;
+
+public interface CorsCustomizer<T extends Configuration> {
+
+  /**
+   * Defines the HTTP methods that are used in the application and should be allowed for cross
+   * origin clients. The given {@code httpMethods} overwrite the {@link
+   * CorsBundle.FinalBuilder#DEFAULT_HTTP_METHODS default methods}.
+   *
+   * <ul>
+   *   <li>{@value HttpMethod#OPTIONS}
+   *   <li>{@value HttpMethod#HEAD}
+   *   <li>{@value HttpMethod#GET}
+   *   <li>{@value HttpMethod#DELETE}
+   *   <li>{@value HttpMethod#POST}
+   *   <li>{@value HttpMethod#PUT}
+   *   <li>{@code "PATCH"}
+   * </ul>
+   *
+   * @param httpMethods all HTTP methods that will be allowed by the CORS filter.
+   * @return the same builder instance
+   */
+  PlatformBundleBuilder<T> withCorsAllowedMethods(String... httpMethods);
+
+  /**
+   * Defines additional HTTP headers that clients may send to the application. The headers defined
+   * in {@link CorsBundle.FinalBuilder#ALWAYS_ALLOWED_HEADERS} are always allowed to be send and
+   * must not be added here.
+   *
+   * @param additionalAllowedHeaders additional HTTP headers that clients may send to the
+   *     application.
+   * @return the same builder instance
+   */
+  PlatformBundleBuilder<T> withCorsAdditionalAllowedHeaders(String... additionalAllowedHeaders);
+
+  /**
+   * Defines additional HTTP headers that can be exposed to clients. The headers defined in {@link
+   * CorsBundle.FinalBuilder#ALWAYS_EXPOSED_HEADERS} can always be exposed and must not be added
+   * here.
+   *
+   * @param additionalExposedHeaders additional HTTP headers that can be exposed.
+   * @return the same builder instance
+   */
+  PlatformBundleBuilder<T> withCorsAdditionalExposedHeaders(String... additionalExposedHeaders);
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
@@ -1,0 +1,116 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+import org.sdase.commons.server.auth.config.AuthConfigProvider;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle.ConsumerTokenConfigProvider;
+import org.sdase.commons.server.cors.CorsConfigProvider;
+import org.sdase.commons.server.opa.config.OpaConfigProvider;
+import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
+
+/**
+ * Container for builder interfaces required for custom configuration classes. They are all in one
+ * place in the order how they are called for easier extension with more supported bundles.
+ */
+public interface CustomConfigurationProviders {
+
+  interface AuthConfigProviderBuilder<C extends Configuration> {
+
+    /**
+     * Disable authentication entirely.
+     *
+     * @return the builder instance
+     */
+    CorsConfigProviderBuilder<C> withoutAuthentication();
+
+    /**
+     * Enables authentication (i.e. token validation) for annotated endpoints and requires tokens
+     *
+     * @param authConfigProvider a provider, for the {@link
+     *     org.sdase.commons.server.auth.config.AuthConfig}, e.g. {@code MyAppConfig::getAuth}
+     * @return the builder instance
+     */
+    CorsConfigProviderBuilder<C> withAuthConfigProvider(AuthConfigProvider<C> authConfigProvider);
+
+    /**
+     * Enables authentication (i.e. token validation) for all endpoints and use the {@link
+     * org.sdase.commons.server.opa.OpaBundle} to authorize the requests. Requests without
+     * Authorization header will <i>not</i> be rejected but need to be handled in the Authorization
+     * policy.
+     *
+     * @param authConfigProvider a provider, for the {@link
+     *     org.sdase.commons.server.auth.config.AuthConfig}, e.g. {@code MyAppConfig::getAuth}
+     * @param opaConfigProvider a provider, for the {@link
+     *     org.sdase.commons.server.opa.config.OpaConfig}, e.g. {@code MyAppConfig::getOpa}
+     * @return the builder instance
+     */
+    CorsConfigProviderBuilder<C> withOpaAuthorization(
+        AuthConfigProvider<C> authConfigProvider, OpaConfigProvider<C> opaConfigProvider);
+  }
+
+  interface CorsConfigProviderBuilder<C extends Configuration> {
+
+    /**
+     * Disable CORS support. Browsers are not allowed to access the application from a foreign
+     * domain.
+     *
+     * @return the builder instance
+     */
+    ConsumerTokenConfigBuilder<C> withoutCorsSupport();
+
+    /**
+     * @param corsConfigProvider a provider, for the {@link
+     *     org.sdase.commons.server.cors.CorsConfiguration}, e.g. {@code MyAppConfig::getCors}
+     * @return the builder instance
+     */
+    ConsumerTokenConfigBuilder<C> withCorsConfigProvider(CorsConfigProvider<C> corsConfigProvider);
+  }
+
+  interface ConsumerTokenConfigBuilder<C extends Configuration> {
+
+    /**
+     * Disable consumer token support. Consumer tokens are not required to access this service and
+     * will be ignored if a client sends them.
+     *
+     * @return the builder instance
+     */
+    OpenApiInitialBuilder<C> withoutConsumerTokenSupport();
+
+    /**
+     * Disable consumer token support. Consumer tokens are not required to access this service but
+     * will be tracked if a client sends them.
+     *
+     * @return the builder instance
+     */
+    OpenApiInitialBuilder<C> withOptionalConsumerToken();
+
+    /**
+     * Enable consumer token support. Consumer tokens are required to access this service. Further
+     * configuration may exclude paths from this requirement.
+     *
+     * @return the builder instance
+     */
+    ConsumerTokenRequiredConfigInitialBuilder<C> withRequiredConsumerToken();
+
+    /**
+     * Configure consumer token support based on provided configuration per instance.
+     *
+     * @param consumerTokenConfigProvider the provider of the configuration, e.g. {@code
+     *     MyConfig::getConsumerToken}
+     * @return the builder instance
+     */
+    OpenApiInitialBuilder<C> withConsumerTokenConfigProvider(
+        ConsumerTokenConfigProvider<C> consumerTokenConfigProvider);
+  }
+
+  interface ConsumerTokenRequiredConfigInitialBuilder<C extends Configuration>
+      extends OpenApiInitialBuilder<C> {
+
+    /**
+     * Define paths by regex patterns that do not require a consumer token from the client.
+     *
+     * @param regex regex that matches paths that do not require a consumer token from the client
+     * @return the builder instance
+     */
+    OpenApiInitialBuilder<C> withExcludePatternsForRequiredConsumerToken(String... regex);
+  }
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
@@ -2,7 +2,6 @@ package org.sdase.commons.starter.builder;
 
 import io.dropwizard.Configuration;
 import org.sdase.commons.server.auth.config.AuthConfigProvider;
-import org.sdase.commons.server.consumer.ConsumerTokenBundle.ConsumerTokenConfigProvider;
 import org.sdase.commons.server.cors.CorsConfigProvider;
 import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
@@ -55,62 +54,13 @@ public interface CustomConfigurationProviders {
      *
      * @return the builder instance
      */
-    ConsumerTokenConfigBuilder<C> withoutCorsSupport();
+    OpenApiInitialBuilder<C> withoutCorsSupport();
 
     /**
      * @param corsConfigProvider a provider, for the {@link
      *     org.sdase.commons.server.cors.CorsConfiguration}, e.g. {@code MyAppConfig::getCors}
      * @return the builder instance
      */
-    ConsumerTokenConfigBuilder<C> withCorsConfigProvider(CorsConfigProvider<C> corsConfigProvider);
-  }
-
-  interface ConsumerTokenConfigBuilder<C extends Configuration> {
-
-    /**
-     * Disable consumer token support. Consumer tokens are not required to access this service and
-     * will be ignored if a client sends them.
-     *
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withoutConsumerTokenSupport();
-
-    /**
-     * Disable consumer token support. Consumer tokens are not required to access this service but
-     * will be tracked if a client sends them.
-     *
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withOptionalConsumerToken();
-
-    /**
-     * Enable consumer token support. Consumer tokens are required to access this service. Further
-     * configuration may exclude paths from this requirement.
-     *
-     * @return the builder instance
-     */
-    ConsumerTokenRequiredConfigInitialBuilder<C> withRequiredConsumerToken();
-
-    /**
-     * Configure consumer token support based on provided configuration per instance.
-     *
-     * @param consumerTokenConfigProvider the provider of the configuration, e.g. {@code
-     *     MyConfig::getConsumerToken}
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withConsumerTokenConfigProvider(
-        ConsumerTokenConfigProvider<C> consumerTokenConfigProvider);
-  }
-
-  interface ConsumerTokenRequiredConfigInitialBuilder<C extends Configuration>
-      extends OpenApiInitialBuilder<C> {
-
-    /**
-     * Define paths by regex patterns that do not require a consumer token from the client.
-     *
-     * @param regex regex that matches paths that do not require a consumer token from the client
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withExcludePatternsForRequiredConsumerToken(String... regex);
+    OpenApiInitialBuilder<C> withCorsConfigProvider(CorsConfigProvider<C> corsConfigProvider);
   }
 }

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
@@ -1,6 +1,9 @@
 package org.sdase.commons.starter.builder;
 
 import io.dropwizard.Configuration;
+import org.sdase.commons.server.auth.config.AuthConfigProvider;
+import org.sdase.commons.server.cors.CorsConfigProvider;
+import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.SdaPlatformBundle;
 import org.sdase.commons.starter.SdaPlatformConfiguration;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
@@ -15,6 +18,21 @@ public interface InitialPlatformBundleBuilder {
    * @return the builder instance
    */
   ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
+
+  /**
+   * Start an application that uses a customized configuration which extends the {@link
+   * SdaPlatformConfiguration} as base of it's configuration file.
+   *
+   * <p>The method automatically enables OPA authorization and sets therefore the authorization
+   * configuration via {@link AuthConfigProviderBuilder#withOpaAuthorization(AuthConfigProvider,
+   * OpaConfigProvider)} and the cors configuration via {@link
+   * org.sdase.commons.starter.builder.CustomConfigurationProviders.CorsConfigProviderBuilder#withCorsConfigProvider(CorsConfigProvider)}
+   *
+   * @param configurationClass - the customized configuration of the application
+   * @return the builder instance
+   */
+  <C extends SdaPlatformConfiguration> ConsumerTokenConfigBuilder<C> usingSdaPlatformConfiguration(
+      Class<C> configurationClass);
 
   /**
    * Start an application that uses a custom configuration has to define providers for the

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
@@ -7,7 +7,7 @@ import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.SdaPlatformBundle;
 import org.sdase.commons.starter.SdaPlatformConfiguration;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
-import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
+import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
 
 public interface InitialPlatformBundleBuilder {
 
@@ -17,7 +17,7 @@ public interface InitialPlatformBundleBuilder {
    *
    * @return the builder instance
    */
-  ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
+  OpenApiInitialBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
 
   /**
    * Start an application that uses a customized configuration which extends the {@link
@@ -31,7 +31,7 @@ public interface InitialPlatformBundleBuilder {
    * @param configurationClass - the customized configuration of the application
    * @return the builder instance
    */
-  <C extends SdaPlatformConfiguration> ConsumerTokenConfigBuilder<C> usingSdaPlatformConfiguration(
+  <C extends SdaPlatformConfiguration> OpenApiInitialBuilder<C> usingSdaPlatformConfiguration(
       Class<C> configurationClass);
 
   /**

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
@@ -1,0 +1,29 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+import org.sdase.commons.starter.SdaPlatformBundle;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
+import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
+
+public interface InitialPlatformBundleBuilder {
+
+  /**
+   * Start an application that uses the {@link SdaPlatformConfiguration} as base of it's
+   * configuration file.
+   *
+   * @return the builder instance
+   */
+  ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
+
+  /**
+   * Start an application that uses a custom configuration has to define providers for the
+   * configurations required by the {@link SdaPlatformBundle}.
+   *
+   * @param configurationClass the class that stores the configuration
+   * @param <C> the type of the applications configuration class
+   * @return the builder instance
+   */
+  <C extends Configuration> AuthConfigProviderBuilder<C> usingCustomConfig(
+      Class<C> configurationClass);
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/JacksonCustomizer.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/JacksonCustomizer.java
@@ -1,0 +1,61 @@
+package org.sdase.commons.starter.builder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.dropwizard.Configuration;
+import java.time.ZonedDateTime;
+import java.util.function.Consumer;
+import org.sdase.commons.server.jackson.EnableFieldFilter;
+import org.sdase.commons.server.jackson.Iso8601Serializer;
+
+public interface JacksonCustomizer<C extends Configuration> {
+
+  /**
+   * Skips registration of the HAL module. This may be used when links and embedded resources are
+   * not required or are achieved with other tooling.
+   *
+   * @return the builder
+   */
+  PlatformBundleBuilder<C> withoutHalSupport();
+
+  /**
+   * Disables the field filter entirely. The field filter may be used by clients to request only a
+   * subset of the properties of a resource and has to be activated with {@link EnableFieldFilter}
+   * for each resource.
+   *
+   * @return the builder
+   */
+  PlatformBundleBuilder<C> withoutFieldFilter();
+
+  /**
+   * Allows customization of the used {@link ObjectMapper}. More customizers may be added by calling
+   * this method multiple times.
+   *
+   * @param customizer receives the used {@link ObjectMapper} for customization, e.g. to enable or
+   *     disable specific features or configure formatting.
+   * @return the builder
+   */
+  PlatformBundleBuilder<C> withObjectMapperCustomization(Consumer<ObjectMapper> customizer);
+
+  /**
+   * Registers a default serializer for {@link ZonedDateTime} that renders 3 digits of milliseconds.
+   * The same serializer may be configured per field as documented in {@link
+   * Iso8601Serializer.WithMillis}.
+   *
+   * <p>This setting overwrites the default behaviour of Jackson which omits milliseconds if they
+   * are zero or adds nanoseconds if they are set.
+   *
+   * @return the builder
+   */
+  PlatformBundleBuilder<C> alwaysWriteZonedDateTimeWithMillisInJson();
+
+  /**
+   * Registers a default serializer for {@link ZonedDateTime} that renders no milliseconds. The same
+   * serializer may be configured per field as documented in {@link Iso8601Serializer}.
+   *
+   * <p>This setting overwrites the default behaviour of Jackson which omits milliseconds if they
+   * are zero or adds nanoseconds if they are set.
+   *
+   * @return the builder
+   */
+  PlatformBundleBuilder<C> alwaysWriteZonedDateTimeWithoutMillisInJson();
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/OpenApiCustomizer.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/OpenApiCustomizer.java
@@ -1,0 +1,59 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+
+public interface OpenApiCustomizer {
+
+  interface OpenApiInitialBuilder<C extends Configuration> extends PlatformBundleBuilder<C> {
+
+    /**
+     * Adds a package to the packages Swagger should scan to pick up resources.
+     *
+     * @param resourcePackage the package to be scanned; not null
+     * @return the builder instance
+     * @throws NullPointerException if resourcePackage is null
+     * @throws IllegalArgumentException if resourcePackage is empty
+     * @see org.sdase.commons.server.openapi.OpenApiBundle.InitialBuilder#addResourcePackage(String)
+     */
+    OpenApiFinalBuilder<C> addOpenApiResourcePackage(String resourcePackage);
+
+    /**
+     * Adds the package of the given class to the packages Swagger should scan to pick up resources.
+     *
+     * @param resourcePackageClass the class whose package should be scanned; not null
+     * @return the builder instance
+     * @throws NullPointerException if resourcePackageClass is null
+     * @see
+     *     org.sdase.commons.server.openapi.OpenApiBundle.InitialBuilder#addResourcePackageClass(Class)
+     */
+    OpenApiFinalBuilder<C> addOpenApiResourcePackageClass(Class<?> resourcePackageClass);
+
+    /**
+     * Use an existing OpenAPI 3 specification as base for the generation.
+     *
+     * <p>Note that the OpenAPI annotations always override values from the files if classes are
+     * registered with {@link #addOpenApiResourcePackage(String)} or {@link
+     * #addOpenApiResourcePackageClass(Class)}.
+     *
+     * @param openApiJsonOrYaml the OpenAPI 3 specification as json or yaml
+     * @return the builder instance
+     * @see
+     *     org.sdase.commons.server.openapi.OpenApiBundle.InitialBuilder#withExistingOpenAPI(String)
+     */
+    OpenApiFinalBuilder<C> withExistingOpenAPI(String openApiJsonOrYaml);
+
+    /**
+     * Reads an existing OpenAPI 3 specification from the given classpath resource and provide it to
+     * {@link #withExistingOpenAPI(String)}
+     *
+     * @param path the path to an OpenAPI 3 YAML or JSON file in the classpath.
+     * @return the builder instance
+     * @see
+     *     org.sdase.commons.server.openapi.OpenApiBundle.InitialBuilder#withExistingOpenAPIFromClasspathResource(String)
+     */
+    OpenApiFinalBuilder<C> withExistingOpenAPIFromClasspathResource(String path);
+  }
+
+  interface OpenApiFinalBuilder<C extends Configuration>
+      extends PlatformBundleBuilder<C>, OpenApiInitialBuilder<C> {}
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/PlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/PlatformBundleBuilder.java
@@ -1,0 +1,22 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Bootstrap;
+import org.sdase.commons.starter.SdaPlatformBundle;
+
+/**
+ * The final builder that is able to configure all the optional settings.
+ *
+ * @param <C> the type of the applications configuration class
+ */
+public interface PlatformBundleBuilder<C extends Configuration>
+    extends CorsCustomizer<C>, SecurityCustomizer<C>, JacksonCustomizer<C> {
+
+  /**
+   * Builds the configured {@link SdaPlatformBundle} which must be added to the {@link Bootstrap} in
+   * {@link io.dropwizard.Application#initialize(Bootstrap)}.
+   *
+   * @return the configured {@link SdaPlatformBundle}
+   */
+  SdaPlatformBundle<C> build();
+}

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/SecurityCustomizer.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/SecurityCustomizer.java
@@ -1,0 +1,15 @@
+package org.sdase.commons.starter.builder;
+
+import io.dropwizard.Configuration;
+
+public interface SecurityCustomizer<C extends Configuration> {
+
+  /**
+   * Switches from suppressing the application start to a warn logging for violated buffer limits.
+   * In rare cases an application might need to increase the default limits and therefore has to
+   * disable strict validation. This option should be used with care.
+   *
+   * @return this builder instance
+   */
+  PlatformBundleBuilder<C> disableBufferLimitValidationSecurityFeature();
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
@@ -1,0 +1,95 @@
+package org.sdase.commons.starter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.auth.AuthBundle;
+import org.sdase.commons.server.auth.config.AuthConfig;
+import org.sdase.commons.server.auth.config.AuthConfigProvider;
+import org.sdase.commons.server.opa.OpaBundle;
+import org.sdase.commons.server.opa.config.OpaConfig;
+import org.sdase.commons.server.opa.config.OpaConfigProvider;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class AuthBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void defaultAuth() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        AuthBundle.builder()
+            .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
+            .withAnnotatedAuthorization()
+            .build());
+  }
+
+  @Test
+  public void customAuthConfigProvider() {
+
+    AuthConfigProvider<SdaPlatformConfiguration> acp = c -> new AuthConfig();
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingCustomConfig(SdaPlatformConfiguration.class)
+            .withAuthConfigProvider(acp)
+            .withoutCorsSupport()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        AuthBundle.builder().withAuthConfigProvider(acp).withAnnotatedAuthorization().build());
+  }
+
+  @Test
+  public void disableAuth() {
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingCustomConfig(SdaPlatformConfiguration.class)
+            .withoutAuthentication()
+            .withoutCorsSupport()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleNotConfiguredByPlatformBundle(bundle, AuthBundle.class);
+  }
+
+  @Test
+  public void opaAuthorization() {
+
+    AuthConfigProvider<SdaPlatformConfiguration> acp = c -> new AuthConfig();
+    OpaConfigProvider<SdaPlatformConfiguration> ocp = c -> new OpaConfig();
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingCustomConfig(SdaPlatformConfiguration.class)
+            .withOpaAuthorization(acp, ocp)
+            .withoutCorsSupport()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        AuthBundle.builder().withAuthConfigProvider(acp).withExternalAuthorization().build());
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, OpaBundle.builder().withOpaConfigProvider(ocp).build());
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
@@ -32,8 +32,22 @@ public class AuthBuilderTest {
         bundle,
         AuthBundle.builder()
             .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
-            .withAnnotatedAuthorization()
+            .withExternalAuthorization()
             .build());
+  }
+
+  @Test
+  public void defaultOpa() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        OpaBundle.builder().withOpaConfigProvider(SdaPlatformConfiguration::getOpa).build());
   }
 
   @Test

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
@@ -24,7 +24,6 @@ public class AuthBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -41,7 +40,6 @@ public class AuthBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -60,7 +58,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withAuthConfigProvider(acp)
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -77,7 +74,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withoutAuthentication()
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -95,7 +91,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withOpaAuthorization(acp, ocp)
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
@@ -1,0 +1,134 @@
+package org.sdase.commons.starter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class ConsumerTokenBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  private Environment environmentMock;
+  private ArgumentCaptor<Object> jerseyRegistrationCaptor;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+    environmentMock = mock(Environment.class, RETURNS_DEEP_STUBS);
+    jerseyRegistrationCaptor = ArgumentCaptor.forClass(Object.class);
+  }
+
+  @Test
+  public void withoutConsumerToken() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleNotConfiguredByPlatformBundle(bundle, ConsumerTokenBundle.class);
+  }
+
+  @Test
+  public void withOptionalConsumerToken() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withOptionalConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    verifyRegisteredConsumerTokenFiltersEqual(
+        bundle, ConsumerTokenBundle.builder().withOptionalConsumerToken().build());
+  }
+
+  @Test
+  public void withRequiredConsumerToken() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    verifyRegisteredConsumerTokenFiltersEqual(
+        bundle, ConsumerTokenBundle.builder().withRequiredConsumerToken().build());
+  }
+
+  @Test
+  public void withRequiredConsumerTokenAndExcludedPaths() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .withExcludePatternsForRequiredConsumerToken("/public", "/ping")
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    verifyRegisteredConsumerTokenFiltersEqual(
+        bundle,
+        ConsumerTokenBundle.builder()
+            .withRequiredConsumerToken()
+            .withExcludePatterns("/public", "/ping")
+            .build());
+  }
+
+  @Test
+  public void withConfigurableConsumerToken() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    verifyRegisteredConsumerTokenFiltersEqual(
+        bundle,
+        ConsumerTokenBundle.builder()
+            .withConfigProvider(SdaPlatformConfiguration::getConsumerToken)
+            .build(),
+        SdaPlatformConfiguration.class);
+  }
+
+  private void verifyRegisteredConsumerTokenFiltersEqual(
+      SdaPlatformBundle<SdaPlatformConfiguration> actualSdaPlatformBundle,
+      ConsumerTokenBundle<Configuration> expectedBundle) {
+    verifyRegisteredConsumerTokenFiltersEqual(
+        actualSdaPlatformBundle, expectedBundle, Configuration.class);
+  }
+
+  private <C extends Configuration> void verifyRegisteredConsumerTokenFiltersEqual(
+      SdaPlatformBundle<SdaPlatformConfiguration> actualSdaPlatformBundle,
+      ConsumerTokenBundle<C> expectedBundle,
+      Class<C> configurationClass) {
+    try {
+      //noinspection unchecked
+      ConsumerTokenBundle<SdaPlatformConfiguration> actualConsumerTokenBundle =
+          bundleAssertion.getBundleOfType(actualSdaPlatformBundle, ConsumerTokenBundle.class);
+
+      actualConsumerTokenBundle.run(new SdaPlatformConfiguration(), environmentMock);
+      expectedBundle.run(configurationClass.newInstance(), environmentMock);
+
+      verify(environmentMock.jersey(), times(2)).register(jerseyRegistrationCaptor.capture());
+
+      List<Object> registeredFilters = jerseyRegistrationCaptor.getAllValues();
+      assertThat(registeredFilters.get(0))
+          .isEqualToComparingFieldByFieldRecursively(registeredFilters.get(1));
+    } catch (InstantiationException | IllegalAccessException e) {
+      fail("Fail to instantiate config class.", e);
+    }
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
@@ -31,23 +31,10 @@ public class ConsumerTokenBuilderTest {
   }
 
   @Test
-  public void withoutConsumerToken() {
+  public void withOptionalConsumerTokenByDefault() {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    bundleAssertion.assertBundleNotConfiguredByPlatformBundle(bundle, ConsumerTokenBundle.class);
-  }
-
-  @Test
-  public void withOptionalConsumerToken() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withOptionalConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -60,47 +47,11 @@ public class ConsumerTokenBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
     verifyRegisteredConsumerTokenFiltersEqual(
-        bundle, ConsumerTokenBundle.builder().withRequiredConsumerToken().build());
-  }
-
-  @Test
-  public void withRequiredConsumerTokenAndExcludedPaths() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
-            .withExcludePatternsForRequiredConsumerToken("/public", "/ping")
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    verifyRegisteredConsumerTokenFiltersEqual(
-        bundle,
-        ConsumerTokenBundle.builder()
-            .withRequiredConsumerToken()
-            .withExcludePatterns("/public", "/ping")
-            .build());
-  }
-
-  @Test
-  public void withConfigurableConsumerToken() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    verifyRegisteredConsumerTokenFiltersEqual(
-        bundle,
-        ConsumerTokenBundle.builder()
-            .withConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-            .build(),
-        SdaPlatformConfiguration.class);
+        bundle, ConsumerTokenBundle.builder().withOptionalConsumerToken().build());
   }
 
   private void verifyRegisteredConsumerTokenFiltersEqual(

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
@@ -1,0 +1,64 @@
+package org.sdase.commons.starter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.auth.config.AuthConfig;
+import org.sdase.commons.server.cors.CorsBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class CorsBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void defaultCorsSettings() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        CorsBundle.builder().withCorsConfigProvider(SdaPlatformConfiguration::getCors).build());
+  }
+
+  @Test
+  public void customCorsSettings() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .withCorsAdditionalExposedHeaders("X-custom-header-1", "X-custom-header-2")
+            .withCorsAdditionalAllowedHeaders("X-custom-header-3", "X-custom-header-4")
+            .withCorsAllowedMethods("GET")
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        CorsBundle.builder()
+            .withCorsConfigProvider(SdaPlatformConfiguration::getCors)
+            .withAdditionalExposedHeaders("X-custom-header-1", "X-custom-header-2")
+            .withAdditionalAllowedHeaders("X-custom-header-3", "X-custom-header-4")
+            .withAllowedMethods("GET")
+            .build());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void noCorsConfigurationIfCorsDisabled() {
+    SdaPlatformBundle.builder()
+        .usingCustomConfig(SdaPlatformConfiguration.class)
+        .withAuthConfigProvider(c -> new AuthConfig())
+        .withoutCorsSupport()
+        .withoutConsumerTokenSupport()
+        .addOpenApiResourcePackageClass(this.getClass())
+        .withCorsAdditionalExposedHeaders("x-foo");
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
@@ -20,7 +20,6 @@ public class CorsBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -34,7 +33,6 @@ public class CorsBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withCorsAdditionalExposedHeaders("X-custom-header-1", "X-custom-header-2")
             .withCorsAdditionalAllowedHeaders("X-custom-header-3", "X-custom-header-4")
@@ -57,7 +55,6 @@ public class CorsBuilderTest {
         .usingCustomConfig(SdaPlatformConfiguration.class)
         .withAuthConfigProvider(c -> new AuthConfig())
         .withoutCorsSupport()
-        .withoutConsumerTokenSupport()
         .addOpenApiResourcePackageClass(this.getClass())
         .withCorsAdditionalExposedHeaders("x-foo");
   }

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -1,0 +1,110 @@
+package org.sdase.commons.starter;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jetty.http.HttpStatus.OK_200;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import javax.ws.rs.core.Response;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sdase.commons.starter.test.StarterApp;
+
+public class FilterPriorityTest {
+
+  @ClassRule
+  public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
+      new DropwizardAppRule<>(StarterApp.class, resourceFilePath("test-config.yaml"));
+
+  @Test
+  public void corsFromSwaggerHasHigherPriority() {
+    Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("/api/openapi.yaml")
+            .request("application/yaml")
+            .header("Origin", "example.com")
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(OK_200);
+    assertThat(response.getMetadata().getFirst("Access-Control-Allow-Origin"))
+        .isEqualTo("example.com");
+  }
+
+  @Test
+  public void traceTokenFilterHasHighestPriority() {
+    // Make sure that trace token filter is even executed when authentication fails
+    Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("api")
+            .path("ping")
+            .request(APPLICATION_JSON)
+            .header("Trace-Token", "MyTraceToken")
+            .get();
+
+    assertThat(response.getMetadata().getFirst("Trace-Token")).isEqualTo("MyTraceToken");
+  }
+
+  @Test
+  public void consumerTokenValidationHappensBeforeAuthentication() {
+    // Make sure that the consumer token filter fails before the authentication filter
+    Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("api")
+            .path("ping")
+            .request(APPLICATION_JSON)
+            .get();
+
+    assertThat(response.readEntity(String.class)).contains("Consumer token is required");
+  }
+
+  @Test
+  public void errorsInConsumerTokenFilterTrackedByPrometheus() {
+    Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("api")
+            .path("ping")
+            .request(APPLICATION_JSON)
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(401);
+
+    String metrics =
+        DW.client()
+            .target("http://localhost:" + DW.getAdminPort())
+            .path("metrics")
+            .path("prometheus")
+            .request(APPLICATION_JSON)
+            .get(String.class);
+
+    assertThat(metrics).contains("consumer_name=\"\"");
+  }
+
+  @Test
+  public void errorsInAuthenticationFilterAreTrackedByPrometheus() {
+    Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("api")
+            .path("ping")
+            .request(APPLICATION_JSON)
+            .header("Consumer-Token", "MyConsumer")
+            .get();
+
+    assertThat(response.getStatus()).isEqualTo(401);
+
+    String metrics =
+        DW.client()
+            .target("http://localhost:" + DW.getAdminPort())
+            .path("metrics")
+            .path("prometheus")
+            .request(APPLICATION_JSON)
+            .get(String.class);
+
+    assertThat(metrics).contains("consumer_name=\"MyConsumer\"");
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.starter;
 
+import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +10,21 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.opa.testing.OpaRule;
 import org.sdase.commons.starter.test.StarterApp;
 
 public class FilterPriorityTest {
 
-  @ClassRule
+  public static final OpaRule OPA = new OpaRule();
+
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      new DropwizardAppRule<>(StarterApp.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(
+          StarterApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("opa.baseUrl", OPA::getUrl));
+
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(OPA).around(DW);
 
   @Test
   public void corsFromSwaggerHasHigherPriority() {
@@ -48,20 +57,6 @@ public class FilterPriorityTest {
   }
 
   @Test
-  public void consumerTokenValidationHappensBeforeAuthentication() {
-    // Make sure that the consumer token filter fails before the authentication filter
-    Response response =
-        DW.client()
-            .target("http://localhost:" + DW.getLocalPort())
-            .path("api")
-            .path("ping")
-            .request(APPLICATION_JSON)
-            .get();
-
-    assertThat(response.readEntity(String.class)).contains("Consumer token is required");
-  }
-
-  @Test
   public void errorsInConsumerTokenFilterTrackedByPrometheus() {
     Response response =
         DW.client()
@@ -71,7 +66,7 @@ public class FilterPriorityTest {
             .request(APPLICATION_JSON)
             .get();
 
-    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getStatus()).isEqualTo(403);
 
     String metrics =
         DW.client()

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -95,7 +95,7 @@ public class FilterPriorityTest {
             .header("Consumer-Token", "MyConsumer")
             .get();
 
-    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getStatus()).isEqualTo(403);
 
     String metrics =
         DW.client()

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
@@ -1,0 +1,107 @@
+package org.sdase.commons.starter;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class JacksonBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void defaultJacksonConfig() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, JacksonConfigurationBundle.builder().build());
+  }
+
+  @Test
+  public void noHalSupport() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .withoutHalSupport()
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, JacksonConfigurationBundle.builder().withoutHalSupport().build());
+  }
+
+  @Test
+  public void noFieldFilter() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .withoutFieldFilter()
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, JacksonConfigurationBundle.builder().withoutFieldFilter().build());
+  }
+
+  @Test
+  public void alwaysWithMillis() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .alwaysWriteZonedDateTimeWithMillisInJson()
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, JacksonConfigurationBundle.builder().alwaysWriteZonedDateTimeWithMillis().build());
+  }
+
+  @Test
+  public void alwaysWithoutMillis() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .alwaysWriteZonedDateTimeWithoutMillisInJson()
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        JacksonConfigurationBundle.builder().alwaysWriteZonedDateTimeWithoutMillis().build());
+  }
+
+  @Test
+  public void withCustomizer() {
+
+    Consumer<ObjectMapper> omc =
+        om -> om.disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES);
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .withObjectMapperCustomization(omc)
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, JacksonConfigurationBundle.builder().withCustomization(omc).build());
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
@@ -22,7 +22,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -35,7 +34,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withoutHalSupport()
             .build();
@@ -49,7 +47,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withoutFieldFilter()
             .build();
@@ -63,7 +60,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .alwaysWriteZonedDateTimeWithMillisInJson()
             .build();
@@ -77,7 +73,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .alwaysWriteZonedDateTimeWithoutMillisInJson()
             .build();
@@ -96,7 +91,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withObjectMapperCustomization(omc)
             .build();

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
@@ -1,0 +1,64 @@
+package org.sdase.commons.starter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.openapi.OpenApiBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class OpenAPIBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void simplestConfig() {
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, OpenApiBundle.builder().addResourcePackageClass(this.getClass()).build());
+  }
+
+  @Test
+  public void multipleResourcePackages() {
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .addOpenApiResourcePackage("com.example")
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        OpenApiBundle.builder()
+            .addResourcePackageClass(this.getClass())
+            .addResourcePackage("com.example")
+            .build());
+  }
+
+  @Test
+  public void withExistingOpenAPIFromClasspathResource() {
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .withExistingOpenAPIFromClasspathResource("/example.yaml")
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        OpenApiBundle.builder().withExistingOpenAPIFromClasspathResource("/example.yaml").build());
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
@@ -20,7 +20,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -34,7 +33,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .addOpenApiResourcePackage("com.example")
             .build();
@@ -53,7 +51,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .withExistingOpenAPIFromClasspathResource("/example.yaml")
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
@@ -1,0 +1,38 @@
+package org.sdase.commons.starter;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.util.Map;
+import javax.ws.rs.core.GenericType;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sdase.commons.starter.test.StarterApp;
+
+public class SdaPlatformBundleAppTest {
+
+  @ClassRule
+  public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
+      new DropwizardAppRule<>(
+          StarterApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("auth.disableAuth", "true"));
+
+  @Test
+  public void pongForPing() {
+    Map<String, String> actual =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort())
+            .path("api")
+            .path("ping")
+            .request(APPLICATION_JSON)
+            .header("Consumer-token", "test-consumer")
+            .get(new GenericType<Map<String, String>>() {});
+
+    assertThat(actual).containsExactly(entry("ping", "pong"));
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
@@ -18,9 +18,7 @@ public class SdaPlatformBundleAppTest {
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
       new DropwizardAppRule<>(
-          StarterApp.class,
-          resourceFilePath("test-config.yaml"),
-          config("auth.disableAuth", "true"));
+          StarterApp.class, resourceFilePath("test-config.yaml"), config("opa.disableOpa", "true"));
 
   @Test
   public void pongForPing() {

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
@@ -1,0 +1,83 @@
+package org.sdase.commons.starter;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.auth.AuthBundle;
+import org.sdase.commons.server.consumer.ConsumerTokenBundle;
+import org.sdase.commons.server.cors.CorsBundle;
+import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
+import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBundle;
+import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
+import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
+import org.sdase.commons.server.jaeger.JaegerBundle;
+import org.sdase.commons.server.openapi.OpenApiBundle;
+import org.sdase.commons.server.opentracing.OpenTracingBundle;
+import org.sdase.commons.server.prometheus.PrometheusBundle;
+import org.sdase.commons.server.security.SecurityBundle;
+import org.sdase.commons.server.trace.TraceTokenBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class SdaPlatformBundleBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void allBundlesRegistered() {
+
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withOptionalConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    SoftAssertions.assertSoftly(
+        softly -> {
+          softly
+              .assertThat(
+                  bundleAssertion.getBundleOfType(bundle, ConfigurationSubstitutionBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(
+                  bundleAssertion.getBundleOfType(bundle, DefaultLoggingConfigurationBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, JacksonConfigurationBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(
+                  bundleAssertion.getBundleOfType(bundle, InternalHealthCheckEndpointBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, JaegerBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, OpenTracingBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, PrometheusBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, TraceTokenBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, SecurityBundle.class))
+              .isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, OpenApiBundle.class))
+              .isNotNull();
+          softly.assertThat(bundleAssertion.getBundleOfType(bundle, AuthBundle.class)).isNotNull();
+          softly.assertThat(bundleAssertion.getBundleOfType(bundle, CorsBundle.class)).isNotNull();
+          softly
+              .assertThat(bundleAssertion.getBundleOfType(bundle, ConsumerTokenBundle.class))
+              .isNotNull();
+          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(13);
+        });
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
@@ -34,7 +34,6 @@ public class SdaPlatformBundleBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withOptionalConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
@@ -11,6 +11,7 @@ import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBu
 import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.server.jaeger.JaegerBundle;
+import org.sdase.commons.server.opa.OpaBundle;
 import org.sdase.commons.server.openapi.OpenApiBundle;
 import org.sdase.commons.server.opentracing.OpenTracingBundle;
 import org.sdase.commons.server.prometheus.PrometheusBundle;
@@ -73,11 +74,12 @@ public class SdaPlatformBundleBuilderTest {
               .assertThat(bundleAssertion.getBundleOfType(bundle, OpenApiBundle.class))
               .isNotNull();
           softly.assertThat(bundleAssertion.getBundleOfType(bundle, AuthBundle.class)).isNotNull();
+          softly.assertThat(bundleAssertion.getBundleOfType(bundle, OpaBundle.class)).isNotNull();
           softly.assertThat(bundleAssertion.getBundleOfType(bundle, CorsBundle.class)).isNotNull();
           softly
               .assertThat(bundleAssertion.getBundleOfType(bundle, ConsumerTokenBundle.class))
               .isNotNull();
-          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(13);
+          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(14);
         });
   }
 }

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
@@ -1,0 +1,43 @@
+package org.sdase.commons.starter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.sdase.commons.server.security.SecurityBundle;
+import org.sdase.commons.starter.test.BundleAssertion;
+
+public class SecurityBuilderTest {
+
+  private BundleAssertion<SdaPlatformConfiguration> bundleAssertion;
+
+  @Before
+  public void setUp() {
+    bundleAssertion = new BundleAssertion<>();
+  }
+
+  @Test
+  public void defaultSecuritySettings() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, SecurityBundle.builder().build());
+  }
+
+  @Test
+  public void customizableLimitsSecuritySettings() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .disableBufferLimitValidationSecurityFeature()
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle, SecurityBundle.builder().disableBufferLimitValidation().build());
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
@@ -19,7 +19,6 @@ public class SecurityBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -32,7 +31,6 @@ public class SecurityBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .disableBufferLimitValidationSecurityFeature()
             .build();

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/BundleAssertion.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/BundleAssertion.java
@@ -1,0 +1,69 @@
+package org.sdase.commons.starter.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeastOnce;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.ConfiguredBundle;
+import io.dropwizard.setup.Bootstrap;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.sdase.commons.starter.SdaPlatformBundle;
+
+/**
+ * Helper class to assert that the {@link SdaPlatformBundle} configures other bundles as expected.
+ *
+ * <p>The {@code BundleAssertion} has to be initialized in a setup method annotated with {@link
+ * org.junit.Before}.
+ */
+public class BundleAssertion<C extends Configuration> {
+
+  private final Bootstrap<C> bootstrapMock;
+
+  private ArgumentCaptor<ConfiguredBundle> configuredBundlesCaptor;
+
+  private boolean verified;
+
+  public BundleAssertion() {
+    configuredBundlesCaptor = ArgumentCaptor.forClass(ConfiguredBundle.class);
+    //noinspection unchecked
+    bootstrapMock = Mockito.mock(Bootstrap.class);
+  }
+
+  public void assertBundleConfiguredByPlatformBundle(
+      SdaPlatformBundle<C> actual, ConfiguredBundle<?> expectedBundle) {
+    assertThat(getBundleOfType(actual, expectedBundle.getClass()))
+        .usingRecursiveComparison()
+        .isEqualTo(expectedBundle);
+  }
+
+  public void assertBundleNotConfiguredByPlatformBundle(
+      SdaPlatformBundle<C> bundle, Class<?> notExpectedBundleClass) {
+    assertThat(getBundleOfType(bundle, notExpectedBundleClass)).isNull();
+  }
+
+  public int countAddedBundles(SdaPlatformBundle<C> platformBundle) {
+    gatherBundles(platformBundle);
+    return configuredBundlesCaptor.getAllValues().size();
+  }
+
+  public <T> T getBundleOfType(SdaPlatformBundle<C> platformBundle, Class<T> bundleClass) {
+    gatherBundles(platformBundle);
+    //noinspection unchecked
+    return (T)
+        configuredBundlesCaptor.getAllValues().stream()
+            .filter(configuredBundle -> bundleClass.isAssignableFrom(configuredBundle.getClass()))
+            .findFirst()
+            .orElse(null);
+  }
+
+  private synchronized void gatherBundles(SdaPlatformBundle<C> platformBundle) {
+    if (verified) {
+      return;
+    }
+    platformBundle.initialize(bootstrapMock);
+    //noinspection unchecked
+    Mockito.verify(bootstrapMock, atLeastOnce()).addBundle(configuredBundlesCaptor.capture());
+    verified = true;
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
@@ -1,0 +1,64 @@
+package org.sdase.commons.starter.test;
+
+import io.dropwizard.Application;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.setup.Environment;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.info.Contact;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.info.License;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.Collections;
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.sdase.commons.starter.SdaPlatformBundle;
+import org.sdase.commons.starter.SdaPlatformConfiguration;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("")
+@OpenAPIDefinition(
+    info =
+        @Info(
+            title = "Starter",
+            description = "A test application",
+            version = "1.1.1",
+            contact =
+                @Contact(name = "John Doe", email = "info@example.com", url = "j.doe@example.com"),
+            license = @License(name = "Sample License")))
+public class StarterApp extends Application<SdaPlatformConfiguration> {
+
+  public static void main(String[] args) throws Exception {
+    new StarterApp().run(args);
+  }
+
+  @Override
+  public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
+    bootstrap.addBundle(
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withRequiredConsumerToken()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build());
+  }
+
+  @Override
+  public void run(SdaPlatformConfiguration configuration, Environment environment) {
+    environment.jersey().register(this);
+  }
+
+  @GET
+  @PermitAll
+  @Path("ping")
+  @Operation(
+      description = "Answers the ping request with a pong.",
+      summary = "The ping endpoint is usually used to check if the application is alive.")
+  @ApiResponses({@ApiResponse(responseCode = "200", description = "Successful ping")})
+  public Object getPing() {
+    return Collections.singletonMap("ping", "pong");
+  }
+}

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
@@ -41,7 +41,6 @@ public class StarterApp extends Application<SdaPlatformConfiguration> {
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build());
   }

--- a/sda-commons-starter/src/test/resources/example.yaml
+++ b/sda-commons-starter/src/test/resources/example.yaml
@@ -1,0 +1,104 @@
+openapi: 3.0.1
+info:
+  title: A manually written OpenAPI file
+  description: This is an example file that was written by hand
+  contact:
+    email: info@sda.se
+  version: '1.1'
+paths:
+  /house:
+    # this path will be added
+    put:
+      summary: Update a house
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/House'
+      responses:
+        "201":
+          description: The house has been updated
+    # this block will be replaced by the scanner output
+    get:
+      responses:
+        "200":
+          description: A successful response for the house
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/House'
+        "500":
+          description: An unexpected internal error
+  # this path will be added
+  /embed:
+    get:
+      responses:
+        "200":
+          description: A response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Embedded'
+  # this path will be added
+  /embedAllOf:
+    get:
+      responses:
+        "200":
+          description: A response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedAllOf'
+  # this path will be added
+  /embedAnyOf:
+    get:
+      responses:
+        "200":
+          description: A response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EmbeddedAnyOf'
+components:
+  schemas:
+    # this schema will be replaced by the scanner output
+    House:
+      description: A House description
+    # this schema will be added
+    Embedded:
+      description: An item that has embedded properties
+      properties:
+        _embedded:
+          properties:
+            one:
+              type: string
+            two:
+              type: string
+    # this schema will be added
+    EmbeddedAllOf:
+      description: An item that has embedded properties in multiple of allOf
+      allOf:
+        - properties:
+            _embedded:
+              properties:
+                three:
+                  type: string
+        - properties:
+            _embedded:
+              properties:
+                four:
+                  type: string
+    # this schema will be added
+    EmbeddedAnyOf:
+      description: An item that has embedded properties in multiple of anyOf
+      anyOf:
+        - properties:
+            _embedded:
+              properties:
+                three:
+                  type: string
+        - properties:
+            _embedded:
+              properties:
+                four:
+                  type: string

--- a/sda-commons-starter/src/test/resources/test-config.yaml
+++ b/sda-commons-starter/src/test/resources/test-config.yaml
@@ -1,0 +1,8 @@
+server:
+  applicationConnectors:
+  - type: http
+    port: 0
+  adminConnectors:
+  - type: http
+    port: 0
+  rootPath: "/api/*"

--- a/settings.gradle
+++ b/settings.gradle
@@ -49,4 +49,6 @@ include 'sda-commons-shared-error'
 include 'sda-commons-shared-tracing'
 include 'sda-commons-shared-forms'
 include 'sda-commons-shared-yaml'
+include 'sda-commons-starter'
+include 'sda-commons-starter-example'
 


### PR DESCRIPTION
This change introduces a new version of the `sda-commons-server-starter` module. The change contains the support of OpenApi 3. By integrating this module only OpenApi 3 annotations are supported in REST endpoint definitions (follow the the links for further details [1][2])

Due to the support of OpenApi 3 there are also changes to the SdaPlatformBundle. The creation of a dropwizard application differs slightly when using OpenApi 3. The following example shows how an application is created (see [3]):

```java
...

@OpenAPIDefinition(
    info =
        @Info(
            title = "SDA Platform Example Application",
            description =
                "This application is an example to show a developer how to create a SDA Dropwizard application",
            version = "1.1.1",
            contact =
                @Contact(name = "John Doe", email = "info@example.com", url = "j.doe@example.com")))
public class SdaPlatformExampleApplication extends Application<MyCustomConfiguration> {

  public static void main(String[] args) throws Exception {
    new SdaPlatformExampleApplication().run(args);
  }

  @override
  public void initialize(Bootstrap<MyCustomConfiguration> bootstrap) {
    bootstrap.addBundle(
        SdaPlatformBundle.builder()
            .usingSdaPlatformConfiguration(MyCustomConfiguration.class)
            // Additional Swagger documentation properties may be set here until
            // the packages that should be scanned for Swagger documentation annotations are defined
	    .addOpenApiResourcePackageClass(this.getClass())
            // or use an existing existing OpenAPI definition.
            // provide the path to the existing openapi file (yaml or json) in the classpath
            .withExistingOpenAPIFromClasspathResource("/custom-openapi.yaml")
            .build());
  }

  ...
```

Hint: Swagger / OpenApi 2 can be used by importing the module `sda-commons-server-starter-swagger`

[1] - https://github.com/SDA-SE/sda-dropwizard-commons/tree/master/sda-commons-server-openapi
[2] - https://github.com/swagger-api/swagger-core/wiki/Swagger-2.X---Annotations
[3] - https://github.com/SDA-SE/sda-dropwizard-commons/blob/master/sda-commons-server-starter-example/src/main/java/org/sdase/commons/server/starter/example/SdaPlatformExampleApplication.java