### PR TITLE
fix(server-mongo-testing): Improve concurrent builds with Flapdoodle

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
@@ -24,6 +24,7 @@ import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.distribution.IFeatureAwareVersion;
 import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.UUIDTempNaming;
 import de.flapdoodle.embed.process.io.directories.*;
 import de.flapdoodle.embed.process.runtime.Network;
 import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
@@ -225,8 +226,13 @@ public class StartLocalMongoDb {
             .temp(
                 DirectoryAndExecutableNaming.of(
                     new PlatformTempDir(), (prefix, postfix) -> "mongod"));
+      } else {
+        artifactStoreBuilder.extraction(
+            DirectoryAndExecutableNaming.builder()
+                .directory(new PropertyOrPlatformTempDir())
+                .executableNaming(new UUIDTempNaming())
+                .build());
       }
-
       return artifactStoreBuilder.build();
     }
   }


### PR DESCRIPTION
Downloaded files will be extracted to the temp directory; executable gets unique name

Fixes https://github.com/SDA-SE/sda-dropwizard-commons/issues/838