### PR TITLE
fix(deps): Update to Gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ subprojects {
  * Problem is: You can't apply plugins 'java' and 'java-platform' at the same time.
  */
 configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
-  apply plugin: 'java'
+  apply plugin: 'java-library'
   apply plugin: 'jacoco'
 
   sourceCompatibility = JavaVersion.VERSION_1_8
@@ -192,7 +192,7 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
   }
 
   dependencies {
-    compile enforcedPlatform(project(':sda-commons-dependencies'))
+    api enforcedPlatform(project(':sda-commons-dependencies'))
   }
 
   sourceSets {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sda-commons-client-jersey-example/build.gradle
+++ b/sda-commons-client-jersey-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-client-jersey')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-client-jersey')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey-wiremock-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey-wiremock-testing')
 }

--- a/sda-commons-client-jersey-wiremock-testing/build.gradle
+++ b/sda-commons-client-jersey-wiremock-testing/build.gradle
@@ -1,13 +1,13 @@
 dependencies {
 
-  compile "com.github.tomakehurst:wiremock-jre8"
+  api "com.github.tomakehurst:wiremock-jre8"
 
-  compile 'org.glassfish.jersey.core:jersey-client'
-  compile 'org.glassfish.jersey.ext:jersey-proxy-client'
-  compile 'jakarta.servlet:jakarta.servlet-api'
-  compile 'org.junit.jupiter:junit-jupiter-api'
+  api 'org.glassfish.jersey.core:jersey-client'
+  api 'org.glassfish.jersey.ext:jersey-proxy-client'
+  api 'jakarta.servlet:jakarta.servlet-api'
+  api 'org.junit.jupiter:junit-jupiter-api'
 
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'org.slf4j:jcl-over-slf4j'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.slf4j:jcl-over-slf4j'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/sda-commons-client-jersey/build.gradle
+++ b/sda-commons-client-jersey/build.gradle
@@ -1,22 +1,22 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-opentracing')
-  compile project(':sda-commons-shared-tracing')
-  compile project(':sda-commons-shared-error')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-opentracing')
+  api project(':sda-commons-shared-tracing')
+  api project(':sda-commons-shared-error')
 
-  compile 'io.dropwizard:dropwizard-client'
-  compile 'jakarta.servlet:jakarta.servlet-api'
-  compile 'org.glassfish.jersey.core:jersey-client'
-  compile 'org.glassfish.jersey.ext:jersey-proxy-client'
-  compile 'org.codefetti.proxy:proxy-handler:1.0.0'
-  compile 'io.opentracing.contrib:opentracing-concurrent'
+  api 'io.dropwizard:dropwizard-client'
+  api 'jakarta.servlet:jakarta.servlet-api'
+  api 'org.glassfish.jersey.core:jersey-client'
+  api 'org.glassfish.jersey.ext:jersey-proxy-client'
+  api 'org.codefetti.proxy:proxy-handler:1.0.0'
+  api 'io.opentracing.contrib:opentracing-concurrent'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey-wiremock-testing')
-  testCompile project(':sda-commons-server-trace')
-  testCompile project(':sda-commons-shared-forms')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey-wiremock-testing')
+  testImplementation project(':sda-commons-server-trace')
+  testImplementation project(':sda-commons-shared-forms')
 
-  testCompile 'org.awaitility:awaitility'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'io.opentracing:opentracing-mock'
+  testImplementation 'org.awaitility:awaitility'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'io.opentracing:opentracing-mock'
 }

--- a/sda-commons-dependency-check/build.gradle
+++ b/sda-commons-dependency-check/build.gradle
@@ -4,52 +4,52 @@ dependencies {
   components.all(BouncycastleAlignmentRule)
 
   // Add all new modules here to verify that there are no dependency clashes.
-  compile project(':sda-commons-client-jersey')
-  compile project(':sda-commons-client-jersey-wiremock-testing')
-  compile project(':sda-commons-server-auth')
-  compile project(':sda-commons-server-auth-testing')
-  compile project(':sda-commons-server-circuitbreaker')
-  compile project(':sda-commons-server-consumer')
-  compile project(':sda-commons-server-cors')
-  compile project(':sda-commons-server-key-mgmt')
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-healthcheck')
-  compile project(':sda-commons-server-hibernate')
-  compile project(':sda-commons-server-hibernate-testing')
-  compile project(':sda-commons-server-jackson')
-  compile project(':sda-commons-server-jaeger')
-  compile project(':sda-commons-server-kafka')
-  compile project(':sda-commons-server-kafka-testing')
-  compile project(':sda-commons-server-mongo-testing')
-  compile project(':sda-commons-server-morphia')
-  compile project(':sda-commons-server-openapi')
-  compile project(':sda-commons-server-opentracing')
-  compile project(':sda-commons-server-prometheus')
-  compile project(':sda-commons-server-s3')
-  compile project(':sda-commons-server-s3-testing')
-  compile project(':sda-commons-server-security')
-  compile project(':sda-commons-server-starter'), {
+  api project(':sda-commons-client-jersey')
+  api project(':sda-commons-client-jersey-wiremock-testing')
+  api project(':sda-commons-server-auth')
+  api project(':sda-commons-server-auth-testing')
+  api project(':sda-commons-server-circuitbreaker')
+  api project(':sda-commons-server-consumer')
+  api project(':sda-commons-server-cors')
+  api project(':sda-commons-server-key-mgmt')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-healthcheck')
+  api project(':sda-commons-server-hibernate')
+  api project(':sda-commons-server-hibernate-testing')
+  api project(':sda-commons-server-jackson')
+  api project(':sda-commons-server-jaeger')
+  api project(':sda-commons-server-kafka')
+  api project(':sda-commons-server-kafka-testing')
+  api project(':sda-commons-server-mongo-testing')
+  api project(':sda-commons-server-morphia')
+  api project(':sda-commons-server-openapi')
+  api project(':sda-commons-server-opentracing')
+  api project(':sda-commons-server-prometheus')
+  api project(':sda-commons-server-s3')
+  api project(':sda-commons-server-s3-testing')
+  api project(':sda-commons-server-security')
+  api project(':sda-commons-server-starter'), {
     // we intentionally allow this conflict. the swagger and openapi module can't be used in one project.
     // since the sda-commons-server-starter will be replaced by sda-commons-starter in the future, we
     // don't check the swagger-related dependencies anymore.
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
-  compile project(':sda-commons-server-swagger'), {
+  api project(':sda-commons-server-swagger'), {
     // we intentionally allow this conflict. the swagger and openapi module can't be used in one project.
     // since the sda-commons-server-swagger will be replaced by sda-commons-server-openapi in the
     // future, we don't check the swagger-related dependencies anymore.
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
-  compile project(':sda-commons-server-testing')
-  compile project(':sda-commons-server-trace')
-  compile project(':sda-commons-server-weld')
-  compile project(':sda-commons-server-weld-testing')
-  compile project(':sda-commons-shared-asyncapi')
-  compile project(':sda-commons-shared-error')
-  compile project(':sda-commons-shared-forms')
-  compile project(':sda-commons-shared-tracing')
-  compile project(':sda-commons-shared-yaml')
-  compile project(':sda-commons-starter')
+  api project(':sda-commons-server-testing')
+  api project(':sda-commons-server-trace')
+  api project(':sda-commons-server-weld')
+  api project(':sda-commons-server-weld-testing')
+  api project(':sda-commons-shared-asyncapi')
+  api project(':sda-commons-shared-error')
+  api project(':sda-commons-shared-forms')
+  api project(':sda-commons-shared-tracing')
+  api project(':sda-commons-shared-yaml')
+  api project(':sda-commons-starter')
 }
 
 /**

--- a/sda-commons-server-auth-testing/build.gradle
+++ b/sda-commons-server-auth-testing/build.gradle
@@ -1,16 +1,16 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-testing')
-  compile project(':sda-commons-server-auth')
-  compile 'com.auth0:java-jwt'
-  compile project(':sda-commons-client-jersey-wiremock-testing')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-testing')
+  api project(':sda-commons-server-auth')
+  api 'com.auth0:java-jwt'
+  api project(':sda-commons-client-jersey-wiremock-testing')
 
   // the following modules ship with different versions of the swagger-hal library.
   // since swagger-hal is not needed in these tests, they are excluded from both.
-  testCompile project(':sda-commons-server-openapi'), {
+  testImplementation project(':sda-commons-server-openapi'), {
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
-  testCompile project(':sda-commons-server-swagger'), {
+  testImplementation project(':sda-commons-server-swagger'), {
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
 

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -1,15 +1,15 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-error')
-  compile project(':sda-commons-server-opentracing')
-  compile project(':sda-commons-shared-tracing')
-  compile 'io.dropwizard:dropwizard-auth'
-  compile 'io.dropwizard:dropwizard-client'
-  compile 'jakarta.servlet:jakarta.servlet-api'
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-error')
+  api project(':sda-commons-server-opentracing')
+  api project(':sda-commons-shared-tracing')
+  api 'io.dropwizard:dropwizard-auth'
+  api 'io.dropwizard:dropwizard-client'
+  api 'jakarta.servlet:jakarta.servlet-api'
 
-  compile 'com.auth0:java-jwt'
+  api 'com.auth0:java-jwt'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey-wiremock-testing')
-  testCompile 'org.awaitility:awaitility'
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey-wiremock-testing')
+  testImplementation 'org.awaitility:awaitility'
 }

--- a/sda-commons-server-circuitbreaker/build.gradle
+++ b/sda-commons-server-circuitbreaker/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'org.javassist:javassist'
-  compile 'io.github.resilience4j:resilience4j-circuitbreaker'
-  compile 'io.github.resilience4j:resilience4j-prometheus'
-  compile 'org.objenesis:objenesis'
+  api 'org.javassist:javassist'
+  api 'io.github.resilience4j:resilience4j-circuitbreaker'
+  api 'io.github.resilience4j:resilience4j-prometheus'
+  api 'org.objenesis:objenesis'
 
-  testCompile project(':sda-commons-server-prometheus')
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey-wiremock-testing')
+  testImplementation project(':sda-commons-server-prometheus')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey-wiremock-testing')
 }

--- a/sda-commons-server-consumer/build.gradle
+++ b/sda-commons-server-consumer/build.gradle
@@ -1,17 +1,17 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-tracing')
-  compile project(':sda-commons-shared-error')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-tracing')
+  api project(':sda-commons-shared-error')
 
-  testCompile project(':sda-commons-server-jackson')
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-jackson')
+  testImplementation project(':sda-commons-server-testing')
 
   // the following modules ship with different versions of the swagger-hal library.
   // since swagger-hal is not needed in these tests, they are excluded from both.
-  testCompile project(':sda-commons-server-openapi'), {
+  testImplementation project(':sda-commons-server-openapi'), {
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
-  testCompile project(':sda-commons-server-swagger'), {
+  testImplementation project(':sda-commons-server-swagger'), {
     exclude group: 'io.openapitools.hal', module: 'swagger-hal'
   }
 }

--- a/sda-commons-server-cors/build.gradle
+++ b/sda-commons-server-cors/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-tracing')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-tracing')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }
 
 test {

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile 'io.dropwizard:dropwizard-core'
-  compile 'jakarta.servlet:jakarta.servlet-api'
-  compile 'io.dropwizard:dropwizard-json-logging'
+  api 'io.dropwizard:dropwizard-core'
+  api 'jakarta.servlet:jakarta.servlet-api'
+  api 'io.dropwizard:dropwizard-json-logging'
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-errorhandling-example/build.gradle
+++ b/sda-commons-server-errorhandling-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
 
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-jackson')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-jackson')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-healthcheck-example/build.gradle
+++ b/sda-commons-server-healthcheck-example/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':sda-commons-server-healthcheck')
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey-wiremock-testing')
+  api project(':sda-commons-server-healthcheck')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey-wiremock-testing')
 }

--- a/sda-commons-server-healthcheck/build.gradle
+++ b/sda-commons-server-healthcheck/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-hibernate-example/build.gradle
+++ b/sda-commons-server-hibernate-example/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compile project(':sda-commons-server-hibernate')
+  api project(':sda-commons-server-hibernate')
 
-  testCompile project(':sda-commons-server-hibernate-testing')
-  testCompile 'org.assertj:assertj-core'
+  testImplementation project(':sda-commons-server-hibernate-testing')
+  testImplementation 'org.assertj:assertj-core'
 }

--- a/sda-commons-server-hibernate-testing/build.gradle
+++ b/sda-commons-server-hibernate-testing/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-  compile project(':sda-commons-server-testing')
-  compile 'com.h2database:h2'
-  compile 'com.github.database-rider:rider-core', {
+  api project(':sda-commons-server-testing')
+  api 'com.h2database:h2'
+  api 'com.github.database-rider:rider-core', {
     // excluded due to licensing issues
     exclude group: 'mysql', module: 'mysql-connector-java'
   }
-  compile 'com.github.database-rider:rider-junit5', {
+  api 'com.github.database-rider:rider-junit5', {
     // excluded due to licensing issues
     exclude group: 'mysql', module: 'mysql-connector-java'
   }

--- a/sda-commons-server-hibernate/build.gradle
+++ b/sda-commons-server-hibernate/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile 'io.dropwizard:dropwizard-hibernate', {
+  api project(':sda-commons-server-dropwizard')
+  api 'io.dropwizard:dropwizard-hibernate', {
     /**
      * dropwizard-hibernate provides javax.transaction:javax.transaction-api through
      * jackson-datatype-hibernate5 and
@@ -10,10 +10,10 @@ dependencies {
      */
     exclude group: 'org.jboss.spec.javax.transaction', module: 'jboss-transaction-api_1.2_spec'
   }
-  compile 'jakarta.servlet:jakarta.servlet-api'
-  compile 'org.postgresql:postgresql'
-  compile 'org.flywaydb:flyway-core'
+  api 'jakarta.servlet:jakarta.servlet-api'
+  api 'org.postgresql:postgresql'
+  api 'org.flywaydb:flyway-core'
 
-  testCompile project(':sda-commons-server-hibernate-testing')
-  testCompile 'org.assertj:assertj-core'
+  testImplementation project(':sda-commons-server-hibernate-testing')
+  testImplementation 'org.assertj:assertj-core'
 }

--- a/sda-commons-server-jackson/build.gradle
+++ b/sda-commons-server-jackson/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
 
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-error')
-  compile 'io.openapitools.jackson.dataformat:jackson-dataformat-hal'
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-error')
+  api 'io.openapitools.jackson.dataformat:jackson-dataformat-hal'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'com.kjetland:mbknor-jackson-jsonschema_2.12', {
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'com.kjetland:mbknor-jackson-jsonschema_2.12', {
     exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     exclude group: 'javax.validation', module: 'validation-api'
     exclude group: 'org.slf4j', module: 'slf4j-api'

--- a/sda-commons-server-jaeger/build.gradle
+++ b/sda-commons-server-jaeger/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'io.jaegertracing:jaeger-client', {
+  api 'io.jaegertracing:jaeger-client', {
     /**
      * Dropwizard comes with jakarta.annotation-api instead of javax.annotation-api.
      * Both contain the same classes.
@@ -13,14 +13,14 @@ dependencies {
      */
     exclude group: "org.apache.tomcat.embed", module: "tomcat-embed-core"
   }
-  compile 'jakarta.annotation:jakarta.annotation-api'
+  api 'jakarta.annotation:jakarta.annotation-api'
 
 
   // Sadly the required code is in a test dependency, but as an alternative we could also copy the class here.
-  compile group: 'io.opentracing', name: 'opentracing-util', classifier: 'tests'
-  compile 'io.prometheus:simpleclient'
+  api group: 'io.opentracing', name: 'opentracing-util', classifier: 'tests'
+  api 'io.prometheus:simpleclient'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-opentracing')
-  testCompile project(':sda-commons-server-prometheus')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-opentracing')
+  testImplementation project(':sda-commons-server-prometheus')
 }

--- a/sda-commons-server-kafka-example/build.gradle
+++ b/sda-commons-server-kafka-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-kafka')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-kafka')
 
-  testCompile project(':sda-commons-server-kafka-testing')
+  testImplementation project(':sda-commons-server-kafka-testing')
 }
 

--- a/sda-commons-server-kafka-testing/build.gradle
+++ b/sda-commons-server-kafka-testing/build.gradle
@@ -5,23 +5,23 @@ configurations.all {
 
 dependencies {
 
-  compile project(':sda-commons-server-testing')
+  api project(':sda-commons-server-testing')
 
-  compile 'com.salesforce.kafka.test:kafka-junit4', {
+  api 'com.salesforce.kafka.test:kafka-junit4', {
     exclude group: 'org.apache.curator', module: 'curator-test'
   }
-  compile 'com.salesforce.kafka.test:kafka-junit5', {
+  api 'com.salesforce.kafka.test:kafka-junit5', {
     exclude group: 'org.apache.curator', module: 'curator-test'
   }
-  compile 'org.apache.curator:curator-test', {
+  api 'org.apache.curator:curator-test', {
     exclude group: 'org.xerial.snappy', module: 'snappy-java'
   }
-  compile 'org.xerial.snappy:snappy-java'
+  api 'org.xerial.snappy:snappy-java'
 
-  compile 'org.apache.kafka:kafka_2.12'
+  api 'org.apache.kafka:kafka_2.12'
 
-  compile 'org.awaitility:awaitility'
+  api 'org.awaitility:awaitility'
 
   // just to check transitive dependency versions
-  testCompile project(':sda-commons-server-dropwizard')
+  testImplementation project(':sda-commons-server-dropwizard')
 }

--- a/sda-commons-server-kafka/build.gradle
+++ b/sda-commons-server-kafka/build.gradle
@@ -1,16 +1,16 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile project(':sda-commons-server-healthcheck')
+  api project(':sda-commons-server-healthcheck')
 
-  compile "org.apache.kafka:kafka-clients"
+  api "org.apache.kafka:kafka-clients"
 
-  compile 'io.prometheus:simpleclient'
+  api 'io.prometheus:simpleclient'
 
-  testCompile 'org.mockito:mockito-core'
+  testImplementation 'org.mockito:mockito-core'
 
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-core'
 
-  testCompile project(':sda-commons-server-kafka-testing')
+  testImplementation project(':sda-commons-server-kafka-testing')
 }
 

--- a/sda-commons-server-key-mgmt/build.gradle
+++ b/sda-commons-server-key-mgmt/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-yaml')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-yaml')
 
-  testCompile project(':sda-commons-starter')
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-shared-error')
+  testImplementation project(':sda-commons-starter')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-shared-error')
 }

--- a/sda-commons-server-mongo-testing/build.gradle
+++ b/sda-commons-server-mongo-testing/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-  compile project(':sda-commons-server-testing')
+  api project(':sda-commons-server-testing')
 
   // This dependency and version is used by Morphia in sda-commons-server-morphia.
   // Only upgrade here when there is a version or GAV conflict with the artifact provided by
   // Morphia.
-  compile 'org.mongodb:mongodb-driver-legacy:4.1.1'
-  compile 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
+  api 'org.mongodb:mongodb-driver-legacy:4.1.1'
+  api 'de.flapdoodle.embed:de.flapdoodle.embed.mongo'
 }

--- a/sda-commons-server-morphia-example/build.gradle
+++ b/sda-commons-server-morphia-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-morphia')
-  compile project(':sda-commons-server-weld')
+  api project(':sda-commons-server-morphia')
+  api project(':sda-commons-server-weld')
 
-  testCompile project(':sda-commons-server-mongo-testing')
-  testCompile project(':sda-commons-server-weld-testing')
+  testImplementation project(':sda-commons-server-mongo-testing')
+  testImplementation project(':sda-commons-server-weld-testing')
 }

--- a/sda-commons-server-morphia/build.gradle
+++ b/sda-commons-server-morphia/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'dev.morphia.morphia:core'
-  compile 'dev.morphia.morphia:validation', {
+  api 'dev.morphia.morphia:core'
+  api 'dev.morphia.morphia:validation', {
     /**
      * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
      * javax.inject.
@@ -21,15 +21,15 @@ dependencies {
      */
     exclude group: 'aopalliance', module: 'aopalliance'
   }
-  compile 'org.glassfish.hk2.external:jakarta.inject'
-  compile 'jakarta.validation:jakarta.validation-api'
-  compile 'org.glassfish.hk2.external:aopalliance-repackaged'
+  api 'org.glassfish.hk2.external:jakarta.inject'
+  api 'jakarta.validation:jakarta.validation-api'
+  api 'org.glassfish.hk2.external:aopalliance-repackaged'
 
-  compile 'org.bouncycastle:bcpkix-jdk15on'
-  compile 'io.opentracing.contrib:opentracing-mongo-driver'
+  api 'org.bouncycastle:bcpkix-jdk15on'
+  api 'io.opentracing.contrib:opentracing-mongo-driver'
 
-  testCompile project(':sda-commons-server-mongo-testing')
-  testCompile 'commons-io:commons-io'
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'io.opentracing:opentracing-mock'
+  testImplementation project(':sda-commons-server-mongo-testing')
+  testImplementation 'commons-io:commons-io'
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'io.opentracing:opentracing-mock'
 }

--- a/sda-commons-server-openapi-example/build.gradle
+++ b/sda-commons-server-openapi-example/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compile project(':sda-commons-starter')
+  api project(':sda-commons-starter')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-auth-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-auth-testing')
 }

--- a/sda-commons-server-openapi/build.gradle
+++ b/sda-commons-server-openapi/build.gradle
@@ -1,28 +1,28 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-yaml')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-yaml')
 
-  compile 'io.swagger.core.v3:swagger-jaxrs2'
-  compile 'io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-v2'
-  compile 'io.swagger.parser.v3:swagger-parser-v3', {
+  api 'io.swagger.core.v3:swagger-jaxrs2'
+  api 'io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-v2'
+  api 'io.swagger.parser.v3:swagger-parser-v3', {
     exclude group: 'io.swagger.core.v3', module: 'swagger-core'
   }
 
   // swagger-hal >= 2.0.0 supports io.swagger.core.v3
-  compile 'io.openapitools.hal:swagger-hal:2.0.0', {
+  api 'io.openapitools.hal:swagger-hal:2.0.0', {
     exclude group: 'io.swagger.core.v3', module: 'swagger-models'
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
-  compile 'io.swagger.core.v3:swagger-core'
-  compile 'io.swagger.core.v3:swagger-models'
+  api 'io.swagger.core.v3:swagger-core'
+  api 'io.swagger.core.v3:swagger-models'
 
-  compile 'io.openapitools.jackson.dataformat:jackson-dataformat-hal', {
+  api 'io.openapitools.jackson.dataformat:jackson-dataformat-hal', {
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
-  compile 'org.slf4j:slf4j-api'
+  api 'org.slf4j:slf4j-api'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'net.javacrumbs.json-unit:json-unit-assertj'
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'net.javacrumbs.json-unit:json-unit-assertj'
 }
 
 test {

--- a/sda-commons-server-opentracing-example/build.gradle
+++ b/sda-commons-server-opentracing-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-opentracing')
-  compile project(':sda-commons-server-jaeger')
-  compile project(':sda-commons-client-jersey')
+  api project(':sda-commons-server-opentracing')
+  api project(':sda-commons-server-jaeger')
+  api project(':sda-commons-client-jersey')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-opentracing/build.gradle
+++ b/sda-commons-server-opentracing/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'io.opentracing.contrib:opentracing-jaxrs2'
-  compile 'io.opentracing.contrib:opentracing-web-servlet-filter'
+  api 'io.opentracing.contrib:opentracing-jaxrs2'
+  api 'io.opentracing.contrib:opentracing-web-servlet-filter'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'io.opentracing:opentracing-mock'
-  testCompile 'org.awaitility:awaitility'
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'io.opentracing:opentracing-mock'
+  testImplementation 'org.awaitility:awaitility'
 }

--- a/sda-commons-server-prometheus-example/build.gradle
+++ b/sda-commons-server-prometheus-example/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-  compile project(':sda-commons-starter')
+  api project(':sda-commons-starter')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-prometheus/build.gradle
+++ b/sda-commons-server-prometheus/build.gradle
@@ -1,14 +1,14 @@
 dependencies {
 
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-tracing')
-  compile 'io.dropwizard:dropwizard-client'
-  compile 'jakarta.servlet:jakarta.servlet-api'
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-tracing')
+  api 'io.dropwizard:dropwizard-client'
+  api 'jakarta.servlet:jakarta.servlet-api'
 
-  compile 'io.prometheus:simpleclient'
-  compile 'io.prometheus:simpleclient_dropwizard'
-  compile 'io.prometheus:simpleclient_servlet'
+  api 'io.prometheus:simpleclient'
+  api 'io.prometheus:simpleclient_dropwizard'
+  api 'io.prometheus:simpleclient_servlet'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-client-jersey')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-client-jersey')
 }

--- a/sda-commons-server-s3-testing/build.gradle
+++ b/sda-commons-server-s3-testing/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-testing')
+  api project(':sda-commons-server-testing')
 
-  compile 'io.findify:s3mock_2.12', {
+  api 'io.findify:s3mock_2.12', {
     /**
      * Dropwizard comes with jakarta.activation-api instead of javax.activation-api.
      * Both contain the same classes.
@@ -14,6 +14,6 @@ dependencies {
      */
     exclude group: "javax.xml.bind", module: "jaxb-api"
   }
-  compile 'jakarta.activation:jakarta.activation-api'
-  compile 'jakarta.xml.bind:jakarta.xml.bind-api'
+  api 'jakarta.activation:jakarta.activation-api'
+  api 'jakarta.xml.bind:jakarta.xml.bind-api'
 }

--- a/sda-commons-server-s3/build.gradle
+++ b/sda-commons-server-s3/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile 'com.amazonaws:aws-java-sdk-s3'
-  compile 'org.slf4j:jcl-over-slf4j'
-  compile 'io.opentracing.contrib:opentracing-aws-sdk-1'
-  compile 'io.opentracing:opentracing-util'
+  api project(':sda-commons-server-dropwizard')
+  api 'com.amazonaws:aws-java-sdk-s3'
+  api 'org.slf4j:jcl-over-slf4j'
+  api 'io.opentracing.contrib:opentracing-aws-sdk-1'
+  api 'io.opentracing:opentracing-util'
 
-  testCompile project(':sda-commons-server-s3-testing')
-  testCompile 'org.assertj:assertj-core'
-  testCompile 'io.opentracing:opentracing-mock'
+  testImplementation project(':sda-commons-server-s3-testing')
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'io.opentracing:opentracing-mock'
 }

--- a/sda-commons-server-security/build.gradle
+++ b/sda-commons-server-security/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-error')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-error')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-jackson')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-jackson')
 }
 

--- a/sda-commons-server-starter-example/build.gradle
+++ b/sda-commons-server-starter-example/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-starter')
+  api project(':sda-commons-server-starter')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-auth-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-auth-testing')
 
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-core'
 }

--- a/sda-commons-server-starter/build.gradle
+++ b/sda-commons-server-starter/build.gradle
@@ -1,19 +1,19 @@
 dependencies {
-  compile project(':sda-commons-server-auth')
-  compile project(':sda-commons-server-consumer')
-  compile project(':sda-commons-server-cors')
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-jackson')
-  compile project(':sda-commons-server-prometheus')
-  compile project(':sda-commons-server-security')
-  compile project(':sda-commons-server-swagger')
-  compile project(':sda-commons-server-trace')
-  compile project(':sda-commons-server-healthcheck')
-  compile project(':sda-commons-server-jaeger')
-  compile project(':sda-commons-server-opentracing')
+  api project(':sda-commons-server-auth')
+  api project(':sda-commons-server-consumer')
+  api project(':sda-commons-server-cors')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-jackson')
+  api project(':sda-commons-server-prometheus')
+  api project(':sda-commons-server-security')
+  api project(':sda-commons-server-swagger')
+  api project(':sda-commons-server-trace')
+  api project(':sda-commons-server-healthcheck')
+  api project(':sda-commons-server-jaeger')
+  api project(':sda-commons-server-opentracing')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'org.assertj:assertj-core'
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'org.assertj:assertj-core'
 }
 
 test {

--- a/sda-commons-server-swagger-example/build.gradle
+++ b/sda-commons-server-swagger-example/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compile project(':sda-commons-server-starter')
+  api project(':sda-commons-server-starter')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-auth-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-auth-testing')
 }

--- a/sda-commons-server-swagger/build.gradle
+++ b/sda-commons-server-swagger/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-yaml')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-yaml')
 
-  compile 'io.swagger:swagger-jaxrs', {
+  api 'io.swagger:swagger-jaxrs', {
     /**
      * swagger-jaxrs uses the following dependency:
      *
@@ -22,32 +22,32 @@ dependencies {
      */
     exclude group: 'javax.validation', module: 'validation-api'
   }
-  compile 'jakarta.ws.rs:jakarta.ws.rs-api'
-  compile 'jakarta.validation:jakarta.validation-api'
+  api 'jakarta.ws.rs:jakarta.ws.rs-api'
+  api 'jakarta.validation:jakarta.validation-api'
 
   // We intentionally stick to the 1.0.4 version here since all updates only work with OpenAPI 3.0.
   // The sda-commons-server-openapi module uses a newer version that is compatible with the new
   // swagger-v3 library.
-  compile 'io.openapitools.hal:swagger-hal:1.0.4', {
+  api 'io.openapitools.hal:swagger-hal:1.0.4', {
     exclude group: 'io.swagger', module: 'swagger-jaxrs'
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
-  compile 'io.openapitools.jackson.dataformat:jackson-dataformat-hal'
+  api 'io.openapitools.jackson.dataformat:jackson-dataformat-hal'
 
-  compile 'org.slf4j:slf4j-api'
+  api 'org.slf4j:slf4j-api'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'net.javacrumbs.json-unit:json-unit-assertj', {
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'net.javacrumbs.json-unit:json-unit-assertj', {
     exclude group: 'org.hamcrest',  module: 'hamcrest-core'
   }
-  testCompile 'com.github.java-json-tools:json-schema-validator', {
+  testImplementation 'com.github.java-json-tools:json-schema-validator', {
     /**
      * Dropwizard comes with jakarta.activation instead of javax.activation.
      * Both contain the same classes.
      */
     exclude group: 'javax.activation', module: 'activation'
   }
-  testCompile 'jakarta.activation:jakarta.activation-api'
+  testImplementation 'jakarta.activation:jakarta.activation-api'
 }
 
 test {

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -1,19 +1,19 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'io.dropwizard:dropwizard-testing'
-  compile 'jakarta.servlet:jakarta.servlet-api'
+  api 'io.dropwizard:dropwizard-testing'
+  api 'jakarta.servlet:jakarta.servlet-api'
 
-  compile 'junit:junit'
-  compile 'org.junit.jupiter:junit-jupiter-api'
-  compile 'org.hamcrest:hamcrest'
-  compile 'org.mockito:mockito-core'
-  compile 'org.assertj:assertj-core'
-  compile 'org.junit-pioneer:junit-pioneer', {
+  api 'junit:junit'
+  api 'org.junit.jupiter:junit-jupiter-api'
+  api 'org.hamcrest:hamcrest'
+  api 'org.mockito:mockito-core'
+  api 'org.assertj:assertj-core'
+  api 'org.junit-pioneer:junit-pioneer', {
     exclude group: 'org.junit', module: 'junit-bom'
   }
-  compile 'org.junit.jupiter:junit-jupiter-params'
-  compile 'org.mockito:mockito-junit-jupiter'
+  api 'org.junit.jupiter:junit-jupiter-params'
+  api 'org.mockito:mockito-junit-jupiter'
 
   runtimeOnly 'org.junit.jupiter:junit-jupiter-engine'
   runtimeOnly 'org.junit.vintage:junit-vintage-engine'

--- a/sda-commons-server-trace/build.gradle
+++ b/sda-commons-server-trace/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-shared-tracing')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-shared-tracing')
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-weld-example/build.gradle
+++ b/sda-commons-server-weld-example/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-weld')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-weld')
 
-  testCompile project(':sda-commons-server-weld-testing')
+  testImplementation project(':sda-commons-server-weld-testing')
 }
 

--- a/sda-commons-server-weld-testing/build.gradle
+++ b/sda-commons-server-weld-testing/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-server-testing')
-  compile project(':sda-commons-server-weld')
+  api project(':sda-commons-server-testing')
+  api project(':sda-commons-server-weld')
 
-  testCompile project(':sda-commons-server-jackson')
-  testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0'
-  testCompile 'jakarta.servlet:jakarta.servlet-api'
+  testImplementation project(':sda-commons-server-jackson')
+  testImplementation 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0'
+  testImplementation 'jakarta.servlet:jakarta.servlet-api'
 }

--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-dropwizard')
 
-  compile 'org.jboss.weld.se:weld-se-core', {
+  api 'org.jboss.weld.se:weld-se-core', {
     exclude group: 'org.jboss.spec.javax.el', module: 'jboss-el-api_3.0_spec'
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
     /**
@@ -32,7 +32,7 @@ dependencies {
      */
     exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
   }
-  compile 'org.jboss.weld.servlet:weld-servlet-core', {
+  api 'org.jboss.weld.servlet:weld-servlet-core', {
     /**
      * Dropwizard manages jakarta.el from Glassfish
      */
@@ -62,11 +62,11 @@ dependencies {
      */
     exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
   }
-  compile 'org.glassfish.hk2.external:jakarta.inject'
-  compile 'org.glassfish:jakarta.el'
-  compile 'jakarta.annotation:jakarta.annotation-api'
+  api 'org.glassfish.hk2.external:jakarta.inject'
+  api 'org.glassfish:jakarta.el'
+  api 'jakarta.annotation:jakarta.annotation-api'
 
-  compile 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
+  api 'jakarta.enterprise:jakarta.enterprise.cdi-api', {
     exclude group: 'jakarta.transaction', module: 'jakarta.transaction-api'
     /**
      * Dropwizard comes with jakarta.inject-api repackaged by glassfish for hk2 instead of
@@ -79,6 +79,6 @@ dependencies {
      */
     exclude group: 'jakarta.el', module: 'jakarta.el-api'
   }
-  compile 'javax.transaction:javax.transaction-api'
-  compile 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'
+  api 'javax.transaction:javax.transaction-api'
+  api 'org.glassfish.jersey.ext.cdi:jersey-cdi1x'
 }

--- a/sda-commons-shared-asyncapi/build.gradle
+++ b/sda-commons-shared-asyncapi/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-  compile project(':sda-commons-server-jackson')
-  compile project(':sda-commons-shared-yaml')
-  compile 'com.kjetland:mbknor-jackson-jsonschema_2.12', {
+  api project(':sda-commons-server-jackson')
+  api project(':sda-commons-shared-yaml')
+  api 'com.kjetland:mbknor-jackson-jsonschema_2.12', {
     exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     exclude group: 'javax.validation', module: 'validation-api'
     exclude group: 'org.slf4j', module: 'slf4j-api'
   }
 
-  testCompile project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-shared-error/build.gradle
+++ b/sda-commons-shared-error/build.gradle
@@ -2,7 +2,7 @@ dependencies {
   compileOnly 'io.swagger:swagger-annotations'
   compileOnly 'io.swagger.core.v3:swagger-annotations'
 
-  testCompile 'junit:junit'
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'junit:junit'
+  testImplementation 'org.assertj:assertj-core'
   testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
 }

--- a/sda-commons-shared-forms/build.gradle
+++ b/sda-commons-shared-forms/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-  compile project(':sda-commons-server-dropwizard')
-  compile 'io.dropwizard:dropwizard-forms'
+  api project(':sda-commons-server-dropwizard')
+  api 'io.dropwizard:dropwizard-forms'
 }

--- a/sda-commons-shared-yaml/build.gradle
+++ b/sda-commons-shared-yaml/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
-  compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
-  compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
-  compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
+  api group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml'
+  api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
+  api group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8'
+  api group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile 'commons-io:commons-io'
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'commons-io:commons-io'
 }

--- a/sda-commons-starter-example/build.gradle
+++ b/sda-commons-starter-example/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-  compile project(':sda-commons-starter')
+  api project(':sda-commons-starter')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-auth-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-auth-testing')
 
-  testCompile 'org.assertj:assertj-core'
+  testImplementation 'org.assertj:assertj-core'
 }

--- a/sda-commons-starter/build.gradle
+++ b/sda-commons-starter/build.gradle
@@ -1,19 +1,19 @@
 dependencies {
-  compile project(':sda-commons-server-auth')
-  compile project(':sda-commons-server-consumer')
-  compile project(':sda-commons-server-cors')
-  compile project(':sda-commons-server-dropwizard')
-  compile project(':sda-commons-server-healthcheck')
-  compile project(':sda-commons-server-jackson')
-  compile project(':sda-commons-server-jaeger')
-  compile project(':sda-commons-server-openapi')
-  compile project(':sda-commons-server-opentracing')
-  compile project(':sda-commons-server-prometheus')
-  compile project(':sda-commons-server-security')
-  compile project(':sda-commons-server-trace')
+  api project(':sda-commons-server-auth')
+  api project(':sda-commons-server-consumer')
+  api project(':sda-commons-server-cors')
+  api project(':sda-commons-server-dropwizard')
+  api project(':sda-commons-server-healthcheck')
+  api project(':sda-commons-server-jackson')
+  api project(':sda-commons-server-jaeger')
+  api project(':sda-commons-server-openapi')
+  api project(':sda-commons-server-opentracing')
+  api project(':sda-commons-server-prometheus')
+  api project(':sda-commons-server-security')
+  api project(':sda-commons-server-trace')
 
-  testCompile project(':sda-commons-server-testing')
-  testCompile project(':sda-commons-server-auth-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-server-auth-testing')
 }
 
 test {


### PR DESCRIPTION
Fixes #978 

Tried out here: https://github.com/SDA-SE/malware-scanner-facade/pull/313

I compared the POMs of some modules of the latest release and of the snapshot and could not find any differences except the version. Modules checked:
- sda-commons-server-kafka
- sda-commons-starter