### PR TITLE
test: Remove imports of packages "sun.*"

### DIFF
--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/service/AuthRSA256ServiceTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/service/AuthRSA256ServiceTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
@@ -28,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.sdase.commons.server.auth.error.JwtAuthException;
 import org.sdase.commons.server.auth.key.RsaPublicKeyLoader;
 import org.sdase.commons.server.auth.service.testsources.JwksTestKeySource;
-import sun.security.rsa.RSAPrivateCrtKeyImpl;
 
 /**
  * This will validate the AuthRSA256Service by this unit test with the inclusion of the token issuer
@@ -319,7 +319,7 @@ class AuthRSA256ServiceTest {
     try {
       final String privateKeyLocation = ResourceHelpers.resourceFilePath(privateKeyFileLocation);
 
-      RSAPrivateCrtKeyImpl privateKey = (RSAPrivateCrtKeyImpl) loadPrivateKey(privateKeyLocation);
+      RSAPrivateCrtKey privateKey = (RSAPrivateCrtKey) loadPrivateKey(privateKeyLocation);
       RSAPublicKeySpec publicKeySpec =
           new RSAPublicKeySpec(privateKey.getModulus(), privateKey.getPublicExponent());
       KeyFactory keyFactory = KeyFactory.getInstance("RSA");

--- a/sda-commons-shared-certificates/src/test/java/org/sdase/commons/shared/certificates/ca/ssl/CompositeX509TrustManagerTest.java
+++ b/sda-commons-shared-certificates/src/test/java/org/sdase/commons/shared/certificates/ca/ssl/CompositeX509TrustManagerTest.java
@@ -18,9 +18,9 @@ import javax.net.ssl.X509TrustManager;
 import org.bouncycastle.openssl.PEMParser;
 import org.junit.Before;
 import org.junit.Test;
-import sun.security.validator.ValidatorException;
 
 public class CompositeX509TrustManagerTest {
+
   public static final String AUTH_TYPE = "Basic";
   private X509TrustManager trustManager;
   private X509Certificate trustedChain;
@@ -78,10 +78,10 @@ public class CompositeX509TrustManagerTest {
     CompositeX509TrustManager compositeX509TrustManager =
         new CompositeX509TrustManager(Collections.singletonList(trustManager));
 
-    assertThatExceptionOfType(ValidatorException.class)
-        .isThrownBy(
+    assertThatCode(
             () ->
-                trustManager.checkServerTrusted(new X509Certificate[] {unTrustedChain}, AUTH_TYPE));
+                trustManager.checkServerTrusted(new X509Certificate[] {unTrustedChain}, AUTH_TYPE))
+        .hasMessageContaining("unable to find valid certification path to requested target");
     assertThatExceptionOfType(CertificateException.class)
         .isThrownBy(
             () ->


### PR DESCRIPTION
Context:
Building sda-dropwizard-commons with Java 17 does not work because it is stricter when internal classes are used. This PR removes 2 imports from package "sun.*".