### PR TITLE
chore: disable snapshots for dependabot PRs

### DIFF
--- a/.github/workflows/pull-request-snapshots.yml
+++ b/.github/workflows/pull-request-snapshots.yml
@@ -5,8 +5,8 @@ on: [pull_request]
 
 jobs:
   pull-request-snapshots:
-    # do not execute for PRs that origin from forks since we are missing the secrets for the push
-    if: "!(github.event.pull_request && github.event.pull_request.head.repo.fork)"
+    # do not execute for PRs that origin from forks or created by dependabot since we are missing the secrets for the push
+    if: "!(github.event.pull_request && github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
As dependabot PR builds have no secrets, the pull request artifacts can't be pushed to Nexus.

Disabling this job for dependabot will be one less red build we have to care about or that may confuse us when approving PRs.
