### PR TITLE
feat(starter): optimize the use of the configuration in the starter bundle

### DIFF
--- a/sda-commons-starter-example/config.yaml
+++ b/sda-commons-starter-example/config.yaml
@@ -2,5 +2,11 @@ auth:
   leeway: ${AUTH_LEEWAY:-0}
   keys: ${AUTH_KEYS:-[]}
 
+opa:
+  disableOpa: ${OPA_DISABLE:-false}
+  baseUrl: ${OPA_URL:-http://localhost:8181}
+  policyPackage: ${OPA_POLICY_PACKAGE:-<your_package>}
+  readTimeout: ${OPA_READ_TIMEOUT:-500}
+
 cors:
   allowedOrigins: ${CORS_ALLOWED_ORIGINS:-[]}

--- a/sda-commons-starter-example/local-config.yaml
+++ b/sda-commons-starter-example/local-config.yaml
@@ -1,6 +1,9 @@
 auth:
   disableAuth: true
 
+opa:
+  disableOpa: true
+
 cors:
   allowedOrigins:
   - "*"

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
@@ -54,7 +54,9 @@ public class SdaPlatformExampleApplication extends Application<SdaPlatformConfig
     //     (from sda-commons-server-auth)
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
-            // Use all defaults provided by the Server Starter module
+            // Use all defaults provided by the Server Starter module. OPA authorization is enabled
+            // automatically
+            //
             .usingSdaPlatformConfiguration()
             // Require a consumer token from the client. Only swagger.json/yaml is always
             // accessible.

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -91,6 +91,12 @@ auth:
   leeway: ${AUTH_LEEWAY:-0}
   keys: ${AUTH_KEYS:-[]}
 
+opa:
+  disableOpa: ${OPA_DISABLE:-false}
+  baseUrl: ${OPA_URL:-http://localhost:8181}
+  policyPackage: ${OPA_POLICY_PACKAGE:-<your_package>}
+  readTimeout: ${OPA_READ_TIMEOUT:-500}
+
 # See sda-commons-server-cors
 cors:
   # List of origins that are allowed to use the service. "*" allows all origins
@@ -104,7 +110,10 @@ cors:
   # allowedOrigins: ${CORS_ALLOWED_ORIGINS:-["*"]}
 ```
 
-Instead of `.usingSdaPlatformConfiguration()`, the configuration may be fully customized using 
+By using `.usingSdaPlatformConfiguration()` or `.usingSdaPlatformConfiguration(MyCustomConfiguration.class)` 
+the authorization including the open policy agent are automatically enabled as well as the cors settings. 
+
+Instead of `.usingSdaPlatformConfiguration()` and `.usingSdaPlatformConfiguration(MyCustomConfiguration.class)`, the configuration may be fully customized using 
 `.usingCustomConfig(MyCustomConfiguration.class)` to support configurations that do not extend 
 [`SdaPlatformConfiguration`](./src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java). This may 
 also be needed to disable some features of the starter module or add special features such as

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java
@@ -150,8 +150,14 @@ public class SdaPlatformBundle<C extends Configuration> implements ConfiguredBun
 
     @Override
     public ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration() {
-      return usingCustomConfig(SdaPlatformConfiguration.class)
-          .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
+      return usingSdaPlatformConfiguration(SdaPlatformConfiguration.class);
+    }
+
+    @Override
+    public <T extends SdaPlatformConfiguration>
+        ConsumerTokenConfigBuilder<T> usingSdaPlatformConfiguration(Class<T> configurationClass) {
+      return usingCustomConfig(configurationClass)
+          .withOpaAuthorization(SdaPlatformConfiguration::getAuth, SdaPlatformConfiguration::getOpa)
           .withCorsConfigProvider(SdaPlatformConfiguration::getCors);
     }
 

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
@@ -5,6 +5,7 @@ import org.sdase.commons.server.auth.config.AuthConfig;
 import org.sdase.commons.server.consumer.ConsumerTokenBundle;
 import org.sdase.commons.server.consumer.ConsumerTokenConfig;
 import org.sdase.commons.server.cors.CorsConfiguration;
+import org.sdase.commons.server.opa.config.OpaConfig;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
 
 /** Default configuration for the {@link SdaPlatformBundle}. */
@@ -12,6 +13,9 @@ public class SdaPlatformConfiguration extends Configuration {
 
   /** Configuration of authentication. */
   private AuthConfig auth = new AuthConfig();
+
+  /** Configuration of the open policy agent. */
+  private OpaConfig opa = new OpaConfig();
 
   /** Configuration of the CORS filter. */
   private CorsConfiguration cors = new CorsConfiguration();
@@ -55,6 +59,15 @@ public class SdaPlatformConfiguration extends Configuration {
 
   public SdaPlatformConfiguration setConsumerToken(ConsumerTokenConfig consumerToken) {
     this.consumerToken = consumerToken;
+    return this;
+  }
+
+  public OpaConfig getOpa() {
+    return opa;
+  }
+
+  public SdaPlatformConfiguration setOpa(OpaConfig opa) {
+    this.opa = opa;
     return this;
   }
 }

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
@@ -1,6 +1,9 @@
 package org.sdase.commons.starter.builder;
 
 import io.dropwizard.Configuration;
+import org.sdase.commons.server.auth.config.AuthConfigProvider;
+import org.sdase.commons.server.cors.CorsConfigProvider;
+import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.SdaPlatformBundle;
 import org.sdase.commons.starter.SdaPlatformConfiguration;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
@@ -15,6 +18,21 @@ public interface InitialPlatformBundleBuilder {
    * @return the builder instance
    */
   ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
+
+  /**
+   * Start an application that uses a customized configuration which extends the {@link
+   * SdaPlatformConfiguration} as base of it's configuration file.
+   *
+   * <p>The method automatically enables OPA authorization and sets therefore the authorization
+   * configuration via {@link AuthConfigProviderBuilder#withOpaAuthorization(AuthConfigProvider,
+   * OpaConfigProvider)} and the cors configuration via {@link
+   * org.sdase.commons.starter.builder.CustomConfigurationProviders.CorsConfigProviderBuilder#withCorsConfigProvider(CorsConfigProvider)}
+   *
+   * @param configurationClass - the customized configuration of the application
+   * @return the builder instance
+   */
+  <C extends SdaPlatformConfiguration> ConsumerTokenConfigBuilder<C> usingSdaPlatformConfiguration(
+      Class<C> configurationClass);
 
   /**
    * Start an application that uses a custom configuration has to define providers for the

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
@@ -32,8 +32,22 @@ public class AuthBuilderTest {
         bundle,
         AuthBundle.builder()
             .withAuthConfigProvider(SdaPlatformConfiguration::getAuth)
-            .withAnnotatedAuthorization()
+            .withExternalAuthorization()
             .build());
+  }
+
+  @Test
+  public void defaultOpa() {
+    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
+        SdaPlatformBundle.builder()
+            .usingSdaPlatformConfiguration()
+            .withoutConsumerTokenSupport()
+            .addOpenApiResourcePackageClass(this.getClass())
+            .build();
+
+    bundleAssertion.assertBundleConfiguredByPlatformBundle(
+        bundle,
+        OpaBundle.builder().withOpaConfigProvider(SdaPlatformConfiguration::getOpa).build());
   }
 
   @Test

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -95,7 +95,7 @@ public class FilterPriorityTest {
             .header("Consumer-Token", "MyConsumer")
             .get();
 
-    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getStatus()).isEqualTo(403);
 
     String metrics =
         DW.client()

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleAppTest.java
@@ -18,9 +18,7 @@ public class SdaPlatformBundleAppTest {
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
       new DropwizardAppRule<>(
-          StarterApp.class,
-          resourceFilePath("test-config.yaml"),
-          config("auth.disableAuth", "true"));
+          StarterApp.class, resourceFilePath("test-config.yaml"), config("opa.disableOpa", "true"));
 
   @Test
   public void pongForPing() {

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
@@ -11,6 +11,7 @@ import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBu
 import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.server.jaeger.JaegerBundle;
+import org.sdase.commons.server.opa.OpaBundle;
 import org.sdase.commons.server.openapi.OpenApiBundle;
 import org.sdase.commons.server.opentracing.OpenTracingBundle;
 import org.sdase.commons.server.prometheus.PrometheusBundle;
@@ -73,11 +74,12 @@ public class SdaPlatformBundleBuilderTest {
               .assertThat(bundleAssertion.getBundleOfType(bundle, OpenApiBundle.class))
               .isNotNull();
           softly.assertThat(bundleAssertion.getBundleOfType(bundle, AuthBundle.class)).isNotNull();
+          softly.assertThat(bundleAssertion.getBundleOfType(bundle, OpaBundle.class)).isNotNull();
           softly.assertThat(bundleAssertion.getBundleOfType(bundle, CorsBundle.class)).isNotNull();
           softly
               .assertThat(bundleAssertion.getBundleOfType(bundle, ConsumerTokenBundle.class))
               .isNotNull();
-          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(13);
+          softly.assertThat(bundleAssertion.countAddedBundles(bundle)).isEqualTo(14);
         });
   }
 }


### PR DESCRIPTION
This commit includes two major changes:
(1) - Users can simply add its custom Dropwizard configuration to initialize the application, if the defaults regarding authorization and CORS are used. Please take a look at the example down below.
(2) - The open policy agent is enabled by default, if `.usingSdaPlatformConfiguration()` or `.usingSdaPlatformConfiguration(MyCustomConfiguration.class)` is used to define the application. From now on all users must configure the open policy agent probably, i.e. configure a policy and add OPA properties to the configuration file. Please check out the [auth-bundle](https://github.com/SDA-SE/sda-dropwizard-commons/tree/master/sda-commons-server-auth) for detailed information.

Example:

Instead of writing the following:

```java

public class MyCustomApplication extends Application<MyCustomConfiguration>

  @override
  public void initialize(Bootstrap<MyCustomConfiguration> bootstrap) {
    bootstrap.addBundle(
        SdaPlatformBundle.builder()
            .usingCustomConfig(MyCustomConfiguration.class)
            .withAuthConfigProvider(MyCustomConfiguration::getAuth)
            .withCorsConfigProvider(MyCustomConfiguration::getCors)
            ...
            .build());

    bootstrap.addBundle(
        OpaBundle.builder().withOpaConfigProvider(MyCustomConfiguration::getOpa).build());
  }

...

```

The developer can now write the same logic much shorter, since OPA is enabled by default and `usingSdaPlatformConfiguration(...)` can handle custom configurations:

```java

public class MyCustomApplication extends Application<MyCustomConfiguration>

  @override
  public void initialize(Bootstrap<MyCustomConfiguration> bootstrap) {
    bootstrap.addBundle(
        SdaPlatformBundle.builder()
            .usingSdaPlatformConfiguration(MyCustomConfiguration.class)
            ...
            .build());
  }

...

```
