### PR TITLE
Verify that UTF-8 characters are returned for openapi.yaml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,6 +175,10 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
 
   sourceCompatibility = JavaVersion.VERSION_1_8
 
+  tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+  }
+
   // Configure JaCoCo to export the reports in XML format
   jacocoTestReport {
     reports {

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleFileIT.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleFileIT.java
@@ -9,6 +9,7 @@ import static org.eclipse.jetty.http.HttpStatus.OK_200;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import java.nio.charset.StandardCharsets;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -68,6 +69,20 @@ public class OpenApiBundleFileIT {
       assertThat(response.getMediaType()).isEqualTo(MediaType.valueOf("application/yaml"));
 
       OpenApiAssertions.assertValid(response);
+    }
+  }
+
+  @Test
+  @Retry(5)
+  public void shouldProvideYamlInUtf8() {
+    try (Response response = getYamlRequest().get()) {
+      assertThat(response.getStatus()).isEqualTo(OK_200);
+      assertThat(response.getMediaType()).isEqualTo(MediaType.valueOf("application/yaml"));
+
+      byte[] bytes = response.readEntity(byte[].class);
+      String content = new String(bytes, StandardCharsets.UTF_8);
+
+      assertThat(content).contains("\u00f6");
     }
   }
 

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/NaturalPersonResource.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/NaturalPersonResource.java
@@ -20,7 +20,7 @@ public class NaturalPersonResource extends PartnerResource {
   @Schema(name = "firstName", example = "John")
   private final String firstName;
 
-  @Schema(name = "lastName", example = "Doe")
+  @Schema(name = "lastName", example = "Döe")
   private final String lastName;
 
   @ArraySchema(arraySchema = @Schema(name = "traits", example = "[\"hipster\", \"generous\"]"))

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/GoldenFileAssertions.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/GoldenFileAssertions.java
@@ -86,8 +86,9 @@ public class GoldenFileAssertions extends AbstractAssert<GoldenFileAssertions, P
 
       // assert normal text
       Assertions.assertThat(actual)
+          .content(StandardCharsets.UTF_8)
           .as(ASSERTION_TEXT, fileName, fileName, fileName)
-          .hasContent(expected);
+          .isEqualTo(expected);
 
     } finally {
       // always update the file content

--- a/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/GoldenFileAssertionsTest.java
+++ b/sda-commons-server-testing/src/test/java/org/sdase/commons/server/testing/GoldenFileAssertionsTest.java
@@ -124,7 +124,10 @@ public class GoldenFileAssertionsTest {
         .doesNotThrowAnyException();
 
     // content should still be expected-content
-    assertThat(path).hasContent("key0: v\nkey2:\n  nested2: \u00f6\n  nested1: a\nkey1: w");
+    assertThat(path)
+        .hasBinaryContent(
+            "key0: v\nkey2:\n  nested2: \u00f6\n  nested1: a\nkey1: w"
+                .getBytes(StandardCharsets.UTF_8));
   }
 
   @Test


### PR DESCRIPTION
There seems to be an issue with OpenAPI-Tests when run on windows regarding UTF-8 characters.

- This PR reproduces UTF-8 issues [in the Windows Build](https://github.com/SDA-SE/sda-dropwizard-commons/runs/4864579329?check_suite_focus=true#step:4:9500) 
- and introduces a fix by [defining the source encoding](https://github.com/SDA-SE/sda-dropwizard-commons/pull/1401/commits/34fd56c295ecec88e65390ecafc1ce8146319950).

To solve the issue, the encoding must be set in the `build.gradle` of each affected service. I think there is no way to provide the encoding setting for source code with sda-commons.