### PR TITLE
fix(server-mongo-testing): MongoDbClassExtension uses default values …

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
@@ -103,12 +103,16 @@ public interface MongoDb {
 
   abstract class Builder<T extends MongoDb> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
-
     public static final Version.Main DEFAULT_VERSION = V3_6;
     public static final Version.Main WINDOWS_VERSION = V4_0;
 
     protected static final long DEFAULT_TIMEOUT_MS = MINUTES.toMillis(1L);
+
+    static final String DEFAULT_USER = "dbuser";
+    static final String DEFAULT_PASSWORD = "sda123"; // NOSONAR
+    static final String DEFAULT_DATABASE = "default_db";
+
+    private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
 
     protected String mongoDbUrlOverride =
         System.getenv(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtension.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtension.java
@@ -34,6 +34,9 @@ public interface MongoDbClassExtension extends MongoDb, BeforeAllCallback {
 
     private Builder() {
       // prevent instantiation
+      username = DEFAULT_USER;
+      password = DEFAULT_PASSWORD; // NOSONAR Sonar's security hotspot
+      database = DEFAULT_DATABASE;
     }
 
     public MongoDbClassExtension build() {

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbRule.java
@@ -50,18 +50,19 @@ public interface MongoDbRule extends MongoDb, TestRule {
   final class Builder extends MongoDb.Builder<MongoDbRule> {
 
     /** @deprecated use {@link MongoDbRule#getUsername()} of the actual rule instance */
-    @Deprecated public static final String DEFAULT_USER = "dbuser";
+    @Deprecated public static final String DEFAULT_USER = MongoDb.Builder.DEFAULT_USER;
 
     /** @deprecated use {@link MongoDbRule#getPassword()} ()} of the actual rule instance */
-    @Deprecated public static final String DEFAULT_PASSWORD = "sda123"; // NOSONAR
+    @Deprecated
+    public static final String DEFAULT_PASSWORD = MongoDb.Builder.DEFAULT_PASSWORD; // NOSONAR
 
     /** @deprecated use {@link MongoDbRule#getDatabase()} of the actual rule instance */
-    @Deprecated public static final String DEFAULT_DATABASE = "default_db";
+    @Deprecated public static final String DEFAULT_DATABASE = MongoDb.Builder.DEFAULT_DATABASE;
 
     private Builder() {
       // prevent instantiation
       username = DEFAULT_USER;
-      password = DEFAULT_PASSWORD; // NOSONAR
+      password = DEFAULT_PASSWORD; // NOSONAR Sonar's security hotspot
       database = DEFAULT_DATABASE;
     }
 

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtensionBuilderTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtensionBuilderTest.java
@@ -1,0 +1,21 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class MongoDbClassExtensionBuilderTest {
+
+  @Test
+  void shouldUseDefaultValues() {
+    assertThatCode(
+            () -> {
+              final MongoDbClassExtension extension = MongoDbClassExtension.builder().build();
+              assertThat(extension.getUsername()).isNotNull();
+              assertThat(extension.getPassword()).isNotNull();
+              assertThat(extension.getDatabase()).isNotNull();
+            })
+        .doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
…for username, password and database

Now it behaves like the MongoDbRule again