### PR TITLE
docs: Deprecation for server-starter + server-swagger

### DIFF
--- a/sda-commons-server-starter/README.md
+++ b/sda-commons-server-starter/README.md
@@ -2,6 +2,11 @@
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-server-starter/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-server-starter)
 
+> #### ⚠️ Deprecated ⚠
+>
+> Please migrate to `sda-commons-starter`
+>
+
 The module `sda-commons-server-starter` provides all basics required to build a service for the SDA Platform with
 Dropwizard.
 

--- a/sda-commons-server-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java
+++ b/sda-commons-server-starter/src/main/java/org/sdase/commons/server/starter/SdaPlatformBundle.java
@@ -45,7 +45,10 @@ import org.sdase.commons.server.trace.TraceTokenBundle;
 /**
  * A {@link ConfiguredBundle} that configures the application with the basics required for a SDA
  * platform compatible microservice.
+ *
+ * @deprecated please migrate to sda-commons-starter's {@code SdaPlatformBundle}
  */
+@Deprecated
 public class SdaPlatformBundle<C extends Configuration> implements ConfiguredBundle<C> {
 
   private SecurityBundle.Builder securityBundleBuilder;

--- a/sda-commons-server-swagger/README.md
+++ b/sda-commons-server-swagger/README.md
@@ -2,6 +2,11 @@
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-server-swagger/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-server-swagger)
 
+> #### ⚠️ Deprecated ⚠
+>
+> Please migrate to `sda-commons-server-openapi`
+>
+
 The module `sda-commons-server-swagger` is the base module to add
 [Swagger](https://github.com/swagger-api/swagger-core) support for applications in the
 SDA SE infrastructure.

--- a/sda-commons-server-swagger/src/main/java/org/sdase/commons/server/swagger/SwaggerBundle.java
+++ b/sda-commons-server-swagger/src/main/java/org/sdase/commons/server/swagger/SwaggerBundle.java
@@ -82,7 +82,10 @@ import org.slf4j.LoggerFactory;
  *    }
  *  }
  * </pre>
+ *
+ * @deprecated please migrate to sda-commons-server-openapi's {@code OpenApiBundle}
  */
+@Deprecated
 public final class SwaggerBundle implements ConfiguredBundle<Configuration> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());

--- a/sda-commons-starter/README.md
+++ b/sda-commons-starter/README.md
@@ -2,11 +2,6 @@
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-starter/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-starter)
 
-> #### ⚠️ Experimental ⚠
->
-> Please be aware that this API is in an early stage and might change in the future.
->
-
 The module `sda-commons-starter` provides all basics required to build a service for the SDA Platform with
 Dropwizard.
 


### PR DESCRIPTION
Please use sda-commons-starter + sda-commons-server-openapi instead.