### PR TITLE
feat(wiremock-testing): add jupiter support for wiremockRule and wiremockClassRule

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -211,6 +211,9 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
       failOnVersionConflict()
     }
   }
+  test {
+    useJUnitPlatform()
+  }
 }
 
 /**

--- a/sda-commons-client-jersey-wiremock-testing/README.md
+++ b/sda-commons-client-jersey-wiremock-testing/README.md
@@ -3,3 +3,54 @@
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-client-jersey-wiremock-testing/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-client-jersey-wiremock-testing)
 
 Testing dependencies for [WireMock](https://wiremock.org) test framework.
+
+## Extensions
+
+This module provides a Junit 5 extension to setup Wiremock for your tests.
+
+### WireMockExtension
+
+Useful for setting up Wiremock for each one of your tests.
+
+Example:
+```java
+class WireMockExtensionTest {
+
+  @RegisterExtension
+  WiremockExtension wire = new WiremockExtension();
+
+  @BeforeEach
+  void before() {
+    wire.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", notMatching("gzip"))
+            .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
+  }
+
+  // Tests
+}
+```
+
+### WireMockClassExtension
+
+Useful for setting up Wiremock once for your test class.
+
+Example:
+```java
+class WireMockClassExtensionTest {
+
+  @RegisterExtension
+  public static WireMockClassExtension wire =
+      new WireMockClassExtension();
+
+  @BeforeAll
+  public static void beforeAll() {
+    wire.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", notMatching("gzip"))
+            .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
+  }
+  
+  // Tests
+}
+```

--- a/sda-commons-client-jersey-wiremock-testing/build.gradle
+++ b/sda-commons-client-jersey-wiremock-testing/build.gradle
@@ -11,4 +11,9 @@ dependencies {
   compile 'org.glassfish.jersey.core:jersey-client'
   compile 'org.glassfish.jersey.ext:jersey-proxy-client'
   compile 'jakarta.servlet:jakarta.servlet-api'
+  compile 'org.junit.jupiter:junit-jupiter-api'
+
+  testCompile 'org.assertj:assertj-core'
+  testCompile 'org.slf4j:jcl-over-slf4j'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtension.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtension.java
@@ -1,0 +1,53 @@
+package org.sdase.commons.client.jersey.wiremock.testing;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.Options;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockClassRule} */
+public class WireMockClassExtension extends WireMockServer
+    implements BeforeAllCallback, AfterAllCallback {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WireMockClassExtension.class);
+
+  /** Constructor that creates a new instance with dynamic port */
+  public WireMockClassExtension() {
+    this(wireMockConfig().dynamicPort());
+  }
+
+  public WireMockClassExtension(Options options) {
+    super(options);
+  }
+
+  public WireMockClassExtension(int port, Integer httpsPort) {
+    this(wireMockConfig().port(port).httpsPort(httpsPort));
+  }
+
+  public WireMockClassExtension(int port) {
+    this(wireMockConfig().port(port));
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    LOGGER.info("Start WireMock");
+    start();
+    if (options.getHttpDisabled()) {
+      WireMock.configureFor("https", "localhost", httpsPort());
+    } else {
+      WireMock.configureFor("http", "localhost", port());
+    }
+  }
+
+  @Override
+  public void afterAll(ExtensionContext context) {
+    LOGGER.info("Stop WireMock");
+    stop();
+  }
+}

--- a/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtension.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtension.java
@@ -1,0 +1,70 @@
+package org.sdase.commons.client.jersey.wiremock.testing;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.Options;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import com.github.tomakehurst.wiremock.verification.NearMiss;
+import java.util.List;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockRule} */
+public class WireMockExtension extends WireMockServer
+    implements BeforeEachCallback, AfterEachCallback {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(WireMockExtension.class);
+
+  /** Constructor that creates a new instance with dynamic port */
+  public WireMockExtension() {
+    this(wireMockConfig().dynamicPort());
+  }
+
+  public WireMockExtension(Options options) {
+    super(options);
+  }
+
+  public WireMockExtension(int port) {
+    this(wireMockConfig().port(port));
+  }
+
+  public WireMockExtension(int port, Integer httpsPort) {
+    this(wireMockConfig().port(port).httpsPort(httpsPort));
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    LOGGER.info("Start WireMock");
+    start();
+
+    if (options.getHttpDisabled()) {
+      WireMock.configureFor("https", "localhost", httpsPort());
+    } else {
+      WireMock.configureFor("localhost", port());
+    }
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    LOGGER.info("Stop WireMock");
+    stop();
+  }
+
+  public void assertAllRequestsMatched() {
+    List<LoggedRequest> unmatchedRequests = findAllUnmatchedRequests();
+    if (!unmatchedRequests.isEmpty()) {
+      List<NearMiss> nearMisses = findNearMissesForAllUnmatchedRequests();
+      if (nearMisses.isEmpty()) {
+        throw VerificationException.forUnmatchedRequests(unmatchedRequests);
+      } else {
+        throw VerificationException.forUnmatchedNearMisses(nearMisses);
+      }
+    }
+  }
+}

--- a/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtensionTest.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtensionTest.java
@@ -1,0 +1,67 @@
+package org.sdase.commons.client.jersey.wiremock.testing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class WireMockClassExtensionTest {
+
+  @RegisterExtension public static WireMockClassExtension wire = new WireMockClassExtension();
+
+  @BeforeAll
+  public static void beforeAll() {
+    wire.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", notMatching("gzip"))
+            .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
+  }
+
+  @Test
+  void shouldGetMockedResponse() throws Exception {
+    URLConnection connection = new URL(wire.baseUrl() + "/api/cars").openConnection();
+    try (InputStream inputStream = connection.getInputStream()) {
+      assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("[]");
+    }
+  }
+
+  @Test
+  void shouldGet404() throws Exception {
+    HttpURLConnection connection =
+        (HttpURLConnection) new URL(wire.baseUrl() + "/foo").openConnection();
+    assertThat(connection.getResponseCode()).isEqualTo(404);
+  }
+
+  @Nested
+  class ConstructorTests {
+    @Test
+    void shouldSetupMockForPortAndHttpsPort() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090, 8091);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+      assertThat(wireMockClassExtension.getOptions().httpsSettings().port()).isEqualTo(8091);
+    }
+
+    @Test
+    void shouldSetupMockForPort() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+    }
+
+    @Test
+    void shouldSetupMockForNoParameters() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension();
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isBetween(0, 9999);
+    }
+  }
+}

--- a/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtensionTest.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtensionTest.java
@@ -1,0 +1,72 @@
+package org.sdase.commons.client.jersey.wiremock.testing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.tomakehurst.wiremock.client.VerificationException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class WireMockExtensionTest {
+
+  @RegisterExtension WireMockExtension wire = new WireMockExtension();
+
+  @BeforeEach
+  void before() {
+    wire.stubFor(
+        get("/api/cars") // NOSONAR
+            .withHeader("Accept", notMatching("gzip"))
+            .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
+  }
+
+  @Test
+  void shouldGetMockedResponse() throws Exception {
+    URLConnection connection = new URL(wire.baseUrl() + "/api/cars").openConnection();
+    try (InputStream inputStream = connection.getInputStream()) {
+      assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("[]");
+      wire.assertAllRequestsMatched();
+    }
+  }
+
+  @Test
+  void shouldGet404() throws Exception {
+    HttpURLConnection connection =
+        (HttpURLConnection) new URL(wire.baseUrl() + "/foo").openConnection();
+    assertThat(connection.getResponseCode()).isEqualTo(404);
+    assertThrows(
+        VerificationException.class,
+        wire::assertAllRequestsMatched,
+        "Expected assertAllRequestsMatched to throw VerificationException, but it didn't");
+  }
+
+  @Nested
+  class ConstructorTests {
+    @Test
+    void shouldSetupMockForPortAndHttpsPort() {
+      WireMockExtension wireMockClassExtension = new WireMockExtension(8090, 8091);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+      assertThat(wireMockClassExtension.getOptions().httpsSettings().port()).isEqualTo(8091);
+    }
+
+    @Test
+    void shouldSetupMockForPort() {
+      WireMockExtension wireMockClassExtension = new WireMockExtension(8090);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+    }
+
+    @Test
+    void shouldSetupMockForNoParameters() {
+      WireMockExtension wireMockClassExtension = new WireMockExtension();
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isBetween(0, 9999);
+    }
+  }
+}

--- a/sda-commons-server-testing/README.md
+++ b/sda-commons-server-testing/README.md
@@ -4,12 +4,18 @@
 
 The module `sda-commons-server-testing` is the base module to add unit and integrations test for applications in the 
 SDA SE infrastructure.
-It provides JUnit test rules that are helpful in integration tests. 
+It provides JUnit test rules and extensions that are helpful in integration tests. 
 
 Add the module with test scope:
 
 ```groovy
   testCompile "org.sdase.commons:sda-commons-server-testing"
+```
+In case you want to use JUnit 5 you also have to activate it in your build.gradle:
+```groovy
+  test {
+    useJUnitPlatform()
+  }
 ```
 
 ## Provided Assertions

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -11,7 +11,11 @@ dependencies {
   compile 'jakarta.servlet:jakarta.servlet-api'
 
   compile 'junit:junit'
+  compile 'org.junit.jupiter:junit-jupiter-api'
   compile 'org.hamcrest:hamcrest'
   compile 'org.mockito:mockito-core'
   compile 'org.assertj:assertj-core'
+
+  runtimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+  runtimeOnly 'org.junit.vintage:junit-vintage-engine'
 }

--- a/sda-commons-shared-error/build.gradle
+++ b/sda-commons-shared-error/build.gradle
@@ -4,4 +4,5 @@ dependencies {
 
   testCompile 'junit:junit'
   testCompile 'org.assertj:assertj-core'
+  testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }


### PR DESCRIPTION
*1 This PR enables JUnit 5 for sda-commons*
- it adds dependencies to junit-jupiter-api
- it adds the jupiter and vintage engines as test runtime dependencies
- configures the main test plugin to use junit 5

These changes replace PR #740

*2 It adds extensions for spinning up Wiremock*

Since there is no official support (yet?) from Wiremock we decided to simply create our own extensions to replace the old JUnit 4 rules.
See: https://github.com/tomakehurst/wiremock/issues/684