### PR TITLE
chore: fix platform-team group name in catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,4 +12,4 @@ metadata:
 spec:
   type: library
   lifecycle: production
-  owner: plattform-team
+  owner: platform-team


### PR DESCRIPTION
Might not be intermediately visible in Backstage.