### PR TITLE
fix: provide fixed path and name to mongod executable

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
@@ -23,12 +23,16 @@ import de.flapdoodle.embed.mongo.config.ImmutableMongodConfig;
 import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.io.directories.*;
 import de.flapdoodle.embed.process.runtime.Network;
 import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import de.flapdoodle.embed.process.store.IArtifactStore;
 import de.flapdoodle.embed.process.store.ImmutableExtractedArtifactStore;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
+import org.apache.commons.lang3.SystemUtils;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 
@@ -195,19 +199,35 @@ public class StartLocalMongoDb {
   }
 
   // Initialization-on-demand holder idiom
-  private static class LazyHolder {
+  static class LazyHolder {
     static final MongodStarter INSTANCE = getMongoStarter();
 
+    private LazyHolder() {}
+
     private static MongodStarter getMongoStarter() {
+      IArtifactStore artifactStore = createArtifactStore(SystemUtils.IS_OS_MAC_OSX);
+      return MongodStarter.getInstance(
+          Defaults.runtimeConfigFor(Command.MongoD).artifactStore(artifactStore).build());
+    }
+
+    static IArtifactStore createArtifactStore(boolean forMacOs) {
       ImmutableExtractedArtifactStore.Builder artifactStoreBuilder =
           ExtractedArtifactStore.builder()
               .from(Defaults.extractedArtifactStoreFor(Command.MongoD))
               .downloadConfig(createDownloadConfig());
 
-      return MongodStarter.getInstance(
-          Defaults.runtimeConfigFor(Command.MongoD)
-              .artifactStore(artifactStoreBuilder.build())
-              .build());
+      // avoid recurring firewall requests on mac,
+      if (forMacOs) {
+        artifactStoreBuilder
+            .extraction(
+                DirectoryAndExecutableNaming.of(
+                    new PlatformTempDir(), (prefix, postfix) -> "mongod"))
+            .temp(
+                DirectoryAndExecutableNaming.of(
+                    new PlatformTempDir(), (prefix, postfix) -> "mongod"));
+      }
+
+      return artifactStoreBuilder.build();
     }
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbVersionTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbVersionTest.java
@@ -1,0 +1,63 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class MongoDbVersionTest {
+
+  @Test
+  public void shouldTakeSpecificMongoDbVersion() {
+    IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
+    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
+    assertThat(mongoDbRule).extracting("version").isEqualTo(specificMongoDbVersion);
+  }
+
+  @Test
+  public void shouldStartSpecificMongoDbVersion() throws Throwable {
+    AtomicReference<String> actualVersion = new AtomicReference<>();
+    final IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
+    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
+    mongoDbRule
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                actualVersion.set(mongoDbRule.getServerVersion());
+              }
+            },
+            Description.EMPTY)
+        .evaluate();
+    assertThat(actualVersion.get()).isEqualTo("3.2.20");
+  }
+
+  @Test
+  public void shouldDetermineMongoDbVersionIfVersionIsNull() {
+    final MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(null).build();
+    assertThat(mongoDbRule)
+        .extracting("version")
+        .isIn(MongoDbRule.Builder.DEFAULT_VERSION, MongoDbRule.Builder.WINDOWS_VERSION);
+  }
+
+  @Test
+  public void shouldUseOsSpecificMongoDbVersion() {
+    MongoDbRule mongoDbRule = MongoDbRule.builder().build();
+    if (SystemUtils.IS_OS_WINDOWS) {
+      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
+      assertThat(mongoDbRule)
+          .extracting("version")
+          .isNotEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
+    } else {
+      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
+      assertThat(mongoDbRule)
+          .extracting("version")
+          .isNotEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
+    }
+  }
+}

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbLazyHolderTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbLazyHolderTest.java
@@ -1,0 +1,57 @@
+package org.sdase.commons.server.mongo.testing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.store.IArtifactStore;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
+
+class StartLocalMongoDbLazyHolderTest {
+
+  @Test
+  void shouldNotUsePrefixAndSuffixInMacOs()
+      throws InvocationTargetException, IllegalAccessException {
+    IArtifactStore artifactStore = StartLocalMongoDb.LazyHolder.createArtifactStore(true);
+
+    DirectoryAndExecutableNaming extractionNaming = getExtractionNaming(artifactStore);
+    DirectoryAndExecutableNaming tempNaming = getTempNaming(artifactStore);
+
+    String executable = extractionNaming.getExecutableNaming().nameFor("prefix", "suffix");
+    String temp = tempNaming.getExecutableNaming().nameFor("prefix", "suffix");
+
+    assertThat(executable).doesNotContain("prefix").doesNotContain("suffix");
+    assertThat(temp).doesNotContain("prefix").doesNotContain("suffix");
+  }
+
+  @Test
+  void shouldUsePrefixAndSuffixForNonOsx()
+      throws InvocationTargetException, IllegalAccessException {
+    IArtifactStore artifactStore = StartLocalMongoDb.LazyHolder.createArtifactStore(false);
+
+    DirectoryAndExecutableNaming extractionNaming = getExtractionNaming(artifactStore);
+    DirectoryAndExecutableNaming tempNaming = getTempNaming(artifactStore);
+
+    String executable = extractionNaming.getExecutableNaming().nameFor("prefix", "suffix");
+    String temp = tempNaming.getExecutableNaming().nameFor("prefix", "suffix");
+
+    assertThat(executable).contains("prefix").contains("suffix");
+    assertThat(temp).contains("prefix").contains("suffix");
+  }
+
+  private DirectoryAndExecutableNaming getTempNaming(IArtifactStore artifactStore)
+      throws IllegalAccessException, InvocationTargetException {
+    Method temp = ReflectionUtils.getRequiredMethod(artifactStore.getClass(), "temp");
+    temp.setAccessible(true);
+    return (DirectoryAndExecutableNaming) temp.invoke(artifactStore);
+  }
+
+  private DirectoryAndExecutableNaming getExtractionNaming(IArtifactStore artifactStore)
+      throws IllegalAccessException, InvocationTargetException {
+    Method extraction = ReflectionUtils.getRequiredMethod(artifactStore.getClass(), "extraction");
+    extraction.setAccessible(true);
+    return (DirectoryAndExecutableNaming) extraction.invoke(artifactStore);
+  }
+}

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
@@ -13,18 +13,12 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Indexes;
 import com.mongodb.internal.connection.ServerAddressHelper;
-import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
-import de.flapdoodle.embed.mongo.distribution.Version;
 import java.util.ArrayList;
-import java.util.concurrent.atomic.AtomicReference;
-import org.apache.commons.lang3.SystemUtils;
 import org.bson.Document;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 import org.sdase.commons.server.testing.EnvironmentRule;
 
 public class StartLocalMongoDbRuleTest {
@@ -153,55 +147,6 @@ public class StartLocalMongoDbRuleTest {
       RULE.clearDatabase();
 
       assertThat(db.listCollectionNames()).doesNotContain("clearDatabaseTest");
-    }
-  }
-
-  @Test
-  public void shouldTakeSpecificMongoDbVersion() {
-    IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
-    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
-    assertThat(mongoDbRule).extracting("version").isEqualTo(specificMongoDbVersion);
-  }
-
-  @Test
-  public void shouldStartSpecificMongoDbVersion() throws Throwable {
-    AtomicReference<String> actualVersion = new AtomicReference<>();
-    final IFeatureAwareVersion specificMongoDbVersion = Version.V3_2_20;
-    MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(specificMongoDbVersion).build();
-    mongoDbRule
-        .apply(
-            new Statement() {
-              @Override
-              public void evaluate() {
-                actualVersion.set(mongoDbRule.getServerVersion());
-              }
-            },
-            Description.EMPTY)
-        .evaluate();
-    assertThat(actualVersion.get()).isEqualTo("3.2.20");
-  }
-
-  @Test
-  public void shouldDetermineMongoDbVersionIfVersionIsNull() {
-    final MongoDbRule mongoDbRule = MongoDbRule.builder().withVersion(null).build();
-    assertThat(mongoDbRule)
-        .extracting("version")
-        .isIn(MongoDbRule.Builder.DEFAULT_VERSION, MongoDbRule.Builder.WINDOWS_VERSION);
-  }
-
-  @Test
-  public void shouldUseOsSpecificMongoDbVersion() {
-    MongoDbRule mongoDbRule = MongoDbRule.builder().build();
-    if (SystemUtils.IS_OS_WINDOWS) {
-      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
-    } else {
-      assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
     }
   }
 }


### PR DESCRIPTION
- extract mongodb executable to fixed path and filename to avoid recurring firewall requests on mac
- move some tests to separate class to avoid clashes with conflicting mongodb executables

Since its not a change to the behaviour of the code, only runs on MacOS and can not be really covered by tests, can we accept the low code coverage here?