### PR TITLE
feat: include metrics for health checks at /metrics/prometheus

### DIFF
--- a/sda-commons-server-prometheus/README.md
+++ b/sda-commons-server-prometheus/README.md
@@ -2,12 +2,8 @@
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-server-prometheus/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-server-prometheus)
 
-The module `sda-commons-server-prometheus` provides 
-
-- an admin endpoint to serve metrics in a format that Prometheus can read. The endpoint is available at the applications 
-  admin port at `/metrics/prometheus`
-- an admin endpoint to serve health check results as Prometheus metrics. The endpoint is available at the applications 
-  admin port at `/healthcheck/prometheus`
+The module `sda-commons-server-prometheus` provides an admin endpoint to serve metrics and health check results in a format that Prometheus can read. 
+The endpoint is available at the applications admin port at `/metrics/prometheus`.
 
 ## Provided metrics
 
@@ -30,18 +26,21 @@ Default metrics that are provided at `/metrics/prometheus`:
 | **`kafka_producer_topic_message_total`**                    | Tracks the number of messaged published to a Kafka topic     | `KafkaMessageProducer`                    |
 |                                   | _`consumer_name`_       | Name of the consumer that processed the message              | Bridged from Kafka                        |
 |                                   | _`topic_name`_          | Name of the topic where messages where consumed from         | Bridged from Kafka                        |
-| **`jvm_`***                         |                       | Multiple metrics about the JVM                               | Bridged from Dropwizard                   |
-| **`io_dropwizard_jetty_`***         |                       | Multiple metrics from the embedded Jetty server              | Bridged from Dropwizard                   |
-| **`io_dropwizard_db_`***            |                       | Multiple metrics from the database if a database is used     | Bridged from Dropwizard                   |
+| **`jvm_`***                       |                         | Multiple metrics about the JVM                               | Bridged from Dropwizard                   |
+| **`io_dropwizard_jetty_`**        |                         | Multiple metrics from the embedded Jetty server              | Bridged from Dropwizard                   |
+| **`io_dropwizard_db_`**           |                         | Multiple metrics from the database if a database is used     | Bridged from Dropwizard                   |
+| **`healthcheck_status`**          | _`name`_                | Metrics that represent the state of the health checks        | `HealthCheckMetricsCollector`             | 
 
 *) A filter that extracts the consumer from the HTTP headers should add `Consumer-Name` to the request properties. That
    filter is not part of the `PrometheusBundle`.
 
 ## Health Checks
 
-All health checks are provided at the applications admin port at `/healthcheck/prometheus` as Gauge metric 
-`healthcheck_status`. The name of the Health Check is used as label `name`. The metric value is `1.0` for healthy and
-`0.0` for unhealthy. Example:
+All health checks are provided as a Gauge metric `healthcheck_status` and are included in the metrics endpoint.
+They are also available at the applications admin port at `/healthcheck/prometheus`.
+This endpoint is only available for backward compatibility and will be removed in the future.
+The name of the Health Check is used as label `name`.
+The metric value is `1.0` for healthy and `0.0` for unhealthy. Example:
 
 ```
 healthcheck_status{name="hibernate",} 1.0

--- a/sda-commons-server-prometheus/src/main/java/org/sdase/commons/server/prometheus/health/HealthCheckMetricsCollector.java
+++ b/sda-commons-server-prometheus/src/main/java/org/sdase/commons/server/prometheus/health/HealthCheckMetricsCollector.java
@@ -1,0 +1,57 @@
+package org.sdase.commons.server.prometheus.health;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.stream.Collectors;
+
+/**
+ * Provides all {@link HealthCheck}s as Prometheus metrics.
+ *
+ * <p>Currently all {@link HealthCheck.Result}s are collected synchronously and sequentially unless
+ * a {@link HealthCheck} is annotated as {@link com.codahale.metrics.health.annotation.Async Async}
+ * when the endpoint is called.
+ */
+public class HealthCheckMetricsCollector extends Collector {
+  private static final String HEALTH_CHECK_STATUS_METRIC = "healthcheck_status";
+  private static final List<String> HEALTH_CHECK_METRIC_LABELS =
+      unmodifiableList(singletonList("name"));
+
+  private final HealthCheckRegistry healthCheckRegistry;
+
+  public HealthCheckMetricsCollector(HealthCheckRegistry healthCheckRegistry) {
+    this.healthCheckRegistry = healthCheckRegistry;
+  }
+
+  public List<MetricFamilySamples> collect() {
+    MetricFamilySamples metricFamilySamples =
+        new MetricFamilySamples(
+            HEALTH_CHECK_STATUS_METRIC,
+            Collector.Type.GAUGE,
+            "Status of a Health Check (1: healthy, 0: unhealthy)",
+            collectHealthCheckSamples());
+    return Collections.singletonList(metricFamilySamples);
+  }
+
+  private List<Sample> collectHealthCheckSamples() {
+    SortedMap<String, HealthCheck.Result> results = healthCheckRegistry.runHealthChecks();
+
+    return results.entrySet().stream()
+        .map(e -> createSample(e.getKey(), e.getValue().isHealthy()))
+        .collect(Collectors.toList());
+  }
+
+  private Sample createSample(String healthCheckName, boolean healthy) {
+    List<String> labelValues = singletonList(healthCheckName);
+    double gaugeValue = healthy ? 1.0 : 0.0;
+    return new Sample(
+        HEALTH_CHECK_STATUS_METRIC, HEALTH_CHECK_METRIC_LABELS, labelValues, gaugeValue);
+  }
+}

--- a/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
+++ b/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
@@ -162,6 +162,15 @@ public class PrometheusBundleTest {
 
   @Test
   public void shouldProvideHealthChecksAsPrometheusMetrics() {
+    String healthChecks = readMetrics();
+
+    assertThat(healthChecks)
+        .contains("healthcheck_status{name=\"anUnhealthyCheck\",} 0.0")
+        .contains("healthcheck_status{name=\"aHealthyCheck\",} 1.0");
+  }
+
+  @Test
+  public void shouldProvideHealthChecksAsPrometheusMetricsOnCustomEndpoint() {
     String healthChecks = readHealthChecks();
 
     assertThat(healthChecks)

--- a/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/health/HealthCheckMetricsCollectorTest.java
+++ b/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/health/HealthCheckMetricsCollectorTest.java
@@ -1,0 +1,49 @@
+package org.sdase.commons.server.prometheus.health;
+
+import static io.prometheus.client.Collector.Type.GAUGE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.health.HealthCheck.Result;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import io.prometheus.client.Collector.MetricFamilySamples;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.junit.Test;
+
+public class HealthCheckMetricsCollectorTest {
+
+  @Test
+  public void shouldExposeMetricsForHealthChecks() {
+    HealthCheckRegistry registry = mock(HealthCheckRegistry.class);
+    HealthCheckMetricsCollector collector = new HealthCheckMetricsCollector(registry);
+
+    SortedMap<String, Result> results = new TreeMap<>();
+    results.put("healthy_check", Result.healthy());
+    results.put("unhealthy_check", Result.unhealthy("Something went wrong"));
+    when(registry.runHealthChecks()).thenReturn(results);
+
+    List<MetricFamilySamples> metrics = collector.collect();
+
+    assertThat(metrics).hasSize(1);
+    MetricFamilySamples gauge = metrics.get(0);
+    assertThat(gauge.name).isEqualTo("healthcheck_status");
+    assertThat(gauge.help).isNotBlank();
+    assertThat(gauge.type).isEqualTo(GAUGE);
+    assertThat(gauge.samples).hasSize(2);
+
+    MetricFamilySamples.Sample sampleHealthy = gauge.samples.get(0);
+    assertThat(sampleHealthy.name).isEqualTo("healthcheck_status");
+    assertThat(sampleHealthy.labelNames).containsExactly("name");
+    assertThat(sampleHealthy.labelValues).containsExactly("healthy_check");
+    assertThat(sampleHealthy.value).isEqualTo(1.0);
+
+    MetricFamilySamples.Sample sampleUnhealthy = gauge.samples.get(1);
+    assertThat(sampleUnhealthy.name).isEqualTo("healthcheck_status");
+    assertThat(sampleUnhealthy.labelNames).containsExactly("name");
+    assertThat(sampleUnhealthy.labelValues).containsExactly("unhealthy_check");
+    assertThat(sampleUnhealthy.value).isEqualTo(0.0);
+  }
+}


### PR DESCRIPTION
Previously these metrics were only available at the additional /healthcheck/prometheus endpoint that is now deprecated.