### PR TITLE
fix(server-jackson): fix link creation of HalLinkProvider

### DIFF
--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
@@ -95,7 +95,7 @@ public class HalLinkProvider implements Feature {
     try {
       if (invocation != null || !methodInvocationState.isProcessed()) {
         // Deprecated type needed for backward compatibility until deprecated package is removed
-        // afterwards the the class from this package can be used
+        // afterwards the class from this package can be used
         throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
             "No proxied method invocation processed.");
       }

--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/hal/HalLinkProvider.java
@@ -92,23 +92,28 @@ public class HalLinkProvider implements Feature {
   private LinkResult linkToInvocation(Object invocation) {
     final HalLinkInvocationStateUtility.MethodInvocationState methodInvocationState =
         HalLinkInvocationStateUtility.loadMethodInvocationState();
-    if (invocation != null || !methodInvocationState.isProcessed()) {
-      // Deprecated type needed for backward compatibility until deprecated package is removed
-      // afterwards the the class from this package can be used
+    try {
+      if (invocation != null || !methodInvocationState.isProcessed()) {
+        // Deprecated type needed for backward compatibility until deprecated package is removed
+        // afterwards the the class from this package can be used
+        throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
+            "No proxied method invocation processed.");
+      }
+      final UriBuilder uriBuilder =
+          baseUriBuilder()
+              .path(methodInvocationState.getType())
+              .path(methodInvocationState.getType(), methodInvocationState.getInvokedMethod())
+              // Add Path Params from invocation state
+              .resolveTemplates(methodInvocationState.getPathParams());
+      // Add Query Params from invocation state
+      methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
+      LinkResult linkResult = new LinkResult(uriBuilder.build());
+      HalLinkInvocationStateUtility.unloadMethodInvocationState();
+      return linkResult;
+    } catch (IllegalArgumentException e) {
       throw new org.sda.commons.server.jackson.hal.HalLinkMethodInvocationException(
-          "No proxied method invocation processed.");
+          "Could not build URI.", e);
     }
-    final UriBuilder uriBuilder =
-        baseUriBuilder()
-            .path(methodInvocationState.getType())
-            .path(methodInvocationState.getType(), methodInvocationState.getInvokedMethod())
-            // Add Path Params from invocation state
-            .resolveTemplates(methodInvocationState.getPathParams());
-    // Add Query Params from invocation state
-    methodInvocationState.getQueryParams().forEach(uriBuilder::queryParam);
-    LinkResult linkResult = new LinkResult(uriBuilder.build());
-    HalLinkInvocationStateUtility.unloadMethodInvocationState();
-    return linkResult;
   }
 
   /**

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/hal/HalLinkProviderTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/hal/HalLinkProviderTest.java
@@ -7,6 +7,7 @@ import static org.sda.commons.server.jackson.hal.HalLinkProvider.methodOn;
 
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import java.net.URI;
+import javax.ws.rs.CookieParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -35,6 +36,13 @@ public class HalLinkProviderTest {
     final org.sda.commons.server.jackson.hal.LinkResult linkResult =
         linkTo(methodOn(TestApi.class).testMethodQueryParam("TEST"));
     assertLinkResult(linkResult, "/testPath?testRequestParam=TEST");
+  }
+
+  @Test
+  public void shouldProvideHalLinkIgnoringCookieParam() {
+    final org.sda.commons.server.jackson.hal.LinkResult linkResult =
+        linkTo(methodOn(TestApi.class).testMethodCookieParam("TEST"));
+    assertLinkResult(linkResult, "/testPath");
   }
 
   @Test
@@ -98,6 +106,10 @@ interface TestApi {
       @PathParam("testArg") String testArg,
       @QueryParam("query") Integer testArgTwo,
       @PathParam("testArg2") String query);
+
+  @Path("/testPath")
+  @GET
+  String testMethodCookieParam(@CookieParam("testCookie") String testCookie);
 
   @Path("/testPath")
   @GET


### PR DESCRIPTION
HalLinkProvider can create URIs for methods with params that are not annotated as `@QueryParam` or `@PathParam` now. These method parameters are ignored when building the URI.