### PR TITLE
MongoDB Testing: Provide option to create test environments with a real MongoDB

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -1,0 +1,36 @@
+# This workflow tests the feature of using an external MongoDB for tests
+name: Java Test MongoDB
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  # Test with real MongoDB
+  test-mongodb:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      TEST_MONGODB_CONNECTION_STRING: mongodb://test:example@localhost:27017/testdb?authSource=admin
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Start MongoDB
+        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:4.0
+
+      - name: Test with Gradle
+        run: ./gradlew :sda-commons-server-morphia-example:test
+
+      - name: Assert use of MongoDB
+        run: "docker logs test_mongo | grep -F 'build index on: testdb.'"
+
+      - name: Stop MongoDB
+        run: docker stop test_mongo
+

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -46,15 +46,20 @@ public interface MongoDbRule extends TestRule {
     return new Builder();
   }
 
-  /**
-   * Returns the hostname and port that can be used to connect to the database.
-   *
-   * @return Hostname with port.
-   */
+  /** @return the hostname and port that can be used to connect to the database. */
   String getHost();
+
+  /** @return the username that must be used to connect to the database. */
+  String getUsername();
+
+  /** @return the password that must be used to connect to the database. */
+  String getPassword();
 
   /** @return the initialized database */
   String getDatabase();
+
+  /** @return the MongoDB options String without leading question mark */
+  String getOptions();
 
   /**
    * @return the version of the MongoDB instance which is associated with this MongoDbRule
@@ -117,14 +122,19 @@ public interface MongoDbRule extends TestRule {
 
     private static final long DEFAULT_TIMEOUT_MS = MINUTES.toMillis(1L);
 
-    public static final String DEFAULT_USER = "dbuser";
-    public static final String DEFAULT_PASSWORD = "sda123"; // NOSONAR
-    public static final String DEFAULT_DATABASE = "default_db";
+    /** @deprecated use {@link MongoDbRule#getUsername()} of the actual rule instance */
+    @Deprecated public static final String DEFAULT_USER = "dbuser";
+
+    /** @deprecated use {@link MongoDbRule#getPassword()} ()} of the actual rule instance */
+    @Deprecated public static final String DEFAULT_PASSWORD = "sda123"; // NOSONAR
+
+    /** @deprecated use {@link MongoDbRule#getDatabase()} of the actual rule instance */
+    @Deprecated public static final String DEFAULT_DATABASE = "default_db";
 
     private IFeatureAwareVersion version;
     private Long timeoutInMillis;
     private String username = DEFAULT_USER;
-    private String password = DEFAULT_PASSWORD; // NOSONAR
+    private String password = DEFAULT_PASSWORD;
     private String database = DEFAULT_DATABASE;
     private boolean scripting = false;
 

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -18,8 +18,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * JUnit Test rule for running a MongoDB instance alongside the (integration) tests. Can be
- * configured with custom user credentials and database name. Use {@link #getHost()} to retrieve the
- * host to connect to.
+ * configured with custom user credentials and database name. Use {@link #getHosts()} to retrieve
+ * the hosts to connect to.
  *
  * <p>Example usage:
  *
@@ -46,8 +46,21 @@ public interface MongoDbRule extends TestRule {
     return new Builder();
   }
 
-  /** @return the hostname and port that can be used to connect to the database. */
-  String getHost();
+  /**
+   * @return the hostname and port that can be used to connect to the database. The result may
+   *     contain a comma separated list of hosts as in the MongoDB Connection String
+   * @deprecated in favor of {@link #getHosts()}
+   */
+  @Deprecated
+  default String getHost() {
+    return getHosts();
+  }
+
+  /**
+   * @return the hostname and port that can be used to connect to the database. The result may
+   *     contain a comma separated list of hosts as in the MongoDB Connection String
+   */
+  String getHosts();
 
   /** @return the username that must be used to connect to the database. */
   String getUsername();

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -8,6 +8,7 @@ import com.mongodb.MongoClient;
 import com.mongodb.client.MongoDatabase;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import de.flapdoodle.embed.mongo.distribution.Version;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
@@ -240,10 +241,16 @@ public interface MongoDbRule extends TestRule {
     }
 
     public MongoDbRule build() {
-      IFeatureAwareVersion mongoDbVersion = determineMongoDbVersion();
-      long t =
-          timeoutInMillis == null || timeoutInMillis < 1L ? DEFAULT_TIMEOUT_MS : timeoutInMillis;
-      return new StartLocalMongoDbRule(username, password, database, scripting, mongoDbVersion, t);
+      String mongoDbUrlOverride = System.getenv(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
+      if (StringUtils.isNotBlank(mongoDbUrlOverride)) {
+        return new UseExistingMongoDbRule(mongoDbUrlOverride);
+      } else {
+        IFeatureAwareVersion mongoDbVersion = determineMongoDbVersion();
+        long t =
+            timeoutInMillis == null || timeoutInMillis < 1L ? DEFAULT_TIMEOUT_MS : timeoutInMillis;
+        return new StartLocalMongoDbRule(
+            username, password, database, scripting, mongoDbVersion, t);
+      }
     }
   }
 }

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -35,6 +35,13 @@ import org.slf4j.LoggerFactory;
  */
 public interface MongoDbRule extends TestRule {
 
+  /**
+   * {@value} is the name of the environment variable that may hold a <a
+   * href="https://docs.mongodb.com/manual/reference/connection-string/">MongoDB Connection
+   * String</a> of the database used in tests instead of starting a dedicated instance.
+   */
+  String OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME = "TEST_MONGODB_CONNECTION_STRING";
+
   static Builder builder() {
     return new Builder();
   }

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
@@ -1,0 +1,305 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static java.lang.Runtime.getRuntime;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.event.ServerClosedEvent;
+import com.mongodb.event.ServerDescriptionChangedEvent;
+import com.mongodb.event.ServerListener;
+import com.mongodb.event.ServerOpeningEvent;
+import com.mongodb.internal.connection.ServerAddressHelper;
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.MongodExecutable;
+import de.flapdoodle.embed.mongo.MongodStarter;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
+import de.flapdoodle.embed.mongo.config.MongodConfig;
+import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.config.store.HttpProxyFactory;
+import de.flapdoodle.embed.process.config.store.ImmutableDownloadConfig;
+import de.flapdoodle.embed.process.config.store.ProxyFactory;
+import de.flapdoodle.embed.process.config.store.SameDownloadPathForEveryDistribution;
+import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import de.flapdoodle.embed.process.store.ImmutableExtractedArtifactStore;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.Authenticator;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * JUnit Test rule for running a MongoDB instance alongside the (integration) tests. Can be
+ * configured with custom user credentials and database name. Use {@link #getHost()} to retrieve the
+ * host to connect to.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * &#64;ClassRule
+ * public static final MongoDbRule RULE = MongoDbRule
+ *     .builder()
+ *     .withDatabase("my_db")
+ *     .withUsername("my_user")
+ *     .withPassword("my_s3cr3t")
+ *     .build();
+ * </pre>
+ */
+public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRule {
+  private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  // Initialization-on-demand holder idiom
+  private static class LazyHolder {
+    static final MongodStarter INSTANCE = getMongoStarter();
+
+    private static MongodStarter getMongoStarter() {
+      ImmutableExtractedArtifactStore.Builder artifactStoreBuilder =
+          ExtractedArtifactStore.builder()
+              .from(Defaults.extractedArtifactStoreFor(Command.MongoD))
+              .downloadConfig(createDownloadConfig());
+
+      return MongodStarter.getInstance(
+          Defaults.runtimeConfigFor(Command.MongoD)
+              .artifactStore(artifactStoreBuilder.build())
+              .build());
+    }
+
+    private static Optional<ProxyFactory> createProxyFactory() {
+      String httpProxy = System.getenv("http_proxy");
+      if (httpProxy != null) {
+        try {
+          URL url = new URL(httpProxy);
+
+          if (url.getUserInfo() != null) {
+            configureAuthentication(url);
+          }
+
+          return Optional.of(new HttpProxyFactory(url.getHost(), url.getPort()));
+        } catch (MalformedURLException exception) {
+          LOG.error("http_proxy could not be parsed.");
+        }
+      }
+      return Optional.empty();
+    }
+
+    private static void configureAuthentication(URL url) {
+      String userInfo = url.getUserInfo();
+      int pos = userInfo.indexOf(':');
+      if (pos >= 0) {
+        String username = userInfo.substring(0, pos);
+        String password = userInfo.substring(pos + 1);
+
+        Authenticator.setDefault(
+            new Authenticator() {
+              @Override
+              protected PasswordAuthentication getPasswordAuthentication() {
+                // Only provide the credentials to the specified
+                // origin
+                if (getRequestorType() == RequestorType.PROXY
+                    && getRequestingHost().equalsIgnoreCase(url.getHost())
+                    && url.getPort() == getRequestingPort()) {
+                  return new PasswordAuthentication(username, password.toCharArray());
+                }
+                return null;
+              }
+            });
+
+        // Starting with Java 8u111, basic auth is not supported
+        // for https by default.
+        // jdk.http.auth.tunneling.disabledSchemes can be used to
+        // enable it again.
+        System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+      } else {
+        LOG.error("http_proxy user info could not be parsed.");
+      }
+    }
+
+    private static DownloadConfig createDownloadConfig() {
+      ImmutableDownloadConfig.Builder downloadConfigBuilder =
+          Defaults.downloadConfigFor(Command.MongoD).proxyFactory(createProxyFactory());
+
+      // Normally the mongod executable is downloaded directly from the
+      // mongodb web page, however sometimes this behavior is undesired. Some
+      // cases are proxy servers, missing internet access, or not wanting to
+      // download executables from untrusted sources.
+      //
+      // Optional it is possible to download it from a source configured in
+      // the environment variable:
+      String embeddedMongoDownloadPath = System.getenv("EMBEDDED_MONGO_DOWNLOAD_PATH");
+
+      if (embeddedMongoDownloadPath != null) {
+        downloadConfigBuilder.downloadPath(
+            new SameDownloadPathForEveryDistribution(embeddedMongoDownloadPath));
+      }
+
+      return downloadConfigBuilder.build();
+    }
+  }
+
+  private static MongodStarter ensureMongodStarter() {
+    return LazyHolder.INSTANCE;
+  }
+
+  private final boolean enableScripting;
+  private final IFeatureAwareVersion version;
+  private final long timeoutMs;
+  private final String username;
+  private final String password;
+  private final String database;
+
+  private MongodConfig mongodConfig;
+  private MongodExecutable mongodExecutable;
+
+  private volatile boolean started;
+
+  StartLocalMongoDbRule(
+      String username,
+      String password,
+      String database,
+      boolean enableScripting,
+      IFeatureAwareVersion version,
+      long timeoutMs) {
+
+    this.version = requireNonNull(version, "version");
+    this.username = requireNonNull(username, "username");
+    this.password = requireNonNull(password, "password");
+    this.database = requireNonNull(database, "database");
+    this.enableScripting = enableScripting;
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public String getHost() {
+    return mongodConfig.net().getBindIp() + ":" + mongodConfig.net().getPort();
+  }
+
+  @Override
+  public String getDatabase() {
+    return database;
+  }
+
+  @Override
+  public IFeatureAwareVersion getVersion() {
+    return version;
+  }
+
+  @Override
+  public MongoClient createClient() {
+    return new MongoClient(
+        ServerAddressHelper.createServerAddress(getHost()),
+        MongoCredential.createCredential(username, database, password.toCharArray()),
+        MongoClientOptions.builder().build());
+  }
+
+  @Override
+  protected void before() {
+    startMongo();
+  }
+
+  @Override
+  protected void after() {
+    stopMongo();
+  }
+
+  private void startMongo() {
+    if (started) {
+      return;
+    }
+
+    try {
+      ImmutableMongodConfig.Builder mongodConfigBuilder =
+          MongodConfig.builder()
+              .version(version)
+              .net(
+                  new Net(
+                      Network.getLocalHost().getHostName(), Network.getFreeServerPort(), false));
+
+      if (!enableScripting) {
+        mongodConfigBuilder.putArgs("--noscripting", "");
+      }
+
+      mongodConfig = mongodConfigBuilder.build();
+
+      mongodExecutable = ensureMongodStarter().prepare(mongodConfig);
+      mongodExecutable.start();
+
+      final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+      final MongoClientOptions options =
+          MongoClientOptions.builder()
+              .addServerListener(
+                  new ServerListener() {
+                    @Override
+                    public void serverOpening(final ServerOpeningEvent event) {
+                      countDownLatch.countDown();
+                    }
+
+                    @Override
+                    public void serverClosed(final ServerClosedEvent event) {
+                      // no action required
+                    }
+
+                    @Override
+                    public void serverDescriptionChanged(
+                        final ServerDescriptionChangedEvent event) {
+                      // no action required
+                    }
+                  })
+              .build();
+
+      try (MongoClient mongoClient = new MongoClient(getHost(), options)) {
+        // ensure MongoDB is available before proceeding
+        if (!countDownLatch.await(timeoutMs, MILLISECONDS)) {
+          throw new IllegalStateException("Timeout, MongoDB not started.");
+        }
+
+        // Create the database user for the test context
+        createDatabaseUser(mongoClient);
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+
+    started = true;
+
+    // safety net
+    getRuntime().addShutdownHook(new Thread(this::stopMongo, "shutdown mongo"));
+  }
+
+  private void stopMongo() {
+    if (started && mongodExecutable != null) {
+      mongodExecutable.stop();
+      started = false;
+    }
+  }
+
+  private void createDatabaseUser(MongoClient mongoClient) {
+    MongoDatabase db = mongoClient.getDatabase(database);
+
+    final BasicDBObject createUserCommand =
+        new BasicDBObject("createUser", username)
+            .append("pwd", password)
+            .append(
+                "roles",
+                Collections.singletonList(
+                    new BasicDBObject("role", "readWrite").append("db", database)));
+    db.runCommand(createUserCommand);
+  }
+}

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
@@ -193,7 +193,12 @@ public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRu
     return database;
   }
 
+  /**
+   * @return the version of the MongoDB instance which is associated with this MongoDbRule
+   * @deprecated because this is specific to flap doodle, use {@link #getServerVersion()}
+   */
   @Override
+  @Deprecated
   public IFeatureAwareVersion getVersion() {
     return version;
   }

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * JUnit Test rule for running a MongoDB instance alongside the (integration) tests. Can be
- * configured with custom user credentials and database name. Use {@link #getHost()} to retrieve the
- * host to connect to.
+ * configured with custom user credentials and database name. Use {@link #getHosts()} to retrieve
+ * the host to connect to.
  *
  * <p>Example usage:
  *
@@ -184,7 +184,7 @@ public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRu
   }
 
   @Override
-  public String getHost() {
+  public String getHosts() {
     return mongodConfig.net().getBindIp() + ":" + mongodConfig.net().getPort();
   }
 
@@ -221,7 +221,7 @@ public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRu
   @Override
   public MongoClient createClient() {
     return new MongoClient(
-        ServerAddressHelper.createServerAddress(getHost()),
+        ServerAddressHelper.createServerAddress(getHosts()),
         MongoCredential.createCredential(username, database, password.toCharArray()),
         MongoClientOptions.builder().build());
   }
@@ -282,7 +282,7 @@ public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRu
                   })
               .build();
 
-      try (MongoClient mongoClient = new MongoClient(getHost(), options)) {
+      try (MongoClient mongoClient = new MongoClient(getHosts(), options)) {
         // ensure MongoDB is available before proceeding
         if (!countDownLatch.await(timeoutMs, MILLISECONDS)) {
           throw new IllegalStateException("Timeout, MongoDB not started.");

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRule.java
@@ -193,6 +193,21 @@ public class StartLocalMongoDbRule extends ExternalResource implements MongoDbRu
     return database;
   }
 
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getOptions() {
+    return "";
+  }
+
   /**
    * @return the version of the MongoDB instance which is associated with this MongoDbRule
    * @deprecated because this is specific to flap doodle, use {@link #getServerVersion()}

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRule.java
@@ -39,6 +39,11 @@ public class UseExistingMongoDbRule extends ExternalResource implements MongoDbR
   }
 
   @Override
+  public String getOptions() {
+    return options;
+  }
+
+  @Override
   public String getUsername() {
     return username;
   }
@@ -46,11 +51,6 @@ public class UseExistingMongoDbRule extends ExternalResource implements MongoDbR
   @Override
   public String getPassword() {
     return password;
-  }
-
-  @Override
-  public String getOptions() {
-    return options;
   }
 
   @Override

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRule.java
@@ -1,0 +1,89 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientURI;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UseExistingMongoDbRule extends ExternalResource implements MongoDbRule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UseExistingMongoDbRule.class);
+
+  private final String host;
+  private final String database;
+  private final String username;
+  private final String password;
+  private final String options;
+  private final MongoClientURI mongoClientUri;
+
+  public UseExistingMongoDbRule(String mongoDbConnectionString) {
+    mongoClientUri = new MongoClientURI(mongoDbConnectionString);
+    host = String.join(",", mongoClientUri.getHosts());
+    database = mongoClientUri.getDatabase();
+    options = optionsFromMongoUrl(mongoDbConnectionString);
+    username = mongoClientUri.getUsername();
+    password = asStringOrNull(mongoClientUri.getPassword());
+  }
+
+  @Override
+  public String getHosts() {
+    return host;
+  }
+
+  @Override
+  public String getDatabase() {
+    return database;
+  }
+
+  @Override
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public String getPassword() {
+    return password;
+  }
+
+  @Override
+  public String getOptions() {
+    return options;
+  }
+
+  @Override
+  public MongoClient createClient() {
+    return new MongoClient(mongoClientUri);
+  }
+
+  @Override
+  protected void before() {
+    if (LOG.isInfoEnabled()) {
+      String withPasswordText = isNotBlank(password) ? "using a password" : "without password";
+      LOG.info(
+          "Testing as '{}' {} in MongoDB '{}' at '{}' with options '{}'",
+          username,
+          withPasswordText,
+          getDatabase(),
+          getHosts(),
+          getOptions());
+      // secondary log, getServerVersion() already requires a connection
+      LOG.info("MongoDB server used for test has version {}", getServerVersion());
+    }
+  }
+
+  private String optionsFromMongoUrl(String mongoDbUrlOverride) {
+    String[] split = mongoDbUrlOverride.split("\\?");
+    if (split.length > 1) {
+      return split[split.length - 1];
+    } else {
+      return "";
+    }
+  }
+
+  private String asStringOrNull(char[] chars) {
+    return chars == null ? null : new String(chars);
+  }
+}

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtil.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtil.java
@@ -1,0 +1,108 @@
+package org.sdase.commons.server.mongo.testing.internal;
+
+import de.flapdoodle.embed.mongo.Command;
+import de.flapdoodle.embed.mongo.config.Defaults;
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.config.store.HttpProxyFactory;
+import de.flapdoodle.embed.process.config.store.ImmutableDownloadConfig;
+import de.flapdoodle.embed.process.config.store.ProxyFactory;
+import de.flapdoodle.embed.process.config.store.SameDownloadPathForEveryDistribution;
+import java.net.Authenticator;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A utility that creates a {@link DownloadConfig} for the {@link
+ * org.sdase.commons.server.mongo.testing.StartLocalMongoDbRule} depending on the environment
+ * property {@value #PROXY_ENV_NAME}.
+ *
+ * <p>A fixed download URL may be configured by {@value #EMBEDDED_MONGO_DOWNLOAD_PATH_ENV_NAME}.
+ */
+public class DownloadConfigFactoryUtil {
+
+  private static final String PROXY_ENV_NAME = "http_proxy";
+  private static final String EMBEDDED_MONGO_DOWNLOAD_PATH_ENV_NAME =
+      "EMBEDDED_MONGO_DOWNLOAD_PATH";
+
+  private static final Logger LOG = LoggerFactory.getLogger(DownloadConfigFactoryUtil.class);
+
+  private DownloadConfigFactoryUtil() {
+    // utility
+  }
+
+  /** @return a download config that */
+  public static DownloadConfig createDownloadConfig() {
+    ImmutableDownloadConfig.Builder downloadConfigBuilder =
+        Defaults.downloadConfigFor(Command.MongoD).proxyFactory(createProxyFactory());
+
+    // Normally the mongod executable is downloaded directly from the
+    // mongodb web page, however sometimes this behavior is undesired. Some
+    // cases are proxy servers, missing internet access, or not wanting to
+    // download executables from untrusted sources.
+    //
+    // Optional it is possible to download it from a source configured in
+    // the environment variable:
+    String embeddedMongoDownloadPath = System.getenv(EMBEDDED_MONGO_DOWNLOAD_PATH_ENV_NAME);
+
+    if (embeddedMongoDownloadPath != null) {
+      downloadConfigBuilder.downloadPath(
+          new SameDownloadPathForEveryDistribution(embeddedMongoDownloadPath));
+    }
+
+    return downloadConfigBuilder.build();
+  }
+
+  private static Optional<ProxyFactory> createProxyFactory() {
+    String httpProxy = System.getenv(PROXY_ENV_NAME);
+    if (httpProxy != null) {
+      try {
+        URL url = new URL(httpProxy);
+
+        if (url.getUserInfo() != null) {
+          configureAuthentication(url);
+        }
+
+        return Optional.of(new HttpProxyFactory(url.getHost(), url.getPort()));
+      } catch (MalformedURLException exception) {
+        LOG.error("http_proxy could not be parsed.");
+      }
+    }
+    return Optional.empty();
+  }
+
+  private static void configureAuthentication(URL url) {
+    String userInfo = url.getUserInfo();
+    int pos = userInfo.indexOf(':');
+    if (pos >= 0) {
+      String username = userInfo.substring(0, pos);
+      String password = userInfo.substring(pos + 1);
+
+      Authenticator.setDefault(
+          new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+              // Only provide the credentials to the specified
+              // origin
+              if (getRequestorType() == RequestorType.PROXY
+                  && getRequestingHost().equalsIgnoreCase(url.getHost())
+                  && url.getPort() == getRequestingPort()) {
+                return new PasswordAuthentication(username, password.toCharArray());
+              }
+              return null;
+            }
+          });
+
+      // Starting with Java 8u111, basic auth is not supported
+      // for https by default.
+      // jdk.http.auth.tunneling.disabledSchemes can be used to
+      // enable it again.
+      System.setProperty("jdk.http.auth.tunneling.disabledSchemes", "");
+    } else {
+      LOG.error("http_proxy user info could not be parsed.");
+    }
+  }
+}

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
@@ -9,6 +9,7 @@ import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoCredential;
 import com.mongodb.MongoQueryException;
 import com.mongodb.MongoSecurityException;
+import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Indexes;
@@ -86,13 +87,13 @@ public class MongoDbRuleTest {
   @Test
   public void shouldNotSupportJavaScriptByDefault() {
     try (MongoClient mongoClient = RULE.createClient()) {
-      assertThatThrownBy(
-              () ->
-                  mongoClient
-                      .getDatabase("my_db")
-                      .getCollection("test")
-                      .find(new Document("$where", "this.name == 5"))
-                      .into(new ArrayList<Document>()))
+      ArrayList<Document> givenTargetType = new ArrayList<>();
+      FindIterable<Document> actualDocumentsNotQueriedYet =
+          mongoClient
+              .getDatabase("my_db")
+              .getCollection("test")
+              .find(new Document("$where", "this.name == 5"));
+      assertThatThrownBy(() -> actualDocumentsNotQueriedYet.into(givenTargetType))
           .isInstanceOf(MongoQueryException.class)
           .hasMessageContaining("no globalScriptEngine in $where parsing");
     }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
@@ -1,187 +1,25 @@
 package org.sdase.commons.server.mongo.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
-import com.mongodb.MongoCredential;
-import com.mongodb.MongoQueryException;
-import com.mongodb.MongoSecurityException;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-import com.mongodb.client.model.Indexes;
-import com.mongodb.internal.connection.ServerAddressHelper;
-import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
-import de.flapdoodle.embed.mongo.distribution.Version;
-import java.util.ArrayList;
-import org.apache.commons.lang3.SystemUtils;
-import org.bson.Document;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
+import org.sdase.commons.server.testing.EnvironmentRule;
 
 public class MongoDbRuleTest {
-  private static final String DATABASE_NAME = "my_db";
-  private static final String DATABASE_USERNAME = "theuser";
-  private static final String DATABASE_PASSWORD = "S3CR3t!"; // NOSONAR
-
-  @ClassRule
-  public static final MongoDbRule RULE =
-      MongoDbRule.builder()
-          .withDatabase(DATABASE_NAME)
-          .withUsername(DATABASE_USERNAME)
-          .withPassword(DATABASE_PASSWORD)
-          .withTimeoutInMillis(30_000)
-          .build();
-
   @Test
-  public void shouldStartMongoDbWithSpecifiedSettings() {
-    try (MongoClient mongoClient =
-        new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
-            MongoCredential.createCredential(
-                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
-            MongoClientOptions.builder().build())) {
-      assertThat(mongoClient.getCredential()).isNotNull();
-      assertThat(mongoClient.getCredential().getUserName()).isEqualTo(DATABASE_USERNAME);
-      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
-      assertThat(documentCount).isZero();
-    }
-  }
-
-  @Test(expected = MongoSecurityException.class)
-  public void shouldRejectAccessForBadCredentials() {
-    try (MongoClient mongoClient =
-        new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
-            MongoCredential.createCredential(
-                DATABASE_USERNAME, DATABASE_NAME, (DATABASE_PASSWORD + "_bad").toCharArray()),
-            MongoClientOptions.builder().build())) {
-      mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
-    }
-  }
-
-  @Test // Flapdoodle can not require auth and create a user
-  public void shouldAllowAccessWithoutCredentials() {
-    try (MongoClient mongoClient =
-        new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
-            MongoClientOptions.builder().build())) {
-      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
-      assertThat(documentCount).isZero();
-    }
-  }
-
-  @Test
-  public void shouldProvideClientForTesting() {
-    try (MongoClient mongoClient = RULE.createClient()) {
-      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
-      assertThat(documentCount).isZero();
-    }
-  }
-
-  @Test
-  public void shouldNotSupportJavaScriptByDefault() {
-    try (MongoClient mongoClient = RULE.createClient()) {
-      ArrayList<Document> givenTargetType = new ArrayList<>();
-      FindIterable<Document> actualDocumentsNotQueriedYet =
-          mongoClient
-              .getDatabase("my_db")
-              .getCollection("test")
-              .find(new Document("$where", "this.name == 5"));
-      assertThatThrownBy(() -> actualDocumentsNotQueriedYet.into(givenTargetType))
-          .isInstanceOf(MongoQueryException.class)
-          .hasMessageContaining("no globalScriptEngine in $where parsing");
-    }
-  }
-
-  @Test
-  public void shouldClearCollections() {
-    try (MongoClient mongoClient =
-        new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
-            MongoCredential.createCredential(
-                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
-            MongoClientOptions.builder().build())) {
-      MongoDatabase db = mongoClient.getDatabase("my_db");
-      MongoCollection<Document> collection = db.getCollection("clearCollectionsTest");
-      collection.createIndex(Indexes.ascending("field"));
-      collection.insertOne(new Document().append("field", "value"));
-
-      RULE.clearCollections();
-
-      assertThat(db.listCollectionNames()).contains("clearCollectionsTest");
-      assertThat(collection.listIndexes()).isNotEmpty();
-      assertThat(collection.countDocuments()).isZero();
-    }
-  }
-
-  @Test
-  public void shouldClearDatabase() {
-    try (MongoClient mongoClient =
-        new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
-            MongoCredential.createCredential(
-                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
-            MongoClientOptions.builder().build())) {
-      MongoDatabase db = mongoClient.getDatabase("my_db");
-      db.getCollection("clearDatabaseTest").insertOne(new Document().append("Hallo", "Welt"));
-
-      RULE.clearDatabase();
-
-      assertThat(db.listCollectionNames()).doesNotContain("clearDatabaseTest");
-    }
-  }
-
-  @Test
-  public void shouldTakeSpecificMongoDbVersion() {
-    IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
-    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
-    assumeThat(mongoDbRule).isExactlyInstanceOf(StartLocalMongoDbRule.class);
-    assertThat(mongoDbRule).extracting("version").isEqualTo(specificMongoDbVersion);
-  }
-
-  @Test
-  public void shouldStartSpecificMongoDbVersion() {
-    final IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
-    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
-    mongoDbRule.apply(
-        new Statement() {
-          @Override
-          public void evaluate() {
-            assertThat(mongoDbRule.getServerVersion()).isEqualTo("3.2.20");
-          }
-        },
-        Description.EMPTY);
-  }
-
-  @Test
-  public void shouldDetermineMongoDbVersionIfVersionIsNull() {
-    final MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(null).build();
-    assumeThat(mongoDbRule).isExactlyInstanceOf(StartLocalMongoDbRule.class);
-    assertThat(mongoDbRule)
-        .extracting("version")
-        .isIn(MongoDbRule.Builder.DEFAULT_VERSION, MongoDbRule.Builder.WINDOWS_VERSION);
-  }
-
-  @Test
-  public void shouldUseOsSpecificMongoDbVersion() {
-    MongoDbRule mongoDbRule = MongoDbRule.builder().build();
-    assumeThat(mongoDbRule).isExactlyInstanceOf(StartLocalMongoDbRule.class);
-    if (SystemUtils.IS_OS_WINDOWS) {
-      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
-    } else {
-      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
-    }
+  public void shouldStartLocalMongoDb() {
+    new EnvironmentRule()
+        .unsetEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME)
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                MongoDbRule actualRule = MongoDbRule.builder().build();
+                assertThat(actualRule).isExactlyInstanceOf(StartLocalMongoDbRule.class);
+              }
+            },
+            Description.EMPTY);
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
@@ -2,24 +2,45 @@ package org.sdase.commons.server.mongo.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.sdase.commons.server.testing.EnvironmentRule;
 
 public class MongoDbRuleTest {
+
   @Test
-  public void shouldStartLocalMongoDb() {
+  public void shouldUseExistingMongoDb() throws Throwable {
+    AtomicReference<MongoDbRule> actualRule = new AtomicReference<>();
+    new EnvironmentRule()
+        .setEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME, "mongodb://localhost")
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                actualRule.set(MongoDbRule.builder().build());
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(actualRule.get()).isExactlyInstanceOf(UseExistingMongoDbRule.class);
+  }
+
+  @Test
+  public void shouldStartLocalMongoDb() throws Throwable {
+    AtomicReference<MongoDbRule> actualRule = new AtomicReference<>();
     new EnvironmentRule()
         .unsetEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME)
         .apply(
             new Statement() {
               @Override
               public void evaluate() {
-                MongoDbRule actualRule = MongoDbRule.builder().build();
-                assertThat(actualRule).isExactlyInstanceOf(StartLocalMongoDbRule.class);
+                actualRule.set(MongoDbRule.builder().build());
               }
             },
-            Description.EMPTY);
+            Description.EMPTY)
+        .evaluate();
+    assertThat(actualRule.get()).isExactlyInstanceOf(StartLocalMongoDbRule.class);
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
@@ -16,6 +16,7 @@ import com.mongodb.internal.connection.ServerAddressHelper;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.SystemUtils;
 import org.bson.Document;
 import org.junit.AfterClass;
@@ -163,17 +164,21 @@ public class StartLocalMongoDbRuleTest {
   }
 
   @Test
-  public void shouldStartSpecificMongoDbVersion() {
+  public void shouldStartSpecificMongoDbVersion() throws Throwable {
+    AtomicReference<String> actualVersion = new AtomicReference<>();
     final IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
     MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
-    mongoDbRule.apply(
-        new Statement() {
-          @Override
-          public void evaluate() {
-            assertThat(mongoDbRule.getServerVersion()).isEqualTo("3.2.20");
-          }
-        },
-        Description.EMPTY);
+    mongoDbRule
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                actualVersion.set(mongoDbRule.getServerVersion());
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(actualVersion.get()).isEqualTo("3.2.20");
   }
 
   @Test

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
@@ -1,0 +1,202 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoCredential;
+import com.mongodb.MongoQueryException;
+import com.mongodb.MongoSecurityException;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Indexes;
+import com.mongodb.internal.connection.ServerAddressHelper;
+import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import java.util.ArrayList;
+import org.apache.commons.lang3.SystemUtils;
+import org.bson.Document;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.sdase.commons.server.testing.EnvironmentRule;
+
+public class StartLocalMongoDbRuleTest {
+
+  private static final String DATABASE_NAME = "my_db";
+  private static final String DATABASE_USERNAME = "theuser";
+  private static final String DATABASE_PASSWORD = "S3CR3t!"; // NOSONAR
+
+  private static MongoDbRule RULE;
+
+  @ClassRule
+  public static final EnvironmentRule ENV =
+      new EnvironmentRule().unsetEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
+
+  @BeforeClass
+  public static void initRule() {
+    // need to init the rule here because the environment variable is checked in the builder
+    RULE =
+        MongoDbRule.builder()
+            .withDatabase(DATABASE_NAME)
+            .withUsername(DATABASE_USERNAME)
+            .withPassword(DATABASE_PASSWORD)
+            .withTimeoutInMillis(30_000)
+            .build();
+    ((StartLocalMongoDbRule) RULE).before();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    ((StartLocalMongoDbRule) RULE).after();
+  }
+
+  @Test
+  public void shouldStartMongoDbWithSpecifiedSettings() {
+    try (MongoClient mongoClient =
+        new MongoClient(
+            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            MongoCredential.createCredential(
+                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
+            MongoClientOptions.builder().build())) {
+      assertThat(mongoClient.getCredential()).isNotNull();
+      assertThat(mongoClient.getCredential().getUserName()).isEqualTo(DATABASE_USERNAME);
+      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
+      assertThat(documentCount).isZero();
+    }
+  }
+
+  @Test(expected = MongoSecurityException.class)
+  public void shouldRejectAccessForBadCredentials() {
+    try (MongoClient mongoClient =
+        new MongoClient(
+            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            MongoCredential.createCredential(
+                DATABASE_USERNAME, DATABASE_NAME, (DATABASE_PASSWORD + "_bad").toCharArray()),
+            MongoClientOptions.builder().build())) {
+      mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
+    }
+  }
+
+  @Test // Flapdoodle can not require auth and create a user
+  public void shouldAllowAccessWithoutCredentials() {
+    try (MongoClient mongoClient =
+        new MongoClient(
+            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            MongoClientOptions.builder().build())) {
+      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
+      assertThat(documentCount).isZero();
+    }
+  }
+
+  @Test
+  public void shouldProvideClientForTesting() {
+    try (MongoClient mongoClient = RULE.createClient()) {
+      long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
+      assertThat(documentCount).isZero();
+    }
+  }
+
+  @Test
+  public void shouldNotSupportJavaScriptByDefault() {
+    try (MongoClient mongoClient = RULE.createClient()) {
+      ArrayList<Document> givenTargetType = new ArrayList<>();
+      FindIterable<Document> actualDocumentsNotQueriedYet =
+          mongoClient
+              .getDatabase("my_db")
+              .getCollection("test")
+              .find(new Document("$where", "this.name == 5"));
+      assertThatThrownBy(() -> actualDocumentsNotQueriedYet.into(givenTargetType))
+          .isInstanceOf(MongoQueryException.class)
+          .hasMessageContaining("no globalScriptEngine in $where parsing");
+    }
+  }
+
+  @Test
+  public void shouldClearCollections() {
+    try (MongoClient mongoClient =
+        new MongoClient(
+            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            MongoCredential.createCredential(
+                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
+            MongoClientOptions.builder().build())) {
+      MongoDatabase db = mongoClient.getDatabase("my_db");
+      MongoCollection<Document> collection = db.getCollection("clearCollectionsTest");
+      collection.createIndex(Indexes.ascending("field"));
+      collection.insertOne(new Document().append("field", "value"));
+
+      RULE.clearCollections();
+
+      assertThat(db.listCollectionNames()).contains("clearCollectionsTest");
+      assertThat(collection.listIndexes()).isNotEmpty();
+      assertThat(collection.countDocuments()).isZero();
+    }
+  }
+
+  @Test
+  public void shouldClearDatabase() {
+    try (MongoClient mongoClient =
+        new MongoClient(
+            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            MongoCredential.createCredential(
+                DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
+            MongoClientOptions.builder().build())) {
+      MongoDatabase db = mongoClient.getDatabase("my_db");
+      db.getCollection("clearDatabaseTest").insertOne(new Document().append("Hallo", "Welt"));
+
+      RULE.clearDatabase();
+
+      assertThat(db.listCollectionNames()).doesNotContain("clearDatabaseTest");
+    }
+  }
+
+  @Test
+  public void shouldTakeSpecificMongoDbVersion() {
+    IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
+    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
+    assertThat(mongoDbRule).extracting("version").isEqualTo(specificMongoDbVersion);
+  }
+
+  @Test
+  public void shouldStartSpecificMongoDbVersion() {
+    final IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
+    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
+    mongoDbRule.apply(
+        new Statement() {
+          @Override
+          public void evaluate() {
+            assertThat(mongoDbRule.getServerVersion()).isEqualTo("3.2.20");
+          }
+        },
+        Description.EMPTY);
+  }
+
+  @Test
+  public void shouldDetermineMongoDbVersionIfVersionIsNull() {
+    final MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(null).build();
+    assertThat(mongoDbRule)
+        .extracting("version")
+        .isIn(MongoDbRule.Builder.DEFAULT_VERSION, MongoDbRule.Builder.WINDOWS_VERSION);
+  }
+
+  @Test
+  public void shouldUseOsSpecificMongoDbVersion() {
+    MongoDbRule mongoDbRule = MongoDbRule.builder().build();
+    if (SystemUtils.IS_OS_WINDOWS) {
+      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
+      assertThat(mongoDbRule)
+          .extracting("version")
+          .isNotEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
+    } else {
+      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
+      assertThat(mongoDbRule)
+          .extracting("version")
+          .isNotEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
+    }
+  }
+}

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
@@ -60,7 +60,7 @@ public class StartLocalMongoDbRuleTest {
   public void shouldStartMongoDbWithSpecifiedSettings() {
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            ServerAddressHelper.createServerAddress(RULE.getHosts()),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -75,7 +75,7 @@ public class StartLocalMongoDbRuleTest {
   public void shouldRejectAccessForBadCredentials() {
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            ServerAddressHelper.createServerAddress(RULE.getHosts()),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, (DATABASE_PASSWORD + "_bad").toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -87,7 +87,7 @@ public class StartLocalMongoDbRuleTest {
   public void shouldAllowAccessWithoutCredentials() {
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            ServerAddressHelper.createServerAddress(RULE.getHosts()),
             MongoClientOptions.builder().build())) {
       long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
       assertThat(documentCount).isZero();
@@ -121,7 +121,7 @@ public class StartLocalMongoDbRuleTest {
   public void shouldClearCollections() {
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            ServerAddressHelper.createServerAddress(RULE.getHosts()),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -142,7 +142,7 @@ public class StartLocalMongoDbRuleTest {
   public void shouldClearDatabase() {
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(RULE.getHost()),
+            ServerAddressHelper.createServerAddress(RULE.getHosts()),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
@@ -1,0 +1,91 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.FindIterable;
+import org.bson.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.sdase.commons.server.testing.EnvironmentRule;
+
+public class UseExistingMongoDbRuleTest {
+
+  @ClassRule
+  public static final MongoDbRule EXTERNAL_DB =
+      MongoDbRule.builder()
+          .withDatabase("testDb")
+          .withUsername("testuser")
+          .withPassword("testpassowrd")
+          .build();
+
+  private static EnvironmentRule ENV;
+
+  private MongoDbRule useExistingMongoDbRule;
+
+  @BeforeClass
+  public static void initEnvAfterStartOfExternalDb() {
+    ENV =
+        new EnvironmentRule()
+            .setEnv(
+                "TEST_MONGODB_CONNECTION_STRING",
+                "mongodb://"
+                    + EXTERNAL_DB.getUsername()
+                    + ":"
+                    + EXTERNAL_DB.getPassword()
+                    + "@"
+                    + EXTERNAL_DB.getHosts()
+                    + "/"
+                    + EXTERNAL_DB.getDatabase()
+                    + "?"
+                    + EXTERNAL_DB.getOptions());
+  }
+
+  @Before
+  public void initUseExistingMongoDbRule() throws Throwable {
+    ENV.apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                useExistingMongoDbRule = MongoDbRule.builder().build();
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(useExistingMongoDbRule).isExactlyInstanceOf(UseExistingMongoDbRule.class);
+  }
+
+  @After
+  public void clearDatabase() {
+    useExistingMongoDbRule.clearDatabase();
+  }
+
+  @Test
+  public void shouldWriteToExternalDb() throws Throwable {
+    useExistingMongoDbRule
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                MongoClient clientInTest = useExistingMongoDbRule.createClient();
+                clientInTest
+                    .getDatabase(useExistingMongoDbRule.getDatabase())
+                    .getCollection("test")
+                    .insertOne(new Document("property", "example"));
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+
+    MongoClient externalDbClient = EXTERNAL_DB.createClient();
+    FindIterable<Document> actualResult =
+        externalDbClient.getDatabase(EXTERNAL_DB.getDatabase()).getCollection("test").find();
+    assertThat(actualResult).hasSize(1);
+    assertThat(actualResult.first()).extracting("property").isEqualTo("example");
+  }
+}

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
@@ -21,7 +21,7 @@ public class UseExistingMongoDbRuleTest {
       MongoDbRule.builder()
           .withDatabase("testDb")
           .withUsername("testuser")
-          .withPassword("testpassowrd")
+          .withPassword("testpassword")
           .build();
 
   private static EnvironmentRule ENV;

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtilTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtilTest.java
@@ -1,0 +1,69 @@
+package org.sdase.commons.server.mongo.testing.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.flapdoodle.embed.process.config.store.DownloadConfig;
+import de.flapdoodle.embed.process.distribution.Distribution;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.sdase.commons.server.mongo.testing.MongoDbRule;
+import org.sdase.commons.server.testing.EnvironmentRule;
+
+public class DownloadConfigFactoryUtilTest {
+
+  @Test
+  public void shouldCreateWithFixedDownloadPath() throws Throwable {
+    AtomicReference<DownloadConfig> actualConfig = new AtomicReference<>();
+    new EnvironmentRule()
+        .setEnv("EMBEDDED_MONGO_DOWNLOAD_PATH", "http://localhost/mongo.tar.gz")
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                actualConfig.set(DownloadConfigFactoryUtil.createDownloadConfig());
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(
+            actualConfig
+                .get()
+                .getDownloadPath()
+                .getPath(Distribution.detectFor(MongoDbRule.Builder.DEFAULT_VERSION)))
+        .isEqualTo("http://localhost/mongo.tar.gz");
+  }
+
+  @Test
+  public void shouldCreateProxyWithAuthentication() throws Throwable {
+    AtomicReference<DownloadConfig> actualConfig = new AtomicReference<>();
+    new EnvironmentRule()
+        .setEnv("http_proxy", "http://tester:dummy@the-test-domain.example.com:1234")
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                actualConfig.set(DownloadConfigFactoryUtil.createDownloadConfig());
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(actualConfig.get()).isNotNull();
+    PasswordAuthentication authentication =
+        Authenticator.requestPasswordAuthentication(
+            "the-test-domain.example.com",
+            null,
+            1234,
+            "http",
+            "none",
+            "http",
+            new URL("http://tester:dummy@the-test-domain.example.com:1234"),
+            Authenticator.RequestorType.PROXY);
+    assertThat(authentication.getUserName()).isEqualTo("tester");
+    assertThat(authentication.getPassword()).isEqualTo("dummy".toCharArray());
+  }
+}

--- a/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
+++ b/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
@@ -29,7 +29,7 @@ public class MorphiaApplicationIT {
           randomPorts(),
           // provide a lambda to only read the value after the mongodb connection parameters are
           // available
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase),
           config("mongo.username", MONGODB::getUsername),
           config("mongo.password", MONGODB::getPassword),

--- a/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
+++ b/sda-commons-server-morphia-example/src/test/java/org/sdase/commons/server/morphia/example/MorphiaApplicationIT.java
@@ -30,7 +30,10 @@ public class MorphiaApplicationIT {
           // provide a lambda to only read the value after the mongodb connection parameters are
           // available
           config("mongo.hosts", MONGODB::getHost),
-          config("mongo.database", MongoDbRule.Builder.DEFAULT_DATABASE));
+          config("mongo.database", MONGODB::getDatabase),
+          config("mongo.username", MONGODB::getUsername),
+          config("mongo.password", MONGODB::getPassword),
+          config("mongo.options", MONGODB::getOptions));
 
   @ClassRule
   public static final RuleChain CHAIN =

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleCustomConverterIT.java
@@ -37,7 +37,7 @@ public class MorphiaBundleCustomConverterIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleDefinedClassIT.java
@@ -30,7 +30,7 @@ public class MorphiaBundleDefinedClassIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleEnsureIndexesIT.java
@@ -35,7 +35,7 @@ public class MorphiaBundleEnsureIndexesIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleHealthCheckIT.java
@@ -27,7 +27,7 @@ public class MorphiaBundleHealthCheckIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleLocalDateConvertersIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleLocalDateConvertersIT.java
@@ -32,7 +32,7 @@ public class MorphiaBundleLocalDateConvertersIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   private static final DropwizardAppRule<Config> DW_PLAIN =
@@ -40,7 +40,7 @@ public class MorphiaBundleLocalDateConvertersIT {
           MorphiaPlainTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleNoEntityDefinedIT.java
@@ -30,7 +30,7 @@ public class MorphiaBundleNoEntityDefinedIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleScanPackageByMarkerClassIT.java
@@ -31,7 +31,7 @@ public class MorphiaBundleScanPackageByMarkerClassIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleTracingIT.java
@@ -33,7 +33,7 @@ public class MorphiaBundleTracingIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationDisabledIT.java
@@ -26,7 +26,7 @@ public class MorphiaBundleValidationDisabledIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);

--- a/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
+++ b/sda-commons-server-morphia/src/test/java/org/sdase/commons/server/morphia/MorphiaBundleValidationIT.java
@@ -27,7 +27,7 @@ public class MorphiaBundleValidationIT {
           MorphiaTestApp.class,
           null,
           randomPorts(),
-          config("mongo.hosts", MONGODB::getHost),
+          config("mongo.hosts", MONGODB::getHosts),
           config("mongo.database", MONGODB::getDatabase));
 
   @ClassRule public static final RuleChain CHAIN = RuleChain.outerRule(MONGODB).around(DW);


### PR DESCRIPTION
This PR introduces an optional environment variable with a MongoDB Connection String.

If `TEST_MONGODB_CONNECTION_STRING` is set in the test environment, the MongoDbRule will not start a local database but provides config for applications in test to use the database in the environment.

This PR prepares for testing against production ready databases (like AWS DocumentDB) that can't be bootstrapped with Flapdoodle or other tools. As before no local database is needed. If no such DB is configured for the environment, Flapdoodle will download and start a local MongoDB instance.

This feature may also be used locally with a running MongoDB to run the tests faster.

Preparing the tests to support external MongoDBs has some requirements that are named in the README of the module.

As this feature required some refactorings and introduces some deprecations it may be helpful to review the single commits instead of looking at all changes at once.