### PR TITLE
feat: Variable substitution now also supports system properties

### DIFF
--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
@@ -27,9 +27,9 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.client.jersey.test.ClientTestApp;
 import org.sdase.commons.client.jersey.test.ClientTestConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
 import org.sdase.commons.server.testing.Retry;
 import org.sdase.commons.server.testing.RetryRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /** Tests that timeouts are correctly mapped. */
 public class GenericClientTimeoutTest {
@@ -44,7 +44,7 @@ public class GenericClientTimeoutTest {
   @Rule
   public final RuleChain rule =
       RuleChain.outerRule(new RetryRule())
-          .around(new EnvironmentRule().setEnv("MOCK_BASE_URL", WIRE.baseUrl()))
+          .around(new SystemPropertyRule().setProperty("MOCK_BASE_URL", WIRE.baseUrl()))
           .around(dw);
 
   private ClientTestApp app;

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTraceTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/test/ClientTraceTest.java
@@ -25,7 +25,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ClientTraceTest {
 
@@ -38,7 +38,8 @@ public class ClientTraceTest {
 
   @Rule
   public final RuleChain rule =
-      RuleChain.outerRule(new EnvironmentRule().setEnv("MOCK_BASE_URL", WIRE.baseUrl())).around(dw);
+      RuleChain.outerRule(new SystemPropertyRule().setProperty("MOCK_BASE_URL", WIRE.baseUrl()))
+          .around(dw);
 
   private ClientTestApp app;
 

--- a/sda-commons-server-auth-testing/README.md
+++ b/sda-commons-server-auth-testing/README.md
@@ -14,7 +14,7 @@ In an integration test, authentication can be configured using the
 [`AuthRule`](./src/main/java/org/sdase/commons/server/auth/testing/AuthRule.java) and/or the [`OpaRule`](./src/main/java/org/sdase/commons/server/opa/testing/OpaRule.java).
 
 ## Auth Rule
-The `AuthRule` uses the `EnvironmentRule` to create the `AuthConfig` in an environment property called `AUTH_RULE`.
+The `AuthRule` uses the `SystemPropertyRule` to create the `AuthConfig` in an environment property called `AUTH_RULE`.
 Therefore the configuration in the test needs to use this property and the application is required to use the 
 [`ConfigurationSubstitutionBundle`](../sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundle.java)
 from [`sda-commons-server-dropwizard`](../sda-commons-server-dropwizard/README.md):

--- a/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthClassExtension.java
+++ b/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthClassExtension.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.sdase.commons.server.auth.config.AuthConfig;
-import org.sdase.commons.server.testing.Environment;
 
 public class AuthClassExtension extends AbstractAuth
     implements BeforeAllCallback, AfterAllCallback {
@@ -69,17 +68,17 @@ public class AuthClassExtension extends AbstractAuth
 
   @Override
   public void beforeAll(ExtensionContext context) {
-    valueToRestore = System.getenv(AUTH_RULE_ENV_KEY);
+    valueToRestore = System.getProperty(AUTH_RULE_ENV_KEY);
   }
 
   @Override
   public void afterAll(ExtensionContext context) {
-    Environment.setEnv(AUTH_RULE_ENV_KEY, valueToRestore);
+    System.setProperty(AUTH_RULE_ENV_KEY, valueToRestore);
   }
 
   private void initDisabledTestAuth() {
     this.authConfig = new AuthConfig().setDisableAuth(true);
-    Environment.setEnv(AUTH_RULE_ENV_KEY, "{\"disableAuth\": true}");
+    System.setProperty(AUTH_RULE_ENV_KEY, "{\"disableAuth\": true}");
   }
 
   private void initEnabledTestAuth() {
@@ -88,7 +87,7 @@ public class AuthClassExtension extends AbstractAuth
 
     try {
       String authKeysConfig = new ObjectMapper().writeValueAsString(authConfig);
-      Environment.setEnv(AUTH_RULE_ENV_KEY, authKeysConfig);
+      System.setProperty(AUTH_RULE_ENV_KEY, authKeysConfig);
     } catch (JsonProcessingException e) {
       fail("Failed to create the config keys: " + e.getMessage());
     }

--- a/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthRule.java
+++ b/sda-commons-server-auth-testing/src/main/java/org/sdase/commons/server/auth/testing/AuthRule.java
@@ -13,7 +13,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.sdase.commons.server.auth.config.AuthConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /**
  * This {@link TestRule} configures a Dropwizard application that uses JWT authentication for
@@ -106,7 +106,7 @@ public class AuthRule extends AbstractAuth implements TestRule {
     this.authConfig = new AuthConfig().setDisableAuth(true);
     delegate =
         RuleChain.outerRule(
-            new EnvironmentRule().setEnv(AUTH_RULE_ENV_KEY, "{\"disableAuth\": true}"));
+            new SystemPropertyRule().setProperty(AUTH_RULE_ENV_KEY, "{\"disableAuth\": true}"));
   }
 
   private void initEnabledTestAuth() {
@@ -116,7 +116,8 @@ public class AuthRule extends AbstractAuth implements TestRule {
     try {
       String authKeysConfig = new ObjectMapper().writeValueAsString(authConfig);
       delegate =
-          RuleChain.outerRule(new EnvironmentRule().setEnv(AUTH_RULE_ENV_KEY, authKeysConfig));
+          RuleChain.outerRule(
+              new SystemPropertyRule().setProperty(AUTH_RULE_ENV_KEY, authKeysConfig));
     } catch (JsonProcessingException e) {
       fail("Failed to create the config keys: " + e.getMessage());
     }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.test.AuthTestApp;
 import org.sdase.commons.server.auth.testing.test.AuthTestConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /** A test that checks if the jersey client that is used to load keys is configurable */
 public class CustomKeyLoaderConfigIT {
@@ -37,8 +37,8 @@ public class CustomKeyLoaderConfigIT {
     WIRE.stubFor(get(anyUrl()).willReturn(okJson("{\"keys\": []}")));
   }
 
-  public static final EnvironmentRule ENVIRONMENT_RULE =
-      new EnvironmentRule().setEnv("AUTH_RULE", "{\"keys\": [{}]}");
+  public static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule().setProperty("AUTH_RULE", "{\"keys\": [{}]}");
 
   private static final DropwizardAppRule<AuthTestConfig> DW =
       new DropwizardAppRule<>(
@@ -50,7 +50,7 @@ public class CustomKeyLoaderConfigIT {
           config("auth.keys[0].location", () -> WIRE.url("jwks")));
 
   @ClassRule
-  public static RuleChain RULE = RuleChain.outerRule(WIRE).around(ENVIRONMENT_RULE).around(DW);
+  public static RuleChain RULE = RuleChain.outerRule(WIRE).around(SYSTEM_PROPERTY_RULE).around(DW);
 
   @Test
   public void shouldSendCustomUserAgentInTheJwksRequest() {

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
@@ -32,11 +32,9 @@ public class KeyLoaderProxyIT {
   private static final WireMockClassRule PROXY_WIRE =
       new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
-      new SystemPropertyRule().setProperty("AUTH_RULE", "{\"keys\": [{}]}");
-
   private static final SystemPropertyRule SYSTEM_PROPERTY =
       new SystemPropertyRule()
+          .setProperty("AUTH_RULE", "{\"keys\": [{}]}")
           .setProperty("http.proxyHost", "localhost")
           .setProperty("http.proxyPort", () -> "" + PROXY_WIRE.port())
           .setProperty("http.nonProxyHosts", "localhost");
@@ -50,10 +48,7 @@ public class KeyLoaderProxyIT {
 
   @ClassRule
   public static final RuleChain rule =
-      RuleChain.outerRule(PROXY_WIRE)
-          .around(SYSTEM_PROPERTY_RULE)
-          .around(SYSTEM_PROPERTY)
-          .around(DW);
+      RuleChain.outerRule(PROXY_WIRE).around(SYSTEM_PROPERTY).around(DW);
 
   @BeforeClass
   public static void setupWiremock() {

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.auth.testing.test.AuthTestApp;
 import org.sdase.commons.server.auth.testing.test.AuthTestConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
 import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /** A test that checks if the jersey client that is used to load keys can use a proxy server */
@@ -33,8 +32,8 @@ public class KeyLoaderProxyIT {
   private static final WireMockClassRule PROXY_WIRE =
       new WireMockClassRule(wireMockConfig().dynamicPort());
 
-  private static final EnvironmentRule ENVIRONMENT_RULE =
-      new EnvironmentRule().setEnv("AUTH_RULE", "{\"keys\": [{}]}");
+  private static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule().setProperty("AUTH_RULE", "{\"keys\": [{}]}");
 
   private static final SystemPropertyRule SYSTEM_PROPERTY =
       new SystemPropertyRule()
@@ -51,7 +50,10 @@ public class KeyLoaderProxyIT {
 
   @ClassRule
   public static final RuleChain rule =
-      RuleChain.outerRule(PROXY_WIRE).around(ENVIRONMENT_RULE).around(SYSTEM_PROPERTY).around(DW);
+      RuleChain.outerRule(PROXY_WIRE)
+          .around(SYSTEM_PROPERTY_RULE)
+          .around(SYSTEM_PROPERTY)
+          .around(DW);
 
   @BeforeClass
   public static void setupWiremock() {

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/config/AuthConfigTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/config/AuthConfigTest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.testing.ResourceHelpers;
 import java.io.BufferedReader;
@@ -21,7 +20,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentSubstitutor;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,8 +58,8 @@ public class AuthConfigTest {
   }
 
   @ClassRule
-  public static EnvironmentRule ENV =
-      new EnvironmentRule().setEnv("KEYS", KEYS_JSON).setEnv("ISSUERS", ISSUERS);
+  public static SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule().setProperty("KEYS", KEYS_JSON).setProperty("ISSUERS", ISSUERS);
 
   @Test
   public void shouldReadConfigFromJsonEnvironment() throws Exception {
@@ -103,7 +103,7 @@ public class AuthConfigTest {
   private String readConfigWithSubstitution(String configPath) throws IOException {
     SubstitutingSourceProvider sourceProvider =
         new SubstitutingSourceProvider(
-            FileInputStream::new, new EnvironmentVariableSubstitutor(false));
+            FileInputStream::new, new SystemPropertyAndEnvironmentSubstitutor(false));
     String config;
     try (BufferedReader reader =
         new BufferedReader(

--- a/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
+++ b/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
@@ -12,7 +12,7 @@ import org.junit.rules.RuleChain;
 import org.sdase.commons.server.consumer.test.ConsumerTokenOptionalTestApp;
 import org.sdase.commons.server.consumer.test.ConsumerTokenTestApp;
 import org.sdase.commons.server.consumer.test.ConsumerTokenTestConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ConsumerTokenBundleOptionalTokenTest {
 
@@ -26,7 +26,7 @@ public class ConsumerTokenBundleOptionalTokenTest {
 
   @ClassRule
   public static RuleChain CHAIN =
-      RuleChain.outerRule(new EnvironmentRule().setEnv("CONSUMER_TOKEN_OPTIONAL", "true"))
+      RuleChain.outerRule(new SystemPropertyRule().setProperty("CONSUMER_TOKEN_OPTIONAL", "true"))
           .around(DW)
           .around(DW_OPTIONAL);
 

--- a/sda-commons-server-dropwizard/README.md
+++ b/sda-commons-server-dropwizard/README.md
@@ -16,8 +16,9 @@ The Dropwizard module provides default Bundles that are useful for most Dropwiza
 ### ConfigurationSubstitutionBundle
 
 The [`ConfigurationSubstitutionBundle`](./src/main/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundle.java)
-allows to use placeholders for environment variables in the config.yaml of the application to dynamically configure the
-application at startup. Default values can be added after the environment variable name separated by `:-`
+allows to use placeholders for environment variables or system properties in the config.yaml of the 
+application to dynamically configure the application at startup. Default values can be added after 
+the environment variable name separated by `:-`
 
 ```yaml
 database:

--- a/sda-commons-server-dropwizard/README.md
+++ b/sda-commons-server-dropwizard/README.md
@@ -18,7 +18,7 @@ The Dropwizard module provides default Bundles that are useful for most Dropwiza
 The [`ConfigurationSubstitutionBundle`](./src/main/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundle.java)
 allows to use placeholders for environment variables or system properties in the config.yaml of the 
 application to dynamically configure the application at startup. Default values can be added after 
-the environment variable name separated by `:-`
+the variable name separated by `:-`
 
 ```yaml
 database:

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundle.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundle.java
@@ -2,17 +2,17 @@ package org.sdase.commons.server.dropwizard.bundles;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
-import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
 /**
  * The {@code ConfigurationSubstitutionBundle} allows to use placeholders for environment variables
- * in configuration yaml files. It should be added as first bundle in the application.
+ * or system properties in configuration yaml files. It should be added as first bundle in the
+ * application.
  *
  * <p>The {@code config.yaml} may contain placeholders that are replaced by the content of
- * environment variables and optional default values:
+ * environment variables or system properties and optional default values:
  *
  * <pre>{@code
  * server:
@@ -38,7 +38,7 @@ public class ConfigurationSubstitutionBundle implements ConfiguredBundle<Configu
     bootstrap.setConfigurationSourceProvider(
         new SubstitutingSourceProvider(
             bootstrap.getConfigurationSourceProvider(),
-            new EnvironmentVariableSubstitutor(false, true)));
+            new SystemPropertyAndEnvironmentSubstitutor(false, true)));
   }
 
   @Override
@@ -47,6 +47,7 @@ public class ConfigurationSubstitutionBundle implements ConfiguredBundle<Configu
   }
 
   public static class Builder {
+
     public ConfigurationSubstitutionBundle build() {
       return new ConfigurationSubstitutionBundle();
     }

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookup.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookup.java
@@ -1,0 +1,15 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import io.dropwizard.configuration.EnvironmentVariableLookup;
+
+public class SystemPropertyAndEnvironmentLookup extends EnvironmentVariableLookup {
+
+  @Override
+  public String lookup(String key) {
+    String result = System.getProperty(key);
+    if (result != null) {
+      return result;
+    }
+    return super.lookup(key);
+  }
+}

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookup.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookup.java
@@ -2,6 +2,10 @@ package org.sdase.commons.server.dropwizard.bundles;
 
 import io.dropwizard.configuration.EnvironmentVariableLookup;
 
+/**
+ * Lookup for Java's system properties and environment variables. System properties have higher
+ * priority.
+ */
 public class SystemPropertyAndEnvironmentLookup extends EnvironmentVariableLookup {
 
   @Override

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentSubstitutor.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentSubstitutor.java
@@ -1,0 +1,40 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import io.dropwizard.configuration.UndefinedEnvironmentVariableException;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.TextStringBuilder;
+
+public class SystemPropertyAndEnvironmentSubstitutor extends StringSubstitutor {
+
+  public SystemPropertyAndEnvironmentSubstitutor() {
+    this(true, false);
+  }
+
+  public SystemPropertyAndEnvironmentSubstitutor(boolean strict) {
+    this(strict, false);
+  }
+
+  /**
+   * @param strict {@code true} if looking up undefined environment variables should throw a {@link
+   *     UndefinedEnvironmentVariableException}, {@code false} otherwise.
+   * @param substitutionInVariables a flag whether substitution is done in variable names.
+   * @see org.apache.commons.text.StringSubstitutor#setEnableSubstitutionInVariables(boolean)
+   */
+  public SystemPropertyAndEnvironmentSubstitutor(boolean strict, boolean substitutionInVariables) {
+    super(new SystemPropertyAndEnvironmentLookup());
+    this.setEnableUndefinedVariableException(strict);
+    this.setEnableSubstitutionInVariables(substitutionInVariables);
+  }
+
+  @Override
+  protected boolean substitute(TextStringBuilder buf, int offset, int length) {
+    try {
+      return super.substitute(buf, offset, length);
+    } catch (IllegalArgumentException e) {
+      if (e.getMessage() != null && e.getMessage().contains("Cannot resolve variable")) {
+        throw new UndefinedEnvironmentVariableException(e.getMessage());
+      }
+      throw e;
+    }
+  }
+}

--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -107,7 +108,7 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
     consoleAppender.putIfAbsent("threshold", DEFAULT_THRESHOLD);
     consoleAppender.putIfAbsent("logFormat", DEFAULT_LOG_FORMAT);
 
-    if ("true".equals(System.getenv("ENABLE_JSON_LOGGING"))) {
+    if ("true".equals(new SystemPropertyAndEnvironmentLookup().lookup("ENABLE_JSON_LOGGING"))) {
       consoleAppender.putIfAbsent("layout", createLoggingConsoleAppenderLayout());
     }
 
@@ -174,7 +175,7 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
   }
 
   private void applyRequestLogConsoleAppenderDefaults(Map<String, Object> consoleAppender) {
-    if ("true".equals(System.getenv("ENABLE_JSON_LOGGING"))) {
+    if ("true".equals(new SystemPropertyAndEnvironmentLookup().lookup("ENABLE_JSON_LOGGING"))) {
       consoleAppender.putIfAbsent("layout", createRequestLogConsoleAppenderLayout());
     }
   }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
@@ -19,18 +19,19 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest {
 
-  public static final EnvironmentRule ENV =
-      new EnvironmentRule().setEnv("ENABLE_JSON_LOGGING", "true");
+  public static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule().setProperty("ENABLE_JSON_LOGGING", "true");
 
   public static final DropwizardAppRule<Configuration> DW =
       new DropwizardAppRule<>(
           LoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
 
-  @ClassRule public static final RuleChain RULE = RuleChain.outerRule(ENV).around(DW);
+  @ClassRule
+  public static final RuleChain RULE = RuleChain.outerRule(SYSTEM_PROPERTY_RULE).around(DW);
 
   @Test()
   public void shouldApplyConsoleAppender() {

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookupTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookupTest.java
@@ -1,0 +1,29 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+class SystemPropertyAndEnvironmentLookupTest {
+
+  @Test
+  @SetSystemProperty(key = "FOO", value = "bar")
+  void shouldLookupSystemProperties() {
+    assertThat(new SystemPropertyAndEnvironmentLookup().lookup("FOO")).isEqualTo("bar");
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "FOO", value = "bar")
+  void shouldLookupEnvironmentVariables() {
+    assertThat(new SystemPropertyAndEnvironmentLookup().lookup("FOO")).isEqualTo("bar");
+  }
+
+  @Test
+  @SetEnvironmentVariable(key = "FOO", value = "bar_env")
+  @SetSystemProperty(key = "FOO", value = "bar_prop")
+  void shouldPreferSystemProperties() {
+    assertThat(new SystemPropertyAndEnvironmentLookup().lookup("FOO")).isEqualTo("bar_prop");
+  }
+}

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentSubstitutorTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentSubstitutorTest.java
@@ -1,0 +1,44 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.dropwizard.configuration.UndefinedEnvironmentVariableException;
+import org.apache.commons.text.TextStringBuilder;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+@SetSystemProperty(key = "TEST", value = "foobar")
+class SystemPropertyAndEnvironmentSubstitutorTest {
+
+  @Test
+  void shouldReplaceProperty() {
+    final String input = "this is a ${TEST}";
+    final TextStringBuilder builder = new TextStringBuilder(input);
+    boolean altered =
+        new SystemPropertyAndEnvironmentSubstitutor(false).substitute(builder, 0, input.length());
+    assertThat(altered).isTrue();
+    assertThat(builder.build()).isEqualTo("this is a foobar");
+  }
+
+  @Test
+  void shouldThrowExceptionIfStrict() {
+    final String input = "this is a ${UNKNOWN_PROPERTY}";
+    final TextStringBuilder builder = new TextStringBuilder(input);
+    final SystemPropertyAndEnvironmentSubstitutor substitutor =
+        new SystemPropertyAndEnvironmentSubstitutor(true);
+    final int length = input.length();
+    assertThatCode(() -> substitutor.substitute(builder, 0, length))
+        .isInstanceOf(UndefinedEnvironmentVariableException.class);
+  }
+
+  @Test
+  void shouldNotThrowExceptionIfNotStrict() {
+    final String input = "this is a ${UNKNOWN_PROPERTY}";
+    final TextStringBuilder builder = new TextStringBuilder(input);
+    final SystemPropertyAndEnvironmentSubstitutor substitutor =
+        new SystemPropertyAndEnvironmentSubstitutor(false);
+    final int length = input.length();
+    assertThatCode(() -> substitutor.substitute(builder, 0, length)).doesNotThrowAnyException();
+  }
+}

--- a/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
+++ b/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
@@ -13,6 +13,7 @@ import io.jaegertracing.Configuration.SamplerConfiguration;
 import io.opentracing.Tracer;
 import io.opentracing.util.GlobalTracer;
 import io.opentracing.util.GlobalTracerTestUtil;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 import org.sdase.commons.server.jaeger.metrics.PrometheusMetricsFactory;
 
 /**
@@ -93,6 +94,6 @@ public class JaegerBundle implements ConfiguredBundle<io.dropwizard.Configuratio
   }
 
   private static String getProperty(String name) {
-    return System.getProperty(name, System.getenv(name));
+    return new SystemPropertyAndEnvironmentLookup().lookup(name);
   }
 }

--- a/sda-commons-server-kafka-testing/src/main/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRule.java
+++ b/sda-commons-server-kafka-testing/src/main/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRule.java
@@ -8,7 +8,6 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.sdase.commons.server.testing.Environment;
 
 /**
  * Rule for setting the Environment Variable `BROKER_CONNECTION_STRING`
@@ -36,7 +35,7 @@ public class KafkaBrokerEnvironmentRule implements TestRule, KafkaBrokerRule {
                 new Statement() {
                   @Override
                   public void evaluate() throws Throwable {
-                    Environment.setEnv(
+                    System.setProperty(
                         CONNECTION_STRING_ENV,
                         String.format(
                             "[ %s ]",
@@ -46,7 +45,7 @@ public class KafkaBrokerEnvironmentRule implements TestRule, KafkaBrokerRule {
                     try {
                       base1.evaluate();
                     } finally {
-                      Environment.unsetEnv(CONNECTION_STRING_ENV);
+                      System.clearProperty(CONNECTION_STRING_ENV);
                     }
                   }
                 })

--- a/sda-commons-server-kafka-testing/src/test/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRuleTest.java
+++ b/sda-commons-server-kafka-testing/src/test/java/org/sdase/commons/server/kafka/confluent/testing/KafkaBrokerEnvironmentRuleTest.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 
 public class KafkaBrokerEnvironmentRuleTest {
 
@@ -24,7 +25,9 @@ public class KafkaBrokerEnvironmentRuleTest {
                 .map(b -> "\"" + b.getConnectString() + "\"")
                 .collect(Collectors.joining(", "))
             + " ]";
-    Assertions.assertThat(System.getenv(KafkaBrokerEnvironmentRule.CONNECTION_STRING_ENV))
+    Assertions.assertThat(
+            new SystemPropertyAndEnvironmentLookup()
+                .lookup(KafkaBrokerEnvironmentRule.CONNECTION_STRING_ENV))
         .isEqualTo(compare);
   }
 }

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.SystemUtils;
 import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.Document;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,7 +40,7 @@ public interface MongoDb {
    * href="https://docs.mongodb.com/manual/reference/connection-string/">MongoDB Connection
    * String</a> of the database used in tests instead of starting a dedicated instance.
    */
-  String OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME = "TEST_MONGODB_CONNECTION_STRING";
+  String OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME = "TEST_MONGODB_CONNECTION_STRING";
 
   /**
    * @return the hostname and port that can be used to connect to the database. The result may
@@ -115,7 +116,8 @@ public interface MongoDb {
     private static final Logger LOG = LoggerFactory.getLogger(Builder.class);
 
     protected String mongoDbUrlOverride =
-        System.getenv(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
+        new SystemPropertyAndEnvironmentLookup()
+            .lookup(OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME);
 
     protected IFeatureAwareVersion version;
     protected Long timeoutInMillis;

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtil.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtil.java
@@ -12,6 +12,7 @@ import java.net.MalformedURLException;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.Optional;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,8 @@ public class DownloadConfigFactoryUtil {
     //
     // Optional it is possible to download it from a source configured in
     // the environment variable:
-    String embeddedMongoDownloadPath = System.getenv(EMBEDDED_MONGO_DOWNLOAD_PATH_ENV_NAME);
+    String embeddedMongoDownloadPath =
+        new SystemPropertyAndEnvironmentLookup().lookup(EMBEDDED_MONGO_DOWNLOAD_PATH_ENV_NAME);
 
     if (embeddedMongoDownloadPath != null) {
       downloadConfigBuilder.downloadPath(
@@ -57,7 +59,7 @@ public class DownloadConfigFactoryUtil {
   }
 
   private static Optional<ProxyFactory> createProxyFactory() {
-    String httpProxy = System.getenv(PROXY_ENV_NAME);
+    String httpProxy = new SystemPropertyAndEnvironmentLookup().lookup(PROXY_ENV_NAME);
     if (httpProxy != null) {
       try {
         URL url = new URL(httpProxy);

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbRuleTest.java
@@ -6,15 +6,17 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class MongoDbRuleTest {
 
   @Test
   public void shouldUseExistingMongoDb() throws Throwable {
     AtomicReference<MongoDbRule> actualRule = new AtomicReference<>();
-    new EnvironmentRule()
-        .setEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME, "mongodb://localhost")
+    new SystemPropertyRule()
+        .setProperty(
+            MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME,
+            "mongodb://localhost")
         .apply(
             new Statement() {
               @Override
@@ -30,8 +32,8 @@ public class MongoDbRuleTest {
   @Test
   public void shouldStartLocalMongoDb() throws Throwable {
     AtomicReference<MongoDbRule> actualRule = new AtomicReference<>();
-    new EnvironmentRule()
-        .unsetEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME)
+    new SystemPropertyRule()
+        .unsetProperty(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME)
         .apply(
             new Statement() {
               @Override

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbRuleTest.java
@@ -19,7 +19,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class StartLocalMongoDbRuleTest {
 
@@ -30,8 +30,9 @@ public class StartLocalMongoDbRuleTest {
   private static MongoDbRule RULE;
 
   @ClassRule
-  public static final EnvironmentRule ENV =
-      new EnvironmentRule().unsetEnv(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
+  public static final SystemPropertyRule ENV =
+      new SystemPropertyRule()
+          .unsetProperty(MongoDbRule.OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME);
 
   @BeforeClass
   public static void initRule() {

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbClassExtensionTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbClassExtensionTest.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.mongo.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sdase.commons.server.mongo.testing.MongoDbClassExtension.OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME;
+import static org.sdase.commons.server.mongo.testing.MongoDbClassExtension.OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME;
 
 import com.mongodb.MongoClient;
 import com.mongodb.client.FindIterable;
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.sdase.commons.server.testing.Environment;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 
 class UseExistingMongoDbClassExtensionTest {
 
@@ -41,8 +41,10 @@ class UseExistingMongoDbClassExtensionTest {
             + "?"
             + EXTERNAL_DB.getOptions();
     originalMongoDbConnectionString =
-        System.getenv().get(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
-    Environment.setEnv(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME, MONGODB_CONNECTION_STRING);
+        new SystemPropertyAndEnvironmentLookup()
+            .lookup(OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME);
+    System.setProperty(
+        OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME, MONGODB_CONNECTION_STRING);
 
     useExistingMongoDbClassExtension =
         MongoDbClassExtension.builder()
@@ -63,10 +65,10 @@ class UseExistingMongoDbClassExtensionTest {
   @AfterEach
   public void clearDatabase() {
     useExistingMongoDbClassExtension.clearDatabase();
-    Environment.unsetEnv(OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME);
+    System.clearProperty(OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME);
     if (StringUtils.isNotBlank(originalMongoDbConnectionString)) {
-      Environment.setEnv(
-          OVERRIDE_MONGODB_CONNECTION_STRING_ENV_NAME, originalMongoDbConnectionString);
+      System.setProperty(
+          OVERRIDE_MONGODB_CONNECTION_STRING_SYSTEM_PROPERTY_NAME, originalMongoDbConnectionString);
     }
   }
 

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDbRuleTest.java
@@ -12,7 +12,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class UseExistingMongoDbRuleTest {
 
@@ -24,15 +24,15 @@ public class UseExistingMongoDbRuleTest {
           .withPassword("testpassword")
           .build();
 
-  private static EnvironmentRule ENV;
+  private static SystemPropertyRule SYSTEM_PROPERTY_RULE;
 
   private MongoDbRule useExistingMongoDbRule;
 
   @BeforeClass
   public static void initEnvAfterStartOfExternalDb() {
-    ENV =
-        new EnvironmentRule()
-            .setEnv(
+    SYSTEM_PROPERTY_RULE =
+        new SystemPropertyRule()
+            .setProperty(
                 "TEST_MONGODB_CONNECTION_STRING",
                 "mongodb://"
                     + EXTERNAL_DB.getUsername()
@@ -48,7 +48,8 @@ public class UseExistingMongoDbRuleTest {
 
   @Before
   public void initUseExistingMongoDbRule() throws Throwable {
-    ENV.apply(
+    SYSTEM_PROPERTY_RULE
+        .apply(
             new Statement() {
               @Override
               public void evaluate() {

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtilTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/internal/DownloadConfigFactoryUtilTest.java
@@ -12,15 +12,15 @@ import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.sdase.commons.server.mongo.testing.MongoDbRule;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class DownloadConfigFactoryUtilTest {
 
   @Test
   public void shouldCreateWithFixedDownloadPath() throws Throwable {
     AtomicReference<DownloadConfig> actualConfig = new AtomicReference<>();
-    new EnvironmentRule()
-        .setEnv("EMBEDDED_MONGO_DOWNLOAD_PATH", "http://localhost/mongo.tar.gz")
+    new SystemPropertyRule()
+        .setProperty("EMBEDDED_MONGO_DOWNLOAD_PATH", "http://localhost/mongo.tar.gz")
         .apply(
             new Statement() {
               @Override
@@ -41,8 +41,8 @@ public class DownloadConfigFactoryUtilTest {
   @Test
   public void shouldCreateProxyWithAuthentication() throws Throwable {
     AtomicReference<DownloadConfig> actualConfig = new AtomicReference<>();
-    new EnvironmentRule()
-        .setEnv("http_proxy", "http://tester:dummy@the-test-domain.example.com:1234")
+    new SystemPropertyRule()
+        .setProperty("http_proxy", "http://tester:dummy@the-test-domain.example.com:1234")
         .apply(
             new Statement() {
               @Override

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/AppStartProhibitedIT.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/AppStartProhibitedIT.java
@@ -19,23 +19,23 @@ import org.junit.runners.Parameterized.Parameters;
 import org.junit.runners.model.Statement;
 import org.sdase.commons.server.security.exception.InsecureConfigurationException;
 import org.sdase.commons.server.security.test.SecurityTestApp;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 /** Tests that the app is not started with insecure configuration. */
 @RunWith(Parameterized.class)
 public class AppStartProhibitedIT {
 
-  private EnvironmentRule env;
+  private SystemPropertyRule env;
   private Class<? extends Throwable> expectedException;
 
   public AppStartProhibitedIT(
       String givenEnvKey,
       String givenEnvValue,
       Class<? extends Throwable> expectedException,
-      Map<String, String> additionalEnvironmentProperties) {
-    this.env = new EnvironmentRule().setEnv(givenEnvKey, givenEnvValue);
-    if (additionalEnvironmentProperties != null) {
-      additionalEnvironmentProperties.forEach(env::setEnv);
+      Map<String, String> additionalSystemProperties) {
+    this.env = new SystemPropertyRule().setProperty(givenEnvKey, givenEnvValue);
+    if (additionalSystemProperties != null) {
+      additionalSystemProperties.forEach(env::setProperty);
     }
     this.expectedException = expectedException;
   }

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/test/SecurityTestApp.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/test/SecurityTestApp.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.sdase.commons.server.dropwizard.bundles.ConfigurationSubstitutionBundle;
+import org.sdase.commons.server.dropwizard.bundles.SystemPropertyAndEnvironmentLookup;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.server.security.SecurityBundle;
 
@@ -25,14 +26,15 @@ public class SecurityTestApp extends Application<Configuration> {
 
   @Override
   public void initialize(Bootstrap<Configuration> bootstrap) {
+    SystemPropertyAndEnvironmentLookup lookup = new SystemPropertyAndEnvironmentLookup();
     bootstrap.addBundle(
         ConfigurationSubstitutionBundle.builder().build()); // needed to update the config in tests
-    if (!"true".equals(System.getenv("DISABLE_BUFFER_CHECK"))) {
+    if (!"true".equals(lookup.lookup("DISABLE_BUFFER_CHECK"))) {
       bootstrap.addBundle(SecurityBundle.builder().build());
     } else {
       bootstrap.addBundle(SecurityBundle.builder().disableBufferLimitValidation().build());
     }
-    if (!"true".equals(System.getenv("DISABLE_JACKSON_CONFIGURATION"))) {
+    if (!"true".equals(lookup.lookup("DISABLE_JACKSON_CONFIGURATION"))) {
       bootstrap.addBundle(
           JacksonConfigurationBundle.builder().build()); // enables custom error handlers
     }

--- a/sda-commons-server-testing/README.md
+++ b/sda-commons-server-testing/README.md
@@ -60,8 +60,22 @@ content should always be reproducible. Note that the [AsyncAPI](../sda-commons-s
 
 ### EnvironmentRule
 
-The [`EnvironmentRule`](./src/main/java/org/sdase/commons/server/testing/EnvironmentRule.java) allows to override or
-unset environment variables in test cases and resets them to the state before the test after the test finished.
+The [`EnvironmentRule`](./src/main/java/org/sdase/commons/server/testing/EnvironmentRule.java) 
+allows to override or unset environment variables in test cases and resets them to the state before 
+the test after the test finished.
+
+**WARNING**
+
+Java considers environment variables to be immutable, so this extension uses reflection to change 
+them. This requires that the SecurityManager allows modifications and can potentially break on 
+different operating systems and Java versions. Be aware that this is a fragile solution and consider
+finding a better one for your specific situation.
+
+Most of the time using the `SystemPropertyRule` should also work for you since our Dropwizard setup
+supports looking up environment variables AND system properties when replacing variables in your
+configuration file.
+
+#### Example
 
 ```java
 public class CustomIT {
@@ -152,8 +166,10 @@ static final SystemPropertyClassExtension PROP =
 
 Set and overwritten values will be reset to their original value once the test has finished.
 
-## JUnit 5
+### JUnit Pioneer
+
 For JUnit 5 we will not supply a replacement for the `EnvironmentRule` and `DropwizardRuleHelper`. 
 
-* The `EnvironmentRule` can be replaced with [JUnit Pioneer](https://junit-pioneer.org/docs/environment-variables/) capabilities.
+* The `EnvironmentRule` can be replaced with [JUnit Pioneer](https://junit-pioneer.org/docs/environment-variables/) 
+  capabilities. **Anyway please read the warning above for overriding environment variables.** 
 * Use `DropwizardAppExtension` directly as a replacement for the `DropwizardRuleHelper`.

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/Environment.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/Environment.java
@@ -3,7 +3,13 @@ package org.sdase.commons.server.testing;
 import java.lang.reflect.Field;
 import java.util.Map;
 
-/** To be used with {@link EnvironmentRule} */
+/**
+ * To be used with {@link EnvironmentRule}
+ *
+ * @deprecated Java 17 will make it very cumbersome using environment variables; try to use system
+ *     properties instead
+ */
+@Deprecated
 public final class Environment {
 
   private Environment() {

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/EnvironmentRule.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/EnvironmentRule.java
@@ -18,7 +18,11 @@ import org.junit.runners.model.Statement;
  *     &#64;ClassRule public static final ENV = new EnvironmentRule().setEnv("DISABLE_JWT", "true");
  *   }
  * </pre>
+ *
+ * @deprecated changing environment variables is not easily supported in Java 17; please consider
+ *     using {@link SystemPropertyRule} instead
  */
+@Deprecated
 public class EnvironmentRule implements TestRule {
 
   private Map<String, Supplier<String>> envToSet = new HashMap<>();

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleTest.java
@@ -7,15 +7,15 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.dropwizard.test.DropwizardApp;
 import org.sdase.commons.server.dropwizard.test.DropwizardConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ConfigurationSubstitutionBundleTest {
 
   @ClassRule
-  public static final EnvironmentRule ENV =
-      new EnvironmentRule()
-          .setEnv("ENV_REPLACEMENT", "valueFromEnv")
-          .setEnv("EXAMPLE_SUFFIX", "hello");
+  public static final SystemPropertyRule ENV =
+      new SystemPropertyRule()
+          .setProperty("ENV_REPLACEMENT", "valueFromEnv")
+          .setProperty("EXAMPLE_SUFFIX", "hello");
 
   @ClassRule
   public static final DropwizardAppRule<DropwizardConfig> DW =

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithOptionalConfigAsJsonTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithOptionalConfigAsJsonTest.java
@@ -7,13 +7,14 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.dropwizard.test.DropwizardApp;
 import org.sdase.commons.server.dropwizard.test.DropwizardConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ConfigurationSubstitutionBundleWithOptionalConfigAsJsonTest {
 
   @ClassRule
-  public static final EnvironmentRule ENV =
-      new EnvironmentRule().setEnv("OPTIONAL_CONFIG", "{'property1':'juice', 'property2':'beer'}");
+  public static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule()
+          .setProperty("OPTIONAL_CONFIG", "{'property1':'juice', 'property2':'beer'}");
 
   @ClassRule
   public static final DropwizardAppRule<DropwizardConfig> DW =

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithOptionalConfigTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithOptionalConfigTest.java
@@ -7,13 +7,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.dropwizard.test.DropwizardApp;
 import org.sdase.commons.server.dropwizard.test.DropwizardConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ConfigurationSubstitutionBundleWithOptionalConfigTest {
 
   @ClassRule
-  public static final EnvironmentRule ENV =
-      new EnvironmentRule().setEnv("PROPERTY_ONE", "valueFromEnv");
+  public static final SystemPropertyRule SYSTEM_PROPERTY_RULE =
+      new SystemPropertyRule().setProperty("PROPERTY_ONE", "valueFromEnv");
 
   @ClassRule
   public static final DropwizardAppRule<DropwizardConfig> DW =

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithoutOptionalConfigTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/dropwizard/bundles/ConfigurationSubstitutionBundleWithoutOptionalConfigTest.java
@@ -7,12 +7,13 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.sdase.commons.server.dropwizard.test.DropwizardApp;
 import org.sdase.commons.server.dropwizard.test.DropwizardConfig;
-import org.sdase.commons.server.testing.EnvironmentRule;
+import org.sdase.commons.server.testing.SystemPropertyRule;
 
 public class ConfigurationSubstitutionBundleWithoutOptionalConfigTest {
 
   @ClassRule
-  public static final EnvironmentRule ENV = new EnvironmentRule().setEnv("OPTIONAL_CONFIG", "null");
+  public static final SystemPropertyRule ENV =
+      new SystemPropertyRule().setProperty("OPTIONAL_CONFIG", "null");
 
   @ClassRule
   public static final DropwizardAppRule<DropwizardConfig> DW =


### PR DESCRIPTION
Additionally, this helps moving on to Java 17 because changing environment variables is not really intended