### PR TITLE
fix(deps): Bump dropwizard from 2.0.16 to 2.0.17

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -7,7 +7,7 @@ javaPlatform {
 }
 
 ext {
-  dropwizardVersion = '2.0.16'
+  dropwizardVersion = '2.0.17'
   morphiaVersion = '1.6.1'
   prometheusVersion = '0.9.0'
   swaggerCoreVersion = '1.6.2'


### PR DESCRIPTION
This is also addressing CVE-2020-25649 from jackson-databind