### PR TITLE
Add JUnit 5 support for Kafka testing

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -17,6 +17,7 @@ ext {
   jsonUnitVersion = '2.22.0'
   scalaVersion = '2.12.8' // Always prefer the version from kafka_2.12. Make sure that the major version is always aligned with kafka, s3mock, and mbknor-jackson-jsonschema.
   kafkaVersion = '2.2.1' // Fix version as decided in https://sda-se.atlassian.net/l/c/ce8EFM2e. Be careful when upgrading this dependency.
+  kafkaJunitVersion = '3.2.2' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5
 }
 
 dependencies {
@@ -146,7 +147,8 @@ dependencies {
     api "com.101tec:zkclient:0.11"
     api "org.apache.curator:curator-test:2.12.0"
     api "com.github.ftrossbach:club-topicana-core:0.1.0"
-    api "com.salesforce.kafka.test:kafka-junit4:3.2.2"
+    api "com.salesforce.kafka.test:kafka-junit4:$kafkaJunitVersion"
+    api "com.salesforce.kafka.test:kafka-junit5:$kafkaJunitVersion"
     api "com.typesafe.scala-logging:scala-logging_2.12:3.9.2", {
       because "conflict between io.findify:s3mock_2.12 and org.apache.kafka:kafka_2.12 prefer version of kafka!"
     }

--- a/sda-commons-server-kafka-testing/README.md
+++ b/sda-commons-server-kafka-testing/README.md
@@ -6,20 +6,10 @@ The module `sda-commons-server-kafka-testing` is the base module to add unit and
 
 It includes the dependencies to [sda-commons-server-testing](../sda-commons-server-testing/README.md) module.
 
-For Kafka based tests, the following libraries are included
+## Use with Kafka-Unit 4
 
-| Group            | Artifact           | Version |
-|------------------|--------------------|---------|
-| `com.salesforce.kafka.test` | `kafka-junit4` | 3.0.1 |
-| `org.apache.kafka` | `kafka_2.12` | 1.1.1|
-| `org.awaitility` | `awaitility` | 3.1.2 |
-
-kafka-junit4 does not depend on a fixed Kafka broker version. The kafka must be included in the used version within an dedicated dependency.
-Currently, the Kafka version 1.1.1 with scala version 2.12 is used.
-
-## Usage of Kafka-Unit
 The kafka-junit4 library provides means for easily setting up a Kafka broker that can be reconfigured easily by using the following class rule:
-```
+```java
 @ClassRule
 protected static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource()
          .withBrokerProperty("auto.create.topics.enable", "false")
@@ -27,45 +17,52 @@ protected static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResour
          .withBrokers(2); // number of broker instances in the cluster
 ```
 
-## Test support with random broker ports
+### Test support with random broker ports
 The usage of random ports allows to execute tests in parallel and reduce the probability of port conflicts, e.g. when local-infra is also started.  
 
-The example above, starts two Kafka brokers within a cluster. To test your application, you have to configure these servers as 
+The example above starts two Kafka brokers within a cluster. To test your application, you have to configure these servers as 
 bootstrap servers. This is normally done via the configuration YAML file within the property `kafka -> brokers`.
 
-By using the following snippets, the broker urls are passed to the application.  
+You can override these properties programmatically using config overrides when creating your
+`DropwizardAppRule`:
 
-**Changes in the YAML:**
-```
-kafka:
-  brokers: ${BROKER_CONNECTION_STRING} 
-```
-
-**Usage of `KafkaBrokerEnvironmentRule` within the test**
-
-The `KafkaBrokerEnvironmentRule` sets the broker urls as JSON formatted string into the environment variable:
-```
-protected static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource()
-         .withBrokers(2);
-
-   protected static final KafkaBrokerEnvironmentRule KAFKA_BROKER_ENVIRONMENT_RULE = new KafkaBrokerEnvironmentRule(KAFKA);
-
-   protected static final DropwizardAppRule<KafkaTestConfiguration> DROPWIZARD_APP_RULE = new DropwizardAppRule<>(
-         KafkaTestApplication.class, ResourceHelpers.resourceFilePath("test-config-default.yml"));
-
-   @ClassRule
-   public static final TestRule CHAIN = RuleChain.outerRule(KAFKA_BROKER_ENVIRONMENT_RULE).around(DROPWIZARD_APP_RULE); 
+```java
+private static final DropwizardAppRule<KafkaTestConfiguration> DW =
+      new DropwizardAppRule<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString)
+      );
 ```
 
-**Usage of ConfigurationSubstitutionBundle within the application**
+## Usage with Kafka-Unit 5
 
-This requires also to add the `ConfigurationSubstitutionBundle` to your bundle.
-```
-bootstrap.addBundle(ConfigurationSubstitutionBundle.builder().build()); 
-```
+The same things can be done if you prefer JUnit 5. You just have to replace the class rule
+by the extension of the same name from package `com.salesforce.kafka.test.junit5` and use 
+Dropwizard's app extension. Just make sure you execute the Kafka extension before the Dropwizard extension.
 
-**Example content of the environment variable**
+Example:
+
+```java
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+// ...
+
+class KafkaJUnit5IT {
+
+  @RegisterExtension
+  @Order(0) // Start the broker before the app
+  static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource().withBrokers(2);
+
+  @RegisterExtension
+  @Order(1)
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+      new DropwizardAppExtension<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config.yaml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString) // Override the Kafka brokers
+      );
+
+}
 ```
-[ "127.0.0.1:38185", "127.0.0.1:44401" ]
-```
-An example for setup a test scenario can be found in [KafkaBundleWithConfigIT.java](./../sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java)

--- a/sda-commons-server-kafka-testing/build.gradle
+++ b/sda-commons-server-kafka-testing/build.gradle
@@ -6,6 +6,10 @@ dependencies {
     exclude group: 'org.apache.curator', module: 'curator-test'
   }
 
+  compile 'com.salesforce.kafka.test:kafka-junit5', {
+    exclude group: 'org.apache.curator', module: 'curator-test'
+  }
+
   compile "org.apache.curator:curator-test", {
     exclude group: 'org.apache.zookeeper', module: 'zookeeper'
   }

--- a/sda-commons-server-kafka-testing/src/main/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRule.java
+++ b/sda-commons-server-kafka-testing/src/main/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRule.java
@@ -10,7 +10,14 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.sdase.commons.server.testing.Environment;
 
-/** Rule for setting the Environment Variable */
+/**
+ * Rule for setting the Environment Variable `BROKER_CONNECTION_STRING`
+ *
+ * @deprecated please replace with the original {@link KafkaBrokerRule} and use standard config
+ *     overrides when creating your {@link io.dropwizard.testing.junit.DropwizardAppRule}, e.g.
+ *     {@code config("kafka.brokers", KAFKA::getKafkaConnectString)}
+ */
+@Deprecated
 public class KafkaBrokerEnvironmentRule implements TestRule, KafkaBrokerRule {
 
   private final SharedKafkaTestResource kafka;

--- a/sda-commons-server-kafka-testing/src/test/java/org/sdase/commons/server/kafka/confluent/testing/KafkaJUnit5IT.java
+++ b/sda-commons-server-kafka-testing/src/test/java/org/sdase/commons/server/kafka/confluent/testing/KafkaJUnit5IT.java
@@ -1,0 +1,55 @@
+package org.sdase.commons.server.kafka.confluent.testing;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class KafkaJUnit5IT {
+
+  @RegisterExtension
+  @Order(0)
+  static SharedKafkaTestResource KAFKA = new SharedKafkaTestResource().withBrokers(2);
+
+  @RegisterExtension
+  @Order(1)
+  static DropwizardAppExtension<TestConfig> DW =
+      new DropwizardAppExtension<>(
+          TestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("brokers", KAFKA::getKafkaConnectString));
+
+  @Test
+  void shouldOverrideBrokers() {
+    assertThat(DW.getConfiguration().getBrokers()).isEqualTo(KAFKA.getKafkaConnectString());
+  }
+
+  public static class TestApp extends Application<TestConfig> {
+
+    @Override
+    public void run(TestConfig configuration, Environment environment) {}
+  }
+
+  public static class TestConfig extends Configuration {
+
+    private String brokers;
+
+    public String getBrokers() {
+      return brokers;
+    }
+
+    @SuppressWarnings("unused")
+    public TestConfig setBrokers(String brokers) {
+      this.brokers = brokers;
+      return this;
+    }
+  }
+}

--- a/sda-commons-server-kafka-testing/src/test/resources/test-config.yaml
+++ b/sda-commons-server-kafka-testing/src/test/resources/test-config.yaml
@@ -1,0 +1,7 @@
+server:
+  applicationConnectors:
+    - type: http
+      port: 0
+  adminConnectors:
+    - type: http
+      port: 0


### PR DESCRIPTION
- [x] Waiting for #741 to be approved.

This PR mainly adds a new dependency to com.salesforce.kafka.test:kafka-junit5 which provides a JUnit 5 extension to start a Kafka broker

Moreover it adjusts the documentation and marks the KafkaBrokerEnvironmentRule as deprecated.

The code was taken over from PR #716 