### PR TITLE
chore(build): fix artifact download

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,7 +36,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
-          commit: ${{github.event.workflow_run.head_sha}}
+          run_id: ${{ github.event.workflow_run.id }}
           name: ubuntu-latest-11-test-results
 
       - name: Set up JDK 11


### PR DESCRIPTION
Although there is close to zero documentation about `workflow_run`, there are usages when you search all repos in GitHub. So this is just another try to make it work.