### PR TITLE
chore: Remove most of the references to Google's Guava library 

### DIFF
--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaIT.java
@@ -2,6 +2,8 @@ package org.sdase.commons.server.opa.testing;
 
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,7 +11,6 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.sdase.commons.server.opa.testing.OpaRule.onAnyRequest;
 import static org.sdase.commons.server.opa.testing.OpaRule.onRequest;
 
-import com.google.common.collect.Lists;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -85,9 +86,7 @@ public class OpaIT {
     PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
 
     assertThat(principalInfo.getConstraints().getConstraint())
-        .contains(
-            entry("customer_ids", Lists.newArrayList("1", "2")),
-            entry("agent_ids", Lists.newArrayList("A1")));
+        .contains(entry("customer_ids", asList("1", "2")), entry("agent_ids", singletonList("A1")));
     assertThat(principalInfo.getConstraints().isFullAccess()).isFalse();
     assertThat(principalInfo.getJwt()).isNull();
   }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
@@ -6,12 +6,13 @@ import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.dropwizard.testing.ConfigOverride.config;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import com.google.common.collect.Lists;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import javax.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
@@ -116,9 +117,7 @@ public class OpaResponsesIT {
     PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
 
     assertThat(principalInfo.getConstraints().getConstraint())
-        .contains(
-            entry("customer_ids", Lists.newArrayList("1", "2")),
-            entry("agent_ids", Lists.newArrayList("A1")));
+        .contains(entry("customer_ids", asList("1", "2")), entry("agent_ids", singletonList("A1")));
     assertThat(principalInfo.getConstraints().isFullAccess()).isTrue();
     assertThat(principalInfo.getJwt()).isNull();
   }

--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/OpaBundle.java
@@ -1,12 +1,11 @@
 package org.sdase.commons.server.opa;
 
+import static java.util.Collections.singletonList;
 import static org.sdase.commons.server.opentracing.client.ClientTracingUtil.registerTracing;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Lists;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.client.JerseyClientBuilder;
@@ -92,7 +91,12 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
     return new Builder<>();
   }
 
-  @VisibleForTesting
+  /**
+   * VisibleForTesting
+   *
+   * @deprecated This method will not be publicly visible anymore; please remove any references
+   */
+  @Deprecated
   @SuppressWarnings("java:S1452") // allow generic wildcard type
   public Map<String, OpaInputExtension<?>> getInputExtensions() {
     return inputExtensions;
@@ -202,7 +206,7 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
   }
 
   private List<String> getSwaggerExcludePatterns() {
-    return Lists.newArrayList("swagger\\.(json|yaml)");
+    return singletonList("swagger\\.(json|yaml)");
   }
 
   private boolean excludeSwagger() {
@@ -218,7 +222,7 @@ public class OpaBundle<T extends Configuration> implements ConfiguredBundle<T> {
   }
 
   private List<String> getOpenApiExcludePatterns() {
-    return Lists.newArrayList("openapi\\.(json|yaml)");
+    return singletonList("openapi\\.(json|yaml)");
   }
 
   private boolean excludeOpenApi() {

--- a/sda-commons-server-hibernate/src/main/java/org/sdase/commons/server/hibernate/NonScanningHibernateBundle.java
+++ b/sda-commons-server-hibernate/src/main/java/org/sdase/commons/server/hibernate/NonScanningHibernateBundle.java
@@ -1,9 +1,9 @@
 package org.sdase.commons.server.hibernate;
 
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.hibernate.HibernateBundle;
 import io.dropwizard.hibernate.SessionFactoryFactory;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -17,8 +17,6 @@ public abstract class NonScanningHibernateBundle<T extends Configuration>
 
   public NonScanningHibernateBundle(
       List<Class<?>> entities, SessionFactoryFactory sessionFactoryFactory) {
-    super(
-        new ImmutableList.Builder<Class<?>>().addAll(entities.iterator()).build(),
-        sessionFactoryFactory);
+    super(new ArrayList<>(entities), sessionFactoryFactory);
   }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.kafka;
 
-import com.google.common.base.Strings;
 import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -75,7 +75,7 @@ public class KafkaProperties extends Properties {
     if (configuration.getAdminConfig() == null
         || configuration.getAdminConfig().getAdminEndpoint() == null
         || configuration.getAdminConfig().getAdminEndpoint().isEmpty()
-        || Strings.isNullOrEmpty(
+        || StringUtils.isBlank(
             String.join(",", configuration.getAdminConfig().getAdminEndpoint()))) {
       props = baseProperties(configuration);
       return props;

--- a/sda-commons-server-opentracing-example/src/main/java/org/sdase/commons/server/opentracing/example/OpenTracingApplication.java
+++ b/sda-commons-server-opentracing-example/src/main/java/org/sdase/commons/server/opentracing/example/OpenTracingApplication.java
@@ -1,6 +1,5 @@
 package org.sdase.commons.server.opentracing.example;
 
-import com.google.common.collect.ImmutableMap;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
@@ -10,6 +9,8 @@ import io.opentracing.Span;
 import io.opentracing.log.Fields;
 import io.opentracing.tag.Tags;
 import io.opentracing.util.GlobalTracer;
+import java.util.HashMap;
+import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.Path;
@@ -154,9 +155,12 @@ public class OpenTracingApplication extends Application<Configuration> {
       // guidance for common tags and logs:
       // https://github.com/opentracing/specification/blob/master/semantic_conventions.md
       Tags.ERROR.set(span, true);
-      span.log(
-          ImmutableMap.of(
-              Fields.EVENT, "error", Fields.ERROR_OBJECT, ex, Fields.MESSAGE, ex.getMessage()));
+
+      Map<String, Object> log = new HashMap<>();
+      log.put(Fields.EVENT, "error");
+      log.put(Fields.ERROR_OBJECT, ex);
+      log.put(Fields.MESSAGE, ex.getMessage());
+      span.log(log);
     } finally {
       // Don't forget to finish your spans!
       span.finish();

--- a/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/tags/TagUtilsTest.java
+++ b/sda-commons-server-opentracing/src/test/java/org/sdase/commons/server/opentracing/tags/TagUtilsTest.java
@@ -1,6 +1,5 @@
 package org.sdase.commons.server.opentracing.tags;
 
-import static com.google.common.net.HttpHeaders.TRANSFER_ENCODING;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
@@ -31,7 +30,7 @@ public class TagUtilsTest {
   public void shouldConvertMultipleHeadersToString() {
     MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
     headers.put(LOCATION, singletonList("1"));
-    headers.put(TRANSFER_ENCODING, singletonList("2"));
+    headers.put("Transfer-Encoding", singletonList("2"));
 
     String tag = convertHeadersToString(headers);
 

--- a/sda-commons-server-swagger/src/main/java/org/sdase/commons/server/swagger/SwaggerBundle.java
+++ b/sda-commons-server-swagger/src/main/java/org/sdase/commons/server/swagger/SwaggerBundle.java
@@ -1,12 +1,10 @@
 package org.sdase.commons.server.swagger;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.swagger.jaxrs.config.SwaggerContextService.*;
 import static java.lang.String.join;
 import static java.util.Objects.requireNonNull;
 import static org.apache.commons.lang3.Validate.notBlank;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.server.AbstractServerFactory;
@@ -161,12 +159,12 @@ public final class SwaggerBundle implements ConfiguredBundle<Configuration> {
         beanConfig.getResourcePackage());
   }
 
-  @VisibleForTesting
+  /** VisibleForTesting */
   String getResourcePackages() {
     return resourcePackages;
   }
 
-  @VisibleForTesting
+  /** VisibleForTesting */
   BeanConfig getBeanConfig() {
     return beanConfig;
   }
@@ -480,7 +478,7 @@ public final class SwaggerBundle implements ConfiguredBundle<Configuration> {
       Info info = new Info();
 
       info.setTitle(title);
-      info.setVersion(firstNonNull(version, DEFAULT_VERSION));
+      info.setVersion(version != null ? version : DEFAULT_VERSION);
       info.setDescription(description);
       info.setTermsOfService(termsOfServiceUrl);
       info.setContact(contact);

--- a/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/test/util/BarSupplier.java
+++ b/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/test/util/BarSupplier.java
@@ -1,6 +1,6 @@
 package org.sdase.commons.server.weld.testing.test.util;
 
-import com.google.common.base.Supplier;
+import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Named;
 


### PR DESCRIPTION
Only one reference left where I could not find an easy replacement:
https://github.com/SDA-SE/sda-dropwizard-commons/blob/5bc5822ddcfd7bac22c953be3dba08adfe0c3783/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/errors/JerseyValidationExceptionMapper.java#L5