### PR TITLE
Feat/global excludes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,8 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
   }
 
   configurations {
-    all*.exclude group: 'javax.servlet', module: 'javax.servlet-api'
+    all*.exclude group: 'javax.servlet', module: 'javax.servlet-api' // prefer jakarta.servlet-api
+    all*.exclude group: 'commons-logging', module: 'commons-logging' // prefer jcl-over-slf4j
   }
 
   configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,10 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
     }
   }
 
+  configurations {
+    all*.exclude group: 'javax.servlet', module: 'javax.servlet-api'
+  }
+
   configurations.all {
     resolutionStrategy {
       // fail eagerly on version conflict (includes transitive dependencies)

--- a/sda-commons-client-jersey-wiremock-testing/build.gradle
+++ b/sda-commons-client-jersey-wiremock-testing/build.gradle
@@ -1,12 +1,6 @@
 dependencies {
 
-  compile "com.github.tomakehurst:wiremock-jre8", {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile "com.github.tomakehurst:wiremock-jre8"
 
   compile 'org.glassfish.jersey.core:jersey-client'
   compile 'org.glassfish.jersey.ext:jersey-proxy-client'

--- a/sda-commons-client-jersey/build.gradle
+++ b/sda-commons-client-jersey/build.gradle
@@ -4,13 +4,7 @@ dependencies {
   compile project(':sda-commons-shared-tracing')
   compile project(':sda-commons-shared-error')
 
-  compile 'io.dropwizard:dropwizard-client', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile 'io.dropwizard:dropwizard-client'
   compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'org.glassfish.jersey.core:jersey-client'
   compile 'org.glassfish.jersey.ext:jersey-proxy-client'

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -4,13 +4,7 @@ dependencies {
   compile project(':sda-commons-server-opentracing')
   compile project(':sda-commons-shared-tracing')
   compile 'io.dropwizard:dropwizard-auth'
-  compile 'io.dropwizard:dropwizard-client', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile 'io.dropwizard:dropwizard-client'
   compile 'jakarta.servlet:jakarta.servlet-api'
 
   compile 'com.auth0:java-jwt'

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -1,11 +1,5 @@
 dependencies {
-  compile 'io.dropwizard:dropwizard-core', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile 'io.dropwizard:dropwizard-core'
   compile 'jakarta.servlet:jakarta.servlet-api'
   compile 'io.dropwizard:dropwizard-json-logging'
 

--- a/sda-commons-server-hibernate/build.gradle
+++ b/sda-commons-server-hibernate/build.gradle
@@ -2,11 +2,6 @@ dependencies {
   compile project(':sda-commons-server-dropwizard')
   compile 'io.dropwizard:dropwizard-hibernate', {
     /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-    /**
      * dropwizard-hibernate provides javax.transaction:javax.transaction-api through
      * jackson-datatype-hibernate5 and
      * org.jboss.spec.javax.transaction:jboss-transaction-api_1.2_spec through hibernate-core.

--- a/sda-commons-server-prometheus/build.gradle
+++ b/sda-commons-server-prometheus/build.gradle
@@ -2,15 +2,8 @@ dependencies {
 
   compile project(':sda-commons-server-dropwizard')
   compile project(':sda-commons-shared-tracing')
-  compile 'io.dropwizard:dropwizard-client', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile 'io.dropwizard:dropwizard-client'
   compile 'jakarta.servlet:jakarta.servlet-api'
-
 
   compile 'io.prometheus:simpleclient'
   compile 'io.prometheus:simpleclient_dropwizard'

--- a/sda-commons-server-s3/build.gradle
+++ b/sda-commons-server-s3/build.gradle
@@ -1,11 +1,6 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
-  compile 'com.amazonaws:aws-java-sdk-s3', {
-    /**
-     * As we use SLF4J for logging, we need the Bridge, not commons-logging itself
-     */
-    exclude group: 'commons-logging', module: 'commons-logging'
-  }
+  compile 'com.amazonaws:aws-java-sdk-s3'
   compile 'org.slf4j:jcl-over-slf4j'
   compile 'io.opentracing.contrib:opentracing-aws-sdk-1'
   compile 'io.opentracing:opentracing-util'

--- a/sda-commons-server-testing/build.gradle
+++ b/sda-commons-server-testing/build.gradle
@@ -1,13 +1,7 @@
 dependencies {
   compile project(':sda-commons-server-dropwizard')
 
-  compile 'io.dropwizard:dropwizard-testing', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  compile 'io.dropwizard:dropwizard-testing'
   compile 'jakarta.servlet:jakarta.servlet-api'
 
   compile 'junit:junit'

--- a/sda-commons-server-weld-testing/build.gradle
+++ b/sda-commons-server-weld-testing/build.gradle
@@ -3,12 +3,6 @@ dependencies {
   compile project(':sda-commons-server-weld')
 
   testCompile project(':sda-commons-server-jackson')
-  testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0', {
-    /**
-     * Dropwizard comes with jakarta.servlet instead of javax.servlet.
-     * Both contain the same classes.
-     */
-    exclude group: 'javax.servlet', module: 'javax.servlet-api'
-  }
+  testCompile 'de.spinscale.dropwizard:dropwizard-jobs-core:3.0.0'
   testCompile 'jakarta.servlet:jakarta.servlet-api'
 }


### PR DESCRIPTION
**Background:**
There is still some way that javax.servlet is leaking into our services. To make things worse javax.servlet is used in version 3.1.0 whereas the javakarta version is already 4.x.

This change was first tested in the PR for Gradle 7: https://github.com/SDA-SE/sda-dropwizard-commons/pull/979

By this change all dependencies in all POMs will be like in the following snippet:
```
<dependency>
  <groupId>org.sdase.commons</groupId>
  <artifactId>sda-commons-shared-tracing</artifactId>
  <version>PR-979-SNAPSHOT</version>
  <scope>compile</scope>
  <exclusions>
    <exclusion>
      <artifactId>javax.servlet-api</artifactId>
      <groupId>javax.servlet</groupId>
    </exclusion>
    <exclusion>
      <artifactId>commons-logging</artifactId>
      <groupId>commons-logging</groupId>
    </exclusion>
  </exclusions>
</dependency>
```

I could confirm locally that no "javax" dependencies is used with this snapshot.