### PR TITLE
feat(starter): use optional consumer token by default

### DIFF
--- a/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
+++ b/sda-commons-server-openapi-example/src/main/java/org/sdase/commons/server/openapi/example/OpenApiExampleApplication.java
@@ -19,10 +19,8 @@ public class OpenApiExampleApplication extends Application<SdaPlatformConfigurat
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             // The following part configures the OpenApi bundle. It is required that the resource
-            // package
-            // class is configured.
+            // package class is configured.
             .addOpenApiResourcePackageClass(getClass())
             .build());
   }

--- a/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
+++ b/sda-commons-server-prometheus-example/src/main/java/org/sdase/commons/server/prometheus/example/MetricExampleApp.java
@@ -20,7 +20,6 @@ public class MetricExampleApp extends Application<SdaPlatformConfiguration> {
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build());
   }

--- a/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
+++ b/sda-commons-starter-example/src/main/java/org/sdase/commons/starter/example/SdaPlatformExampleApplication.java
@@ -55,13 +55,8 @@ public class SdaPlatformExampleApplication extends Application<SdaPlatformConfig
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             // Use all defaults provided by the Server Starter module. OPA authorization is enabled
-            // automatically
-            //
+            // by default
             .usingSdaPlatformConfiguration()
-            // Require a consumer token from the client. Only swagger.json/yaml is always
-            // accessible.
-            // (from sda-commons-server-consumer)
-            .withRequiredConsumerToken()
             // Additional Swagger documentation properties may be set here until
             // the packages that should be scanned for Swagger documentation annotations are defined
             .addOpenApiResourcePackageClass(this.getClass())

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
@@ -75,18 +75,6 @@ public class SdaPlatformExampleApplicationIT {
   }
 
   @Test
-  public void rejectApiRequestWithoutConsumerToken() {
-    Response response =
-        baseUrlWebTarget()
-            .path("people")
-            .request(APPLICATION_JSON)
-            .headers(AUTH.auth().buildAuthHeader())
-            .get();
-
-    assertThat(response.getStatus()).isEqualTo(401);
-  }
-
-  @Test
   public void accessApiWithAuthenticationAndConsumerToken() {
     OPA.mock(onAnyRequest().allow());
     Response response =

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -19,7 +19,6 @@ automatically contain
 
 They may be configured easily to
 
-- [require a Consumer token from clients](../sda-commons-server-consumer/README.md)
 - [allow cross origin resource sharing](../sda-commons-server-cors/README.md)
 - [use the Open Policy Agent for authorization](../sda-commons-server-auth/README.md)
 
@@ -59,7 +58,6 @@ public class MyFirstApp extends Application<SdaPlatformConfiguration> {
    public void initialize(Bootstrap<SdaPlatformConfiguration> bootstrap) {
       bootstrap.addBundle(SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             // more Swagger data that may also be added with annotations
             .addSwaggerResourcePackageClass(this.getClass())
             // or use an existing OpenApi definition

--- a/sda-commons-starter/build.gradle
+++ b/sda-commons-starter/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   compile project(':sda-commons-server-trace')
 
   testCompile project(':sda-commons-server-testing')
+  testCompile project(':sda-commons-server-auth-testing')
 }
 
 test {

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformConfiguration.java
@@ -2,11 +2,8 @@ package org.sdase.commons.starter;
 
 import io.dropwizard.Configuration;
 import org.sdase.commons.server.auth.config.AuthConfig;
-import org.sdase.commons.server.consumer.ConsumerTokenBundle;
-import org.sdase.commons.server.consumer.ConsumerTokenConfig;
 import org.sdase.commons.server.cors.CorsConfiguration;
 import org.sdase.commons.server.opa.config.OpaConfig;
-import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
 
 /** Default configuration for the {@link SdaPlatformBundle}. */
 public class SdaPlatformConfiguration extends Configuration {
@@ -19,21 +16,6 @@ public class SdaPlatformConfiguration extends Configuration {
 
   /** Configuration of the CORS filter. */
   private CorsConfiguration cors = new CorsConfiguration();
-
-  /**
-   * Configuration of the consumer token. This configuration only affects the consumer token bundle,
-   * if it is explicitly added using {@link
-   * ConsumerTokenConfigBuilder#withConsumerTokenConfigProvider(ConsumerTokenBundle.ConsumerTokenConfigProvider)}:
-   *
-   * <pre>{@code
-   * SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-   *     SdaPlatformBundle.builder()
-   *         .usingSdaPlatformConfiguration()
-   *         .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-   *         // ...
-   * }</pre>
-   */
-  private ConsumerTokenConfig consumerToken = new ConsumerTokenConfig();
 
   public AuthConfig getAuth() {
     return auth;
@@ -50,15 +32,6 @@ public class SdaPlatformConfiguration extends Configuration {
 
   public SdaPlatformConfiguration setCors(CorsConfiguration cors) {
     this.cors = cors;
-    return this;
-  }
-
-  public ConsumerTokenConfig getConsumerToken() {
-    return consumerToken;
-  }
-
-  public SdaPlatformConfiguration setConsumerToken(ConsumerTokenConfig consumerToken) {
-    this.consumerToken = consumerToken;
     return this;
   }
 

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/CustomConfigurationProviders.java
@@ -2,7 +2,6 @@ package org.sdase.commons.starter.builder;
 
 import io.dropwizard.Configuration;
 import org.sdase.commons.server.auth.config.AuthConfigProvider;
-import org.sdase.commons.server.consumer.ConsumerTokenBundle.ConsumerTokenConfigProvider;
 import org.sdase.commons.server.cors.CorsConfigProvider;
 import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
@@ -55,62 +54,13 @@ public interface CustomConfigurationProviders {
      *
      * @return the builder instance
      */
-    ConsumerTokenConfigBuilder<C> withoutCorsSupport();
+    OpenApiInitialBuilder<C> withoutCorsSupport();
 
     /**
      * @param corsConfigProvider a provider, for the {@link
      *     org.sdase.commons.server.cors.CorsConfiguration}, e.g. {@code MyAppConfig::getCors}
      * @return the builder instance
      */
-    ConsumerTokenConfigBuilder<C> withCorsConfigProvider(CorsConfigProvider<C> corsConfigProvider);
-  }
-
-  interface ConsumerTokenConfigBuilder<C extends Configuration> {
-
-    /**
-     * Disable consumer token support. Consumer tokens are not required to access this service and
-     * will be ignored if a client sends them.
-     *
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withoutConsumerTokenSupport();
-
-    /**
-     * Disable consumer token support. Consumer tokens are not required to access this service but
-     * will be tracked if a client sends them.
-     *
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withOptionalConsumerToken();
-
-    /**
-     * Enable consumer token support. Consumer tokens are required to access this service. Further
-     * configuration may exclude paths from this requirement.
-     *
-     * @return the builder instance
-     */
-    ConsumerTokenRequiredConfigInitialBuilder<C> withRequiredConsumerToken();
-
-    /**
-     * Configure consumer token support based on provided configuration per instance.
-     *
-     * @param consumerTokenConfigProvider the provider of the configuration, e.g. {@code
-     *     MyConfig::getConsumerToken}
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withConsumerTokenConfigProvider(
-        ConsumerTokenConfigProvider<C> consumerTokenConfigProvider);
-  }
-
-  interface ConsumerTokenRequiredConfigInitialBuilder<C extends Configuration>
-      extends OpenApiInitialBuilder<C> {
-
-    /**
-     * Define paths by regex patterns that do not require a consumer token from the client.
-     *
-     * @param regex regex that matches paths that do not require a consumer token from the client
-     * @return the builder instance
-     */
-    OpenApiInitialBuilder<C> withExcludePatternsForRequiredConsumerToken(String... regex);
+    OpenApiInitialBuilder<C> withCorsConfigProvider(CorsConfigProvider<C> corsConfigProvider);
   }
 }

--- a/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
+++ b/sda-commons-starter/src/main/java/org/sdase/commons/starter/builder/InitialPlatformBundleBuilder.java
@@ -7,7 +7,7 @@ import org.sdase.commons.server.opa.config.OpaConfigProvider;
 import org.sdase.commons.starter.SdaPlatformBundle;
 import org.sdase.commons.starter.SdaPlatformConfiguration;
 import org.sdase.commons.starter.builder.CustomConfigurationProviders.AuthConfigProviderBuilder;
-import org.sdase.commons.starter.builder.CustomConfigurationProviders.ConsumerTokenConfigBuilder;
+import org.sdase.commons.starter.builder.OpenApiCustomizer.OpenApiInitialBuilder;
 
 public interface InitialPlatformBundleBuilder {
 
@@ -17,7 +17,7 @@ public interface InitialPlatformBundleBuilder {
    *
    * @return the builder instance
    */
-  ConsumerTokenConfigBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
+  OpenApiInitialBuilder<SdaPlatformConfiguration> usingSdaPlatformConfiguration();
 
   /**
    * Start an application that uses a customized configuration which extends the {@link
@@ -31,7 +31,7 @@ public interface InitialPlatformBundleBuilder {
    * @param configurationClass - the customized configuration of the application
    * @return the builder instance
    */
-  <C extends SdaPlatformConfiguration> ConsumerTokenConfigBuilder<C> usingSdaPlatformConfiguration(
+  <C extends SdaPlatformConfiguration> OpenApiInitialBuilder<C> usingSdaPlatformConfiguration(
       Class<C> configurationClass);
 
   /**

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/AuthBuilderTest.java
@@ -24,7 +24,6 @@ public class AuthBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -41,7 +40,6 @@ public class AuthBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -60,7 +58,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withAuthConfigProvider(acp)
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -77,7 +74,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withoutAuthentication()
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -95,7 +91,6 @@ public class AuthBuilderTest {
             .usingCustomConfig(SdaPlatformConfiguration.class)
             .withOpaAuthorization(acp, ocp)
             .withoutCorsSupport()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/ConsumerTokenBuilderTest.java
@@ -31,23 +31,10 @@ public class ConsumerTokenBuilderTest {
   }
 
   @Test
-  public void withoutConsumerToken() {
+  public void withOptionalConsumerTokenByDefault() {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    bundleAssertion.assertBundleNotConfiguredByPlatformBundle(bundle, ConsumerTokenBundle.class);
-  }
-
-  @Test
-  public void withOptionalConsumerToken() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withOptionalConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -60,47 +47,11 @@ public class ConsumerTokenBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
     verifyRegisteredConsumerTokenFiltersEqual(
-        bundle, ConsumerTokenBundle.builder().withRequiredConsumerToken().build());
-  }
-
-  @Test
-  public void withRequiredConsumerTokenAndExcludedPaths() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
-            .withExcludePatternsForRequiredConsumerToken("/public", "/ping")
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    verifyRegisteredConsumerTokenFiltersEqual(
-        bundle,
-        ConsumerTokenBundle.builder()
-            .withRequiredConsumerToken()
-            .withExcludePatterns("/public", "/ping")
-            .build());
-  }
-
-  @Test
-  public void withConfigurableConsumerToken() {
-    SdaPlatformBundle<SdaPlatformConfiguration> bundle =
-        SdaPlatformBundle.builder()
-            .usingSdaPlatformConfiguration()
-            .withConsumerTokenConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-            .addOpenApiResourcePackageClass(this.getClass())
-            .build();
-
-    verifyRegisteredConsumerTokenFiltersEqual(
-        bundle,
-        ConsumerTokenBundle.builder()
-            .withConfigProvider(SdaPlatformConfiguration::getConsumerToken)
-            .build(),
-        SdaPlatformConfiguration.class);
+        bundle, ConsumerTokenBundle.builder().withOptionalConsumerToken().build());
   }
 
   private void verifyRegisteredConsumerTokenFiltersEqual(

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/CorsBuilderTest.java
@@ -20,7 +20,6 @@ public class CorsBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -34,7 +33,6 @@ public class CorsBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withCorsAdditionalExposedHeaders("X-custom-header-1", "X-custom-header-2")
             .withCorsAdditionalAllowedHeaders("X-custom-header-3", "X-custom-header-4")
@@ -57,7 +55,6 @@ public class CorsBuilderTest {
         .usingCustomConfig(SdaPlatformConfiguration.class)
         .withAuthConfigProvider(c -> new AuthConfig())
         .withoutCorsSupport()
-        .withoutConsumerTokenSupport()
         .addOpenApiResourcePackageClass(this.getClass())
         .withCorsAdditionalExposedHeaders("x-foo");
   }

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.starter;
 
+import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +10,21 @@ import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.sdase.commons.server.opa.testing.OpaRule;
 import org.sdase.commons.starter.test.StarterApp;
 
 public class FilterPriorityTest {
 
-  @ClassRule
+  public static final OpaRule OPA = new OpaRule();
+
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      new DropwizardAppRule<>(StarterApp.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(
+          StarterApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("opa.baseUrl", OPA::getUrl));
+
+  @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(OPA).around(DW);
 
   @Test
   public void corsFromSwaggerHasHigherPriority() {
@@ -48,20 +57,6 @@ public class FilterPriorityTest {
   }
 
   @Test
-  public void consumerTokenValidationHappensBeforeAuthentication() {
-    // Make sure that the consumer token filter fails before the authentication filter
-    Response response =
-        DW.client()
-            .target("http://localhost:" + DW.getLocalPort())
-            .path("api")
-            .path("ping")
-            .request(APPLICATION_JSON)
-            .get();
-
-    assertThat(response.readEntity(String.class)).contains("Consumer token is required");
-  }
-
-  @Test
   public void errorsInConsumerTokenFilterTrackedByPrometheus() {
     Response response =
         DW.client()
@@ -71,7 +66,7 @@ public class FilterPriorityTest {
             .request(APPLICATION_JSON)
             .get();
 
-    assertThat(response.getStatus()).isEqualTo(401);
+    assertThat(response.getStatus()).isEqualTo(403);
 
     String metrics =
         DW.client()

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/JacksonBuilderTest.java
@@ -22,7 +22,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -35,7 +34,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withoutHalSupport()
             .build();
@@ -49,7 +47,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withoutFieldFilter()
             .build();
@@ -63,7 +60,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .alwaysWriteZonedDateTimeWithMillisInJson()
             .build();
@@ -77,7 +73,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .alwaysWriteZonedDateTimeWithoutMillisInJson()
             .build();
@@ -96,7 +91,6 @@ public class JacksonBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .withObjectMapperCustomization(omc)
             .build();

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/OpenAPIBuilderTest.java
@@ -20,7 +20,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -34,7 +33,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .addOpenApiResourcePackage("com.example")
             .build();
@@ -53,7 +51,6 @@ public class OpenAPIBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .withExistingOpenAPIFromClasspathResource("/example.yaml")
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SdaPlatformBundleBuilderTest.java
@@ -34,7 +34,6 @@ public class SdaPlatformBundleBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withOptionalConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/SecurityBuilderTest.java
@@ -19,7 +19,6 @@ public class SecurityBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .build();
 
@@ -32,7 +31,6 @@ public class SecurityBuilderTest {
     SdaPlatformBundle<SdaPlatformConfiguration> bundle =
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withoutConsumerTokenSupport()
             .addOpenApiResourcePackageClass(this.getClass())
             .disableBufferLimitValidationSecurityFeature()
             .build();

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/test/StarterApp.java
@@ -41,7 +41,6 @@ public class StarterApp extends Application<SdaPlatformConfiguration> {
     bootstrap.addBundle(
         SdaPlatformBundle.builder()
             .usingSdaPlatformConfiguration()
-            .withRequiredConsumerToken()
             .addOpenApiResourcePackageClass(this.getClass())
             .build());
   }


### PR DESCRIPTION
With this change, the consumer token for incoming HTTP request is optional by default. Consumer-Token is only used for logging and metrics. It is more or less used for a tracing in a simple way. Technically the consumer token support is removed from the `SdaPlatformBundle` and `SdaPlatformConfiguration`. The `sda-commons-server-consumer` is left as is, because it is used in the `sda-commons-server-starter`.