### PR TITLE
chore: disable test result publishing for dependabot PRs

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -65,8 +65,8 @@ jobs:
     timeout-minutes: 60
     needs: build
     runs-on: ubuntu-latest
-    # Don't run for forks because of missing secrets
-    if: (success() || failure()) && !(github.event.pull_request && github.event.pull_request.head.repo.fork)
+    # Don't run for forks and dependabot because of missing secrets
+    if: (success() || failure()) && !(github.event.pull_request && github.event.pull_request.head.repo.fork) && github.actor != 'dependabot[bot]'
     steps:
       - name: Download Artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Failing tests will still fail the build, but there is no easy to read information in the PR.