### PR TITLE
chore: Build with Eclipse Temurin instead of Adopt OpenJDK

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
           cache: 'gradle'
 
@@ -93,7 +93,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 

--- a/.github/workflows/publish-release-maven-central.yml
+++ b/.github/workflows/publish-release-maven-central.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/publish-release-sda.yml
+++ b/.github/workflows/publish-release-sda.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/pull-request-snapshots.yml
+++ b/.github/workflows/pull-request-snapshots.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up JDK 1.8
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 8
           cache: 'gradle'
 

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 


### PR DESCRIPTION
Adopt OpenJDK is discontinued and will not get further updates.