### PR TITLE
fix(server-testing): Enforce the correct version of 'org.junit.platfo…

### DIFF
--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -15,9 +15,12 @@ dependencies {
   compile 'org.hamcrest:hamcrest'
   compile 'org.mockito:mockito-core'
   compile 'org.assertj:assertj-core'
-  compile 'org.junit-pioneer:junit-pioneer'
+  compile 'org.junit-pioneer:junit-pioneer', {
+    exclude group: 'org.junit.platform', module: 'junit-platform-launcher'
+  }
   compile 'org.junit.jupiter:junit-jupiter-params'
 
+  runtimeOnly 'org.junit.platform:junit-platform-launcher' // enforce JUnit's version
   runtimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   runtimeOnly 'org.junit.vintage:junit-vintage-engine'
 }


### PR DESCRIPTION
…rm:junit-platform-launcher'

Resolves a version conflict as junit-pioneer brings an older version

Strangely only came up when I wanted to update the cookiecutter-template:
https://github.com/SDA-SE/cookiecutter-templates/pull/92

"failOnVersionConflict" did not come across the problem in sda-commons.