### PR TITLE
test: use the randomPorts config override instead of test-config.yaml files

### DIFF
--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaConfig.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/config/OpaConfig.java
@@ -1,12 +1,13 @@
 package org.sdase.commons.server.opa.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import javax.validation.constraints.NotNull;
 
 /** Configuration for requesting OPA PDP. */
 @SuppressWarnings("UnusedReturnValue")
 public class OpaConfig {
   /** The client configuration of the HTTP client that is used to call the Open Policy Agent. */
-  private OpaClientConfiguration opaClient;
+  private OpaClientConfiguration opaClient = new OpaClientConfiguration();
 
   /** flag if OPA is disabled (for testing) */
   private boolean disableOpa;
@@ -101,6 +102,7 @@ public class OpaConfig {
     return this;
   }
 
+  @JsonIgnore
   public String getPolicyPackagePath() {
     return policyPackage.replaceAll("\\.", "/").trim();
   }

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/JwksKeySourceIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/JwksKeySourceIT.java
@@ -1,9 +1,9 @@
 package org.sdase.commons.server.auth.key;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.math.BigInteger;
 import java.util.List;
@@ -16,9 +16,7 @@ public class JwksKeySourceIT {
 
   @ClassRule
   public static DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          KeyProviderTestApp.class,
-          ResourceHelpers.resourceFilePath("test-config-key-provider.yaml"));
+      new DropwizardAppRule<>(KeyProviderTestApp.class, null, randomPorts());
 
   @Test
   public void shouldLoadKeysFromHttp() {

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/OpenIdProviderDiscoveryKeySourceIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/OpenIdProviderDiscoveryKeySourceIT.java
@@ -1,9 +1,9 @@
 package org.sdase.commons.server.auth.key;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.math.BigInteger;
 import java.util.List;
@@ -15,9 +15,7 @@ public class OpenIdProviderDiscoveryKeySourceIT {
 
   @ClassRule
   public static DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          KeyProviderTestApp.class,
-          ResourceHelpers.resourceFilePath("test-config-key-provider.yaml"));
+      new DropwizardAppRule<>(KeyProviderTestApp.class, null, randomPorts());
 
   @Test
   public void shouldLoadKeysFromHttp() {

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/PemKeySourceTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/PemKeySourceTest.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.auth.key;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -19,9 +20,7 @@ public class PemKeySourceTest {
 
   @ClassRule
   public static DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          KeyProviderTestApp.class,
-          ResourceHelpers.resourceFilePath("test-config-key-provider.yaml"));
+      new DropwizardAppRule<>(KeyProviderTestApp.class, null, randomPorts());
 
   @Test
   public void shouldLoadPemKeyFromHttp() {

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
@@ -6,7 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -46,7 +46,8 @@ public class OpaBundleBodyInputExtensionTest {
   private static final DropwizardAppRule<TestConfiguration> DW_WITH_EXTENSION =
       new DropwizardAppRule<>(
           TestApplicationWithExtension.class,
-          resourceFilePath("test-config-key-provider.yaml"),
+          null,
+          randomPorts(),
           config("opa.baseUrl", WIRE::baseUrl),
           config("opa.policyPackage", "with"),
 
@@ -56,7 +57,8 @@ public class OpaBundleBodyInputExtensionTest {
   private static final DropwizardAppRule<TestConfiguration> DW_WITHOUT_EXTENSION =
       new DropwizardAppRule<>(
           TestApplicationWithoutExtension.class,
-          resourceFilePath("test-config-key-provider.yaml"),
+          null,
+          randomPorts(),
           config("opa.baseUrl", WIRE::baseUrl),
           config("opa.policyPackage", "without"),
 
@@ -214,7 +216,7 @@ public class OpaBundleBodyInputExtensionTest {
   }
 
   public static class TestConfiguration extends Configuration {
-    private OpaConfig opa;
+    private OpaConfig opa = new OpaConfig();
 
     public OpaConfig getOpa() {
       return opa;

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
@@ -7,7 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -44,7 +44,8 @@ public class OpaBundleClientConfigurationIT {
   private static final DropwizardAppRule<TestConfiguration> DW =
       new DropwizardAppRule<>(
           TestApplication.class,
-          resourceFilePath("test-config-key-provider.yaml"),
+          null,
+          randomPorts(),
           config("opa.baseUrl", WIRE::baseUrl),
           config("opa.policyPackage", "test"),
           config("opa.opaClient.userAgent", "my-user-agent"),
@@ -79,7 +80,7 @@ public class OpaBundleClientConfigurationIT {
   }
 
   public static class TestConfiguration extends Configuration {
-    @Valid private OpaConfig opa;
+    @Valid private OpaConfig opa = new OpaConfig();
 
     public OpaConfig getOpa() {
       return opa;

--- a/sda-commons-server-auth/src/test/resources/test-config-key-provider.yaml
+++ b/sda-commons-server-auth/src/test/resources/test-config-key-provider.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
+++ b/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.errorhandling;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
@@ -19,8 +19,7 @@ public class ErrorHandlingExampleIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          ErrorHandlingExampleApplication.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(ErrorHandlingExampleApplication.class, null, randomPorts());
 
   @Test
   public void shouldGetNotFoundException() {

--- a/sda-commons-server-errorhandling-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-errorhandling-example/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-healthcheck-example/src/test/java/org/sdase/commons/server/healthcheck/example/HealthExampleIT.java
+++ b/sda-commons-server-healthcheck-example/src/test/java/org/sdase/commons/server/healthcheck/example/HealthExampleIT.java
@@ -4,7 +4,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
@@ -30,7 +30,8 @@ public class HealthExampleIT {
   public static final DropwizardAppRule<HealthExampleConfiguration> DW =
       new DropwizardAppRule<>(
           HealthExampleApplication.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("externalServiceUrl", () -> WIRE.url(SERVICE_PATH)));
 
   // start the two rules in order

--- a/sda-commons-server-healthcheck-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-healthcheck-example/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-healthcheck/src/test/java/org/sdase/commons/server/healthcheck/HealthCheckIT.java
+++ b/sda-commons-server-healthcheck/src/test/java/org/sdase/commons/server/healthcheck/HealthCheckIT.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.healthcheck;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,7 +21,7 @@ public class HealthCheckIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> RULE =
-      new DropwizardAppRule<>(HealthApplication.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(HealthApplication.class, null, randomPorts());
 
   @Before
   public void setUp() {

--- a/sda-commons-server-healthcheck/src/test/resources/test-config.yaml
+++ b/sda-commons-server-healthcheck/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-hibernate-example/src/main/java/org/sdase/commons/server/hibernate/example/HibernateExampleConfiguration.java
+++ b/sda-commons-server-hibernate-example/src/main/java/org/sdase/commons/server/hibernate/example/HibernateExampleConfiguration.java
@@ -9,7 +9,7 @@ public class HibernateExampleConfiguration extends Configuration {
    * configuration required for hibernate database access. This section is mandatory within the
    * configuration if you use the hibernate bundle
    */
-  private DataSourceFactory database;
+  private DataSourceFactory database = new DataSourceFactory();
 
   public DataSourceFactory getDatabase() {
     return database;

--- a/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleIT.java
+++ b/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.hibernate.example.test;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,7 +39,8 @@ public class HibernateExampleIT {
   public static final DropwizardAppRule<HibernateExampleConfiguration> DW =
       new DropwizardAppRule<>(
           HibernateExampleApplication.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("database.driverClass", "org.h2.Driver"),
           config("database.user", "sa"),
           config("database.password", "sa"),

--- a/sda-commons-server-hibernate-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-hibernate-example/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationBundleIT.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationBundleIT.java
@@ -1,11 +1,11 @@
 package org.sdase.commons.server.jackson;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,8 +35,7 @@ public class JacksonConfigurationBundleIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          JacksonConfigurationTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(JacksonConfigurationTestApp.class, null, randomPorts());
 
   // Validation and Error Tests
   @Test

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationNoFieldFilterBundleIT.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationNoFieldFilterBundleIT.java
@@ -1,7 +1,8 @@
 package org.sdase.commons.server.jackson;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
+
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import java.util.Map;
 import javax.ws.rs.core.GenericType;
@@ -16,9 +17,7 @@ public class JacksonConfigurationNoFieldFilterBundleIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          JacksonConfigurationNoFieldFilterTestApp.class,
-          ResourceHelpers.resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(JacksonConfigurationNoFieldFilterTestApp.class, null, randomPorts());
 
   @Test
   public void shouldGetJohnDoe() {

--- a/sda-commons-server-jackson/src/test/resources/test-config.yaml
+++ b/sda-commons-server-jackson/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-jaeger/src/test/java/org/sdase/commons/server/jaeger/JaegerBundleMetricsTest.java
+++ b/sda-commons-server-jaeger/src/test/java/org/sdase/commons/server/jaeger/JaegerBundleMetricsTest.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.jaeger;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
@@ -13,7 +13,7 @@ public class JaegerBundleMetricsTest {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(TraceTestApp.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(TraceTestApp.class, null, randomPorts());
 
   @Test
   public void shouldHavePrometheusMetrics() {

--- a/sda-commons-server-jaeger/src/test/resources/test-config.yaml
+++ b/sda-commons-server-jaeger/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
+++ b/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia.example;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.morphia.Datastore;
@@ -24,7 +24,9 @@ public class MorphiaApplicationIT {
   private static final WeldAppRule<MorphiaApplicationConfiguration> APP_RULE =
       new WeldAppRule<>(
           MorphiaApplication.class, // normal WELD rule initialization
-          resourceFilePath("test-config.yaml"),
+          null,
+          // start the application with random ports
+          randomPorts(),
           // provide a lambda to only read the value after the mongodb connection parameters are
           // available
           config("mongo.hosts", MONGODB::getHost),

--- a/sda-commons-server-morphia-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-morphia-example/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.MongoClient;
@@ -35,7 +35,8 @@ public class MorphiaBundleCustomConverterIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -28,7 +28,8 @@ public class MorphiaBundleDefinedClassIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.tuple;
@@ -33,7 +33,8 @@ public class MorphiaBundleEnsureIndexesIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +25,8 @@ public class MorphiaBundleHealthCheckIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleLocalDateConvertersIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleLocalDateConvertersIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -30,14 +30,16 @@ public class MorphiaBundleLocalDateConvertersIT {
   private static final DropwizardAppRule<Config> DW_SDA =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 
   private static final DropwizardAppRule<Config> DW_PLAIN =
       new DropwizardAppRule<>(
           MorphiaPlainTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -28,7 +28,8 @@ public class MorphiaBundleNoEntityDefinedIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
@@ -29,7 +29,8 @@ public class MorphiaBundleScanPackageByMarkerClassIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.morphia.Datastore;
@@ -31,7 +31,8 @@ public class MorphiaBundleTracingIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import dev.morphia.Datastore;
@@ -24,7 +24,8 @@ public class MorphiaBundleValidationDisabledIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.morphia;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import dev.morphia.Datastore;
@@ -25,7 +25,8 @@ public class MorphiaBundleValidationIT {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           MorphiaTestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("mongo.hosts", MONGODB::getHost),
           config("mongo.database", MONGODB::getDatabase));
 

--- a/sda-commons-server-morphia/src/test/resources/test-config.yaml
+++ b/sda-commons-server-morphia/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
+++ b/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/OpenTracingBundleTest.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.opentracing;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static io.opentracing.log.Fields.ERROR_KIND;
 import static io.opentracing.log.Fields.ERROR_OBJECT;
 import static io.opentracing.log.Fields.EVENT;
@@ -36,7 +36,7 @@ public class OpenTracingBundleTest {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(TraceTestApp.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(TraceTestApp.class, null, randomPorts());
 
   private MockTracer tracer;
 

--- a/sda-commons-server-opentracing/src/test/resources/test-config.yaml
+++ b/sda-commons-server-opentracing/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
+++ b/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.prometheus.example;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.testing.junit.DropwizardAppRule;
@@ -17,7 +17,12 @@ public class PrometheusMetricsIT {
 
   @ClassRule
   public static final DropwizardAppRule<SdaPlatformConfiguration> DW =
-      new DropwizardAppRule<>(MetricExampleApp.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(
+          MetricExampleApp.class,
+          null,
+          // use random ports so that tests can run in parallel
+          // and do not affect each other when one is not shutting down
+          randomPorts());
 
   @Test
   public void produceGaugeMetric() {

--- a/sda-commons-server-prometheus-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-prometheus-example/src/test/resources/test-config.yaml
@@ -1,9 +1,0 @@
-# use random ports so that tests can run in parallel
-# and do not affect each other when one is not shutting down
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
+++ b/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.prometheus;
 
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
@@ -22,8 +22,7 @@ public class PrometheusBundleTest {
   // of the test requests
   @Rule
   public final DropwizardAppRule<Configuration> DW =
-      new DropwizardAppRule<>(
-          PrometheusTestApplication.class, resourceFilePath("test-config.yaml"));
+      new DropwizardAppRule<>(PrometheusTestApplication.class, null, randomPorts());
 
   private static final String REST_URI = "http://localhost:%d";
   private String resourceUri;

--- a/sda-commons-server-prometheus/src/test/resources/test-config.yaml
+++ b/sda-commons-server-prometheus/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleSignerOverrideTest.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleSignerOverrideTest.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.s3;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -22,7 +22,8 @@ public class S3BundleSignerOverrideTest {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           TestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("s3Config.endpoint", S_3_MOCK_RULE::getEndpoint),
           config("s3Config.accessKey", "access-key"),
           config("s3Config.secretKey", "secret-key"),

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.s3;
 
 import static io.dropwizard.testing.ConfigOverride.config;
-import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.amazonaws.services.s3.AmazonS3;
@@ -23,7 +23,8 @@ public class S3BundleTest {
   private static final DropwizardAppRule<Config> DW =
       new DropwizardAppRule<>(
           TestApp.class,
-          resourceFilePath("test-config.yaml"),
+          null,
+          randomPorts(),
           config("s3Config.endpoint", S_3_MOCK_RULE::getEndpoint),
           config("s3Config.accessKey", "access-key"),
           config("s3Config.secretKey", "secret-key"));

--- a/sda-commons-server-s3/src/test/resources/test-config.yaml
+++ b/sda-commons-server-s3/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0

--- a/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationIT.java
+++ b/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationIT.java
@@ -1,7 +1,8 @@
 package org.sdase.commons.server.weld;
 
+import static io.dropwizard.testing.ConfigOverride.randomPorts;
+
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
@@ -12,8 +13,7 @@ public class WeldExampleApplicationIT {
 
   @ClassRule
   public static final DropwizardAppRule<Configuration> RULE =
-      new WeldAppRule<>(
-          WeldExampleApplication.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
+      new WeldAppRule<>(WeldExampleApplication.class, null, randomPorts());
 
   @Test
   public void shouldBeInjectedCorrectly() {

--- a/sda-commons-server-weld-example/src/test/resources/test-config.yaml
+++ b/sda-commons-server-weld-example/src/test/resources/test-config.yaml
@@ -1,7 +1,0 @@
-server:
-  applicationConnectors:
-  - type: http
-    port: 0
-  adminConnectors:
-  - type: http
-    port: 0


### PR DESCRIPTION
This reverts some changes of #628 where we needed to add a number of `test-config.yaml` files to configure random ports. Dropwizard 2.0.16 includes a new config override `ConfigOverride.randomPorts()` that can be used instead. I didn't touched files that contained additional settings, yet.

I also made sure that the `OpaConfig` always has a default `OpaClientConfiguration` set. This is necessary to allow to use the `DropwizardAppRule` without a config file (i.e. `new DropwizardAppRule<>(Application.class, null, randomPorts())`. This change will not affect services since there already was a null check in the code before: https://github.com/SDA-SE/sda-dropwizard-commons/blob/a08c00b6b0fabbe619b11e8573bc88aa9dbabd4a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java#L171-L172