### PR TITLE
docs(server-morphia): set default for mongo caCertificate in Readme

### DIFF
--- a/sda-commons-server-morphia/README.md
+++ b/sda-commons-server-morphia/README.md
@@ -97,7 +97,7 @@ mongo:
   username: "${MONGODB_USERNAME:-}"
   password: "${MONGODB_PASSWORD:-}"
   useSsl: ${MONGODB_USE_SSL:-true}
-  caCertificate: "${MONGODB_CA_CERTIFICATE}"
+  caCertificate: "${MONGODB_CA_CERTIFICATE:-}"
 ```
 _Please note the double quotes around the values.
  Without them for `caCertificate`, Dropwizard will not be able to load the certificate correctly because the `MONGODB_CA_CERTIFICATE` variable contains line breaks.  


### PR DESCRIPTION
set default for the mongo caCertificate environment variable in the Readme
so the var is not required in the deployment when adding it to the project.