### PR TITLE
fix: deprecate accidentally introduced package `org.sda.`

### DIFF
--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkMethodInvocationException.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkMethodInvocationException.java
@@ -1,6 +1,14 @@
 package org.sda.commons.server.jackson.hal;
 
-public class HalLinkMethodInvocationException extends RuntimeException {
+/**
+ * @deprecated this package has been created by mistake. The {@code
+ *     HalLinkMethodInvocationException} moved to {@link
+ *     org.sdase.commons.server.jackson.hal.HalLinkMethodInvocationException}, please update the
+ *     imports.
+ */
+@Deprecated
+public class HalLinkMethodInvocationException
+    extends org.sdase.commons.server.jackson.hal.HalLinkMethodInvocationException {
 
   public HalLinkMethodInvocationException(String message) {
     super(message);

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/HalLinkProvider.java
@@ -1,17 +1,7 @@
 package org.sda.commons.server.jackson.hal;
 
-import io.openapitools.jackson.dataformat.hal.HALLink;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Feature;
 import javax.ws.rs.core.FeatureContext;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriInfo;
-import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
-import org.sda.commons.server.jackson.hal.HalLinkInvocationStateUtility.MethodInvocationState;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Helper utility which is registered as singleton instance in the jersey environment via the
@@ -41,123 +31,34 @@ import org.slf4j.LoggerFactory;
  * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs. If
  * no request context is available, it will fall back to a simple path without host that does not
  * include any configured root or context path.
+ *
+ * @deprecated this package has been created by mistake. The {@code HalLinkProvider} moved to {@link
+ *     org.sdase.commons.server.jackson.hal.HalLinkProvider}, please update the imports.
  */
+@Deprecated
 public class HalLinkProvider implements Feature {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HalLinkProvider.class);
-  private static HalLinkProvider instance;
-
-  @Context private UriInfo uriInfo;
-
-  private HalLinkProvider() {}
-
   /**
-   * Creates a {@linkplain HALLink} based on JAX-RS annotated parameters of an interface. This
-   * method requires a second entrypoint with {@linkplain
-   * HalLinkInvocationStateUtility#methodOn(Class)} to process the annotated JAX-RS interface with
-   * the corresponding {@linkplain PathParam} and {@linkplain QueryParam} and the passed arguments
-   * to the proxied method invocation.
-   *
-   * <p>Example:
-   *
-   * <pre>
-   * &#064;Path("")
-   * interface TestApi {
-   *  &#064;Path("/testPath/{testArg}")
-   *  &#064;GET
-   *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
-   * }
-   *
-   * // Get the generated HALLink
-   * HALLink halLink = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asHalLink();
-   * // Get the generated URI
-   * URI uri = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asURI();
-   * </pre>
-   *
-   * <p>The example would create the following URI: {@code
-   * "baseUri/testPath/ResourceID?query=detailed"}
-   *
-   * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs.
-   * If no request context is available, it will fall back to a simple path without host that does
-   * not include any configured root or context path.
-   *
-   * @param invocation the invocation placeholder.
-   * @return the generated {@linkplain LinkResult} based on the method invocation
-   * @throws HalLinkMethodInvocationException - If no method invocation is provided via {@linkplain
-   *     HalLinkProvider#methodOn(Class)}
+   * @deprecated use {@link org.sdase.commons.server.jackson.hal.HalLinkProvider#linkTo(Object)}
+   *     instead
    */
+  @Deprecated
   public static LinkResult linkTo(Object invocation) {
-    return getInstance().linkToInvocation(invocation);
-  }
-
-  private LinkResult linkToInvocation(Object invocation) {
-    final MethodInvocationState methodInvocationState =
-        HalLinkInvocationStateUtility.loadMethodInvocationState();
-    if (invocation != null || !methodInvocationState.isProcessed()) {
-      throw new HalLinkMethodInvocationException("No proxied method invocation processed.");
-    }
-    final UriBuilder uriBuilder =
-        baseUriBuilder()
-            .path(methodInvocationState.getType())
-            .path(methodInvocationState.getType(), methodInvocationState.getInvokedMethod())
-            // Add Path Params from invocation state
-            .resolveTemplates(methodInvocationState.getPathParams());
-    // Add Query Params from invocation state
-    methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
-    LinkResult linkResult = new LinkResult(uriBuilder.build());
-    HalLinkInvocationStateUtility.unloadMethodInvocationState();
-    return linkResult;
+    return new LinkResult(
+        org.sdase.commons.server.jackson.hal.HalLinkProvider.linkTo(invocation).asUri());
   }
 
   /**
-   * Creates and returns a proxy instance based on the passed type parameter with a method
-   * invocation handler, which processes and saves the needed method invocation information in the
-   * current thread. Parameters in the afterwards called method of the proxy will be used to resolve
-   * the URI template of the corresponding method. The called method of the interface must have a
-   * return type, which means it should not be of type {@code void}.
-   *
-   * <p>After the method invocation of the proxy instance the outer method {@linkplain
-   * HalLinkProvider#linkTo(Object)} will process the derived information of the invocation to
-   * create the HALLink.
-   *
-   * <p>It should be ensured that the parameters are annotated with {@linkplain PathParam} or with
-   * {@linkplain QueryParam}. The passed class type must represent interfaces, not classes or
-   * primitive types.
-   *
-   * @param <T> the type parameter based on the passed type.
-   * @param type the type on which the method should be invoked must be an interface.
-   * @return the proxy instance
-   * @throws HalLinkMethodInvocationException if the proxy instance could not be created
+   * @deprecated use {@link org.sdase.commons.server.jackson.hal.HalLinkProvider#linkTo(Object)}
+   *     instead
    */
+  @Deprecated
   public static <T> T methodOn(Class<T> type) {
-    return HalLinkInvocationStateUtility.methodOn(type);
-  }
-
-  private UriBuilder baseUriBuilder() {
-    try {
-      return uriInfo.getBaseUriBuilder();
-    } catch (Exception e) {
-      LOG.error(
-          "Unable to access baseUriBuilder from request context. Using context unaware builder as a fallback.",
-          e);
-      return new JerseyUriBuilder().path("/");
-    }
+    return org.sdase.commons.server.jackson.hal.HalLinkProvider.methodOn(type);
   }
 
   @Override
   public boolean configure(FeatureContext context) {
     return true;
-  }
-
-  /**
-   * Returns the singleton instance of the HalLinkProvider
-   *
-   * @return the HalLinProvider instance
-   */
-  public static synchronized HalLinkProvider getInstance() {
-    if (instance == null) {
-      instance = new HalLinkProvider();
-    }
-    return instance;
   }
 }

--- a/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/LinkResult.java
+++ b/sda-commons-server-jackson/src/main/java/org/sda/commons/server/jackson/hal/LinkResult.java
@@ -1,13 +1,16 @@
 package org.sda.commons.server.jackson.hal;
 
 import io.openapitools.jackson.dataformat.hal.HALLink;
-import io.openapitools.jackson.dataformat.hal.HALLink.Builder;
 import java.net.URI;
 
-/** Wrapper class to provide the processed Link as {@linkplain URI} or {@linkplain HALLink} */
-public final class LinkResult {
-  private final URI uri;
-  private final HALLink halLink;
+/**
+ * Wrapper class to provide the processed Link as {@linkplain URI} or {@linkplain HALLink}
+ *
+ * @deprecated this package has been created by mistake. The {@code LinkResult} moved to {@link
+ *     org.sdase.commons.server.jackson.hal.LinkResult}, please update the imports.
+ */
+@Deprecated
+public final class LinkResult extends org.sdase.commons.server.jackson.hal.LinkResult {
 
   /**
    * Instantiates a new Link result.
@@ -15,25 +18,6 @@ public final class LinkResult {
    * @param uri the uri
    */
   public LinkResult(URI uri) {
-    this.uri = uri;
-    this.halLink = new Builder(uri).build();
-  }
-
-  /**
-   * Returns the link result as {@linkplain URI}
-   *
-   * @return the uri
-   */
-  public URI asUri() {
-    return this.uri;
-  }
-
-  /**
-   * Returns the link result as {@linkplain HALLink}
-   *
-   * @return the hal link
-   */
-  public HALLink asHalLink() {
-    return halLink;
+    super(uri);
   }
 }

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/JacksonConfigurationBundle.java
@@ -9,7 +9,6 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.time.ZonedDateTime;
 import java.util.function.Consumer;
-import org.sda.commons.server.jackson.hal.HalLinkProvider;
 import org.sdase.commons.server.jackson.errors.ApiExceptionMapper;
 import org.sdase.commons.server.jackson.errors.EarlyEofExceptionMapper;
 import org.sdase.commons.server.jackson.errors.JacksonPropertyNodeNameProvider;
@@ -19,6 +18,7 @@ import org.sdase.commons.server.jackson.errors.RuntimeExceptionMapper;
 import org.sdase.commons.server.jackson.errors.ValidationExceptionMapper;
 import org.sdase.commons.server.jackson.errors.WebApplicationExceptionMapper;
 import org.sdase.commons.server.jackson.filter.JacksonFieldFilterModule;
+import org.sdase.commons.server.jackson.hal.HalLinkProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkInvocationStateUtility.java
@@ -1,4 +1,4 @@
-package org.sda.commons.server.jackson.hal;
+package org.sdase.commons.server.jackson.hal;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Parameter;
@@ -68,7 +68,9 @@ public class HalLinkInvocationStateUtility {
           Proxy.newProxyInstance(
               type.getClassLoader(), new Class[] {type}, METHOD_PROCESSING_INVOCATION_HANDLER);
     } catch (IllegalArgumentException | SecurityException | NullPointerException e) {
-      throw new HalLinkMethodInvocationException(
+      // Deprecated type needed for backward compatibility until deprecated package is removed
+      // afterwards the the class from this package can be used
+      throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
           String.format("Could not create proxy instance of type '%s' for method invocation", type),
           e);
     }
@@ -88,7 +90,9 @@ public class HalLinkInvocationStateUtility {
 
     // Check if all parameters has an Query/Path-Param annotation
     if (annotatedParams.size() != parameters.length) {
-      throw new HalLinkMethodInvocationException(
+      // Deprecated type needed for backward compatibility until deprecated package is removed
+      // afterwards the the class from this package can be used
+      throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
           "Each method parameter needs at least a @PathParam or @QueryParam annotation.");
     }
 

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkMethodInvocationException.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkMethodInvocationException.java
@@ -1,0 +1,12 @@
+package org.sdase.commons.server.jackson.hal;
+
+public class HalLinkMethodInvocationException extends RuntimeException {
+
+  public HalLinkMethodInvocationException(String message) {
+    super(message);
+  }
+
+  public HalLinkMethodInvocationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
@@ -1,0 +1,165 @@
+package org.sdase.commons.server.jackson.hal;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriInfo;
+import org.glassfish.jersey.uri.internal.JerseyUriBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper utility which is registered as singleton instance in the jersey environment via the
+ * {@linkplain org.sdase.commons.server.jackson.JacksonConfigurationBundle}. It provides the
+ * context-based HALLink for a JAX-RS interface using the {@linkplain PathParam} and {@linkplain
+ * QueryParam} annotations.
+ *
+ * <p>Usage:
+ *
+ * <pre>
+ * &#064;Path("")
+ * interface TestApi {
+ *  &#064;Path("/testPath/{testArg}")
+ *  &#064;GET
+ *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
+ * }
+ *
+ * // Get the generated HALLink
+ * HALLink HalLink = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asHalLink();
+ * // Get the generated URI
+ * URI Uri = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asURI();
+ * </pre>
+ *
+ * <p>The example would create the following URI: {@code
+ * "baseUri/testPath/ResourceID?query=detailed"}
+ *
+ * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs. If
+ * no request context is available, it will fall back to a simple path without host that does not
+ * include any configured root or context path.
+ */
+public class HalLinkProvider implements Feature {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HalLinkProvider.class);
+  private static HalLinkProvider instance;
+
+  @Context private UriInfo uriInfo;
+
+  private HalLinkProvider() {}
+
+  /**
+   * Creates a {@linkplain HALLink} based on JAX-RS annotated parameters of an interface. This
+   * method requires a second entrypoint with {@linkplain
+   * HalLinkInvocationStateUtility#methodOn(Class)} to process the annotated JAX-RS interface with
+   * the corresponding {@linkplain PathParam} and {@linkplain QueryParam} and the passed arguments
+   * to the proxied method invocation.
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * &#064;Path("")
+   * interface TestApi {
+   *  &#064;Path("/testPath/{testArg}")
+   *  &#064;GET
+   *  String testMethod(@PathParam("testArg") String testArg, @QueryParam("query") query);
+   * }
+   *
+   * // Get the generated HALLink
+   * HALLink halLink = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asHalLink();
+   * // Get the generated URI
+   * URI uri = linkTo(methodOn(TestApi.class).testMethod("ResourceID", "detailed")).asURI();
+   * </pre>
+   *
+   * <p>The example would create the following URI: {@code
+   * "baseUri/testPath/ResourceID?query=detailed"}
+   *
+   * <p>The builder will use the `UriInfo` of the current request context to create absolute URIs.
+   * If no request context is available, it will fall back to a simple path without host that does
+   * not include any configured root or context path.
+   *
+   * @param invocation the invocation placeholder.
+   * @return the generated {@linkplain LinkResult} based on the method invocation
+   * @throws HalLinkMethodInvocationException - If no method invocation is provided via {@linkplain
+   *     HalLinkProvider#methodOn(Class)}
+   */
+  public static LinkResult linkTo(Object invocation) {
+    return getInstance().linkToInvocation(invocation);
+  }
+
+  private LinkResult linkToInvocation(Object invocation) {
+    final HalLinkInvocationStateUtility.MethodInvocationState methodInvocationState =
+        HalLinkInvocationStateUtility.loadMethodInvocationState();
+    if (invocation != null || !methodInvocationState.isProcessed()) {
+      // Deprecated type needed for backward compatibility until deprecated package is removed
+      // afterwards the the class from this package can be used
+      throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
+          "No proxied method invocation processed.");
+    }
+    final UriBuilder uriBuilder =
+        baseUriBuilder()
+            .path(methodInvocationState.getType())
+            .path(methodInvocationState.getType(), methodInvocationState.getInvokedMethod())
+            // Add Path Params from invocation state
+            .resolveTemplates(methodInvocationState.getPathParams());
+    // Add Query Params from invocation state
+    methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
+    LinkResult linkResult = new LinkResult(uriBuilder.build());
+    HalLinkInvocationStateUtility.unloadMethodInvocationState();
+    return linkResult;
+  }
+
+  /**
+   * Creates and returns a proxy instance based on the passed type parameter with a method
+   * invocation handler, which processes and saves the needed method invocation information in the
+   * current thread. Parameters in the afterwards called method of the proxy will be used to resolve
+   * the URI template of the corresponding method. The called method of the interface must have a
+   * return type, which means it should not be of type {@code void}.
+   *
+   * <p>After the method invocation of the proxy instance the outer method {@linkplain
+   * HalLinkProvider#linkTo(Object)} will process the derived information of the invocation to
+   * create the HALLink.
+   *
+   * <p>It should be ensured that the parameters are annotated with {@linkplain PathParam} or with
+   * {@linkplain QueryParam}. The passed class type must represent interfaces, not classes or
+   * primitive types.
+   *
+   * @param <T> the type parameter based on the passed type.
+   * @param type the type on which the method should be invoked must be an interface.
+   * @return the proxy instance
+   * @throws HalLinkMethodInvocationException if the proxy instance could not be created
+   */
+  public static <T> T methodOn(Class<T> type) {
+    return HalLinkInvocationStateUtility.methodOn(type);
+  }
+
+  private UriBuilder baseUriBuilder() {
+    try {
+      return uriInfo.getBaseUriBuilder();
+    } catch (Exception e) {
+      LOG.error(
+          "Unable to access baseUriBuilder from request context. Using context unaware builder as a fallback.",
+          e);
+      return new JerseyUriBuilder().path("/");
+    }
+  }
+
+  @Override
+  public boolean configure(FeatureContext context) {
+    return true;
+  }
+
+  /**
+   * Returns the singleton instance of the HalLinkProvider
+   *
+   * @return the HalLinProvider instance
+   */
+  public static synchronized HalLinkProvider getInstance() {
+    if (instance == null) {
+      instance = new HalLinkProvider();
+    }
+    return instance;
+  }
+}

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/LinkResult.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/LinkResult.java
@@ -1,0 +1,39 @@
+package org.sdase.commons.server.jackson.hal;
+
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.HALLink.Builder;
+import java.net.URI;
+
+/** Wrapper class to provide the processed Link as {@linkplain URI} or {@linkplain HALLink} */
+public class LinkResult {
+  private final URI uri;
+  private final HALLink halLink;
+
+  /**
+   * Instantiates a new Link result.
+   *
+   * @param uri the uri
+   */
+  public LinkResult(URI uri) {
+    this.uri = uri;
+    this.halLink = new Builder(uri).build();
+  }
+
+  /**
+   * Returns the link result as {@linkplain URI}
+   *
+   * @return the uri
+   */
+  public URI asUri() {
+    return this.uri;
+  }
+
+  /**
+   * Returns the link result as {@linkplain HALLink}
+   *
+   * @return the hal link
+   */
+  public HALLink asHalLink() {
+    return halLink;
+  }
+}

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/hal/HalLinkProviderTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/hal/HalLinkProviderTest.java
@@ -1,4 +1,4 @@
-package org.sda.commons.server.jackson.hal;
+package org.sdase.commons.server.jackson.hal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,37 +12,41 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import org.junit.Test;
+import org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException;
+import org.sda.commons.server.jackson.hal.LinkResult;
 
 public class HalLinkProviderTest {
 
   @Test
   public void shouldProvideHalLinkForNormalPathParams() {
-    final LinkResult linkResult = linkTo(methodOn(TestApi.class).testMethod("TEST"));
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
+        linkTo(methodOn(TestApi.class).testMethod("TEST"));
     assertLinkResult(linkResult, "/testPath/TEST");
   }
 
   @Test
   public void shouldFailWhenNoInterfaceIsProvided() {
     assertThatThrownBy(() -> linkTo(methodOn(TestController.class).testMethod("FAIL")))
-        .isInstanceOf(HalLinkMethodInvocationException.class);
+        .isInstanceOf(org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException.class);
   }
 
   @Test
   public void shouldProvideHalLinkForQueryParam() {
-    final LinkResult linkResult = linkTo(methodOn(TestApi.class).testMethodQueryParam("TEST"));
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
+        linkTo(methodOn(TestApi.class).testMethodQueryParam("TEST"));
     assertLinkResult(linkResult, "/testPath?testRequestParam=TEST");
   }
 
   @Test
   public void shouldProvideHalLinkForDetailed() {
-    final LinkResult linkResult =
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
         linkTo(methodOn(TestApi.class).testMethodDetail("TEST", 1, "testTheQuery"));
     assertLinkResult(linkResult, "/testPath/TEST/detail/testTheQuery?query=1");
   }
 
   @Test
   public void shouldProvideHalLinkForDetailedAndIgnoreQueryParamWithNullValue() {
-    final LinkResult linkResult =
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
         linkTo(methodOn(TestApi.class).testMethodDetail("TEST", null, "testTheQuery"));
     assertLinkResult(linkResult, "/testPath/TEST/detail/testTheQuery");
   }
@@ -51,19 +55,20 @@ public class HalLinkProviderTest {
   public void shouldFailWithoutAnnotation() {
     assertThatThrownBy(
             () -> linkTo(methodOn(TestApi.class).testMethodWithoutPathParamAnnotation("FAIL")))
-        .isInstanceOf(HalLinkMethodInvocationException.class);
+        .isInstanceOf(org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException.class);
   }
 
   @Test
   public void shouldDoNothingWhenNoParamsAreProvided() {
-    final LinkResult linkResult = linkTo(methodOn(TestApi.class).testMethodWithoutParams());
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
+        linkTo(methodOn(TestApi.class).testMethodWithoutParams());
     assertLinkResult(linkResult, "/testPathWithNoParams");
   }
 
   @Test
   public void shouldFailWithNonProxiedMethod() {
     assertThatThrownBy(() -> linkTo("testMethod"))
-        .isInstanceOf(HalLinkMethodInvocationException.class);
+        .isInstanceOf(org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException.class);
   }
 
   @Test


### PR DESCRIPTION
All classes have been moved to `org.sdase.`

The change should be backward compatible therefore the tests still point to the deprecated classes.

Once the deprecated code is removed, the new exception must be thrown and the test must use the types from the same package.