### PR TITLE
WIP: chore(server-kafka): don't forward kafka properties with null value

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -1,7 +1,9 @@
 package org.sdase.commons.server.kafka;
 
 import com.google.common.base.Strings;
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -61,7 +63,11 @@ public class KafkaProperties extends Properties {
     props.putAll(configureSecurity(configuration.getSecurity()));
 
     if (configuration.getConfig() != null) {
-      props.putAll(configuration.getConfig());
+      Map<String, String> nonNullConfigs =
+          configuration.getConfig().entrySet().stream()
+              .filter(entry -> entry.getValue() != null)
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+      props.putAll(nonNullConfigs);
     }
 
     return props;

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesTest.java
@@ -166,4 +166,22 @@ public class KafkaPropertiesTest {
     assertThat(props.getProperty(SaslConfigs.SASL_JAAS_CONFIG)).isNull();
     assertThat(props.getProperty(SaslConfigs.SASL_MECHANISM)).isNull();
   }
+
+  @Test
+  public void itShouldFilterNullValueConfigs() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    config.getConfig().put("setting", "from.global");
+    config.getConfig().put("ssl.truststore.location", null);
+
+    assertThat(KafkaProperties.forProducer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forProducer(config).containsKey("ssl.truststore.location"))
+        .isFalse();
+    assertThat(KafkaProperties.forConsumer(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forConsumer(config).containsKey("ssl.truststore.location"))
+        .isFalse();
+    assertThat(KafkaProperties.forAdminClient(config).get("setting")).isEqualTo("from.global");
+    assertThat(KafkaProperties.forAdminClient(config).containsKey("ssl.truststore.location"))
+        .isFalse();
+  }
 }


### PR DESCRIPTION
if you define `ssl.truststore.location` in the config.yml so it can be set, but you don't use SASL in the deployment so the value of the location is null, the service logs spam the warning `The configuration 'ssl.truststore.location' was supplied but isn't a known config.`.

By not forwarding config properties with the value null this can be prevented.