### PR TITLE
chore(build): fix fossa workflow

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,7 +18,7 @@ jobs:
           java-version: 1.8
 
       - name: Install Fossa
-        run: "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash"
+        run: "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
 
       - name: Fossa Analyze
         env:


### PR DESCRIPTION
In some (all?) PRs we noticed that the Fossa build does not execute. It fails with missing privileges for installation of the Fossa CLI:

> Run curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | bash
  …
> fossas/fossa-cli info checking GitHub for latest tag
> fossas/fossa-cli info found version: 1.1.10 for v1.1.10/linux/amd64
> install: cannot change permissions of ‘/usr/local/bin’: Operation not permitted
> Error: Process completed with exit code 1.

`sudo` will provide enough privileges.