### PR TITLE
Simplify CSP and add sandbox

### DIFF
--- a/sda-commons-server-security/src/main/java/org/sdase/commons/server/security/filter/WebSecurityHeaderFilter.java
+++ b/sda-commons-server-security/src/main/java/org/sdase/commons/server/security/filter/WebSecurityHeaderFilter.java
@@ -35,16 +35,7 @@ public class WebSecurityHeaderFilter implements ContainerResponseFilter {
     webSecurityHeaders.put("X-Permitted-Cross-Domain-Policies", "none");
     webSecurityHeaders.put(
         "Content-Security-Policy",
-        String.join(
-            "; ",
-            asList(
-                "default-src 'self'",
-                "script-src 'self'",
-                "img-src 'self'",
-                "style-src 'self'",
-                "font-src 'self'",
-                "frame-src 'none'",
-                "object-src 'none'")));
+        String.join("; ", asList("default-src 'none'", "frame-ancestors 'none'", "sandbox")));
     return webSecurityHeaders;
   }
 

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/filter/WebSecurityHeaderFilterIT.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/filter/WebSecurityHeaderFilterIT.java
@@ -43,14 +43,7 @@ public class WebSecurityHeaderFilterIT {
           "Content-Security-Policy",
           String.join(
               "; ", // NOSONAR
-              asList(
-                  "default-src 'self'",
-                  "script-src 'self'",
-                  "img-src 'self'",
-                  "style-src 'self'",
-                  "font-src 'self'",
-                  "frame-src 'none'",
-                  "object-src 'none'"))
+              asList("default-src 'none'", "frame-ancestors 'none'", "sandbox"))
         });
   }
 


### PR DESCRIPTION
Hardening is important. This PRs improves the header security for an api endpoint:
- simplify CSP
- adding sandbox
according to "API Security in Action" page 58.

Complications with frontend applications like angular are not expected.
In case HTML applications are delivered to the client directly, it will infect for example javascript execution.