### PR TITLE
fix(server-testing): refactor the golden-file-assertions api to match the assertThat() pattern

### DIFF
--- a/sda-commons-server-swagger/README.md
+++ b/sda-commons-server-swagger/README.md
@@ -151,14 +151,16 @@ public class SwaggerDocumentationTest {
 
     // check and update the file
     GoldenFileAssertions.assertThat(filePath)
-        .hasContentAndUpdateGolden(normalizeSwaggerYaml(expected));
+        .hasYamlContentAndUpdateGolden(normalizeSwaggerYaml(expected));
   }
 }
 ```
 
 This test uses the [`GoldenFileAssertions` from sda-commons-server-testing](../sda-commons-server-testing)
 and removes all contents that vary between tests (the `servers` key that contains random port numbers) with
-[`SwaggerFileHelper#nomalizSwaggerYaml(String yaml)`](./src/main/java/org/sdase/commons/server/swagger/SwaggerFileHelper.java).
+[`SwaggerFileHelper#normalizeSwaggerYaml(String yaml)`](./src/main/java/org/sdase/commons/server/swagger/SwaggerFileHelper.java).
+Please note that the Swagger output is only semantically reproducible but the order of properties
+might change between runs.
 
 ## Further Information
 

--- a/sda-commons-server-testing/README.md
+++ b/sda-commons-server-testing/README.md
@@ -40,8 +40,10 @@ public class MyTestIT {
 }
 ```
 
-There is also a `GoldenFileAssertions.assertThatYaml(...)` variant that interprets the content as YAML
-or JSON and ignores the order of keys.
+There is also a `assertThat(...).hasYamlContentAndUpdateGolden(...)` variant that interprets the content as
+YAML or JSON and ignores the order of keys. If possible, prefer the other variant since the written
+content should always be reproducible. Note that the [AsyncAPI](../sda-commons-shared-asyncapi) and
+[OpenAPI](../sda-commons-server-openapi) generations export reproducible content. 
 
 ## Provided Rules
 

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/GoldenFileAssertionsTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/GoldenFileAssertionsTest.java
@@ -79,8 +79,8 @@ public class GoldenFileAssertionsTest {
     // should be accepted
     assertThatCode(
             () ->
-                GoldenFileAssertions.assertThatYaml(path)
-                    .hasContentAndUpdateGolden(
+                GoldenFileAssertions.assertThat(path)
+                    .hasYamlContentAndUpdateGolden(
                         "key0: v\nkey2:\n  nested2: b\n  nested1: a\nkey1: w"))
         .doesNotThrowAnyException();
 
@@ -95,10 +95,10 @@ public class GoldenFileAssertionsTest {
     Files.write(path, "key0: v\nkey1: w\nkey2:\n  nested1: a\n  nested2: b".getBytes());
 
     // should throw and update the file
-    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThatYaml(path);
+    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThat(path);
     assertThatThrownBy(
             () ->
-                goldenFileAssertions.hasContentAndUpdateGolden(
+                goldenFileAssertions.hasYamlContentAndUpdateGolden(
                     "key0: w\nkey1: x\nkey2:\n  nested1: b\n  nested2: c"))
         .isInstanceOf(AssertionError.class)
         .hasMessageContaining(
@@ -122,8 +122,8 @@ public class GoldenFileAssertionsTest {
     // should be accepted
     assertThatCode(
             () ->
-                GoldenFileAssertions.assertThatYaml(path)
-                    .hasContentAndUpdateGolden(
+                GoldenFileAssertions.assertThat(path)
+                    .hasYamlContentAndUpdateGolden(
                         "{\"key0\": \"v\",\"key2\":{\"nested2\":\"b\",\"nested1\": \"a\"},\"key1\": \"w\"}"))
         .doesNotThrowAnyException();
 
@@ -143,10 +143,10 @@ public class GoldenFileAssertionsTest {
             .getBytes());
 
     // should throw and update the file
-    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThatYaml(path);
+    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThat(path);
     assertThatThrownBy(
             () ->
-                goldenFileAssertions.hasContentAndUpdateGolden(
+                goldenFileAssertions.hasYamlContentAndUpdateGolden(
                     "{\"key0\": \"2\",\"key1\": \"x\",\"key2\":{\"nested1\":\"b\",\"nested2\": \"c\"}}"))
         .isInstanceOf(AssertionError.class)
         .hasMessageContaining(
@@ -165,8 +165,8 @@ public class GoldenFileAssertionsTest {
     Path path = Paths.get(temporaryFolder.getRoot().getAbsolutePath(), "non-existing-file.yaml");
 
     // should throw and update the file
-    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThatYaml(path);
-    assertThatThrownBy(() -> goldenFileAssertions.hasContentAndUpdateGolden("expected-content"))
+    GoldenFileAssertions goldenFileAssertions = GoldenFileAssertions.assertThat(path);
+    assertThatThrownBy(() -> goldenFileAssertions.hasYamlContentAndUpdateGolden("expected-content"))
         .isInstanceOf(AssertionError.class)
         .hasMessageContaining(
             "The current %s file is not up-to-date. If this happens locally,",


### PR DESCRIPTION
Take two on #666.

This refactors
```java
GoldenFileAssertions.assertThat(filePath).hasContentAndUpdateGolden(expected);
GoldenFileAssertions.assertThatYaml(filePath).hasContentAndUpdateGolden(expected);
```

to
```java
GoldenFileAssertions.assertThat(filePath).hasContentAndUpdateGolden(expected);
GoldenFileAssertions.assertThat(filePath).hasYamlContentAndUpdateGolden(expected);
```

to better match the AssertJ style.

This also adds a clarification that one should prefer the first option since it has better outputs. The AsyncAPI and OpenAPI generations are automatically sorted and stable. The swagger export is problematic and not easy to fix.

PS: I cancelled the old release to not need a breaking change.