### PR TITLE
feat(server-mongo-testing): Make temp dir configurable for local deve…

### DIFF
--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDb.java
@@ -222,10 +222,10 @@ public class StartLocalMongoDb {
         artifactStoreBuilder
             .extraction(
                 DirectoryAndExecutableNaming.of(
-                    new PlatformTempDir(), (prefix, postfix) -> "mongod"))
+                    new PropertyOrPlatformTempDir(), (prefix, postfix) -> "mongod"))
             .temp(
                 DirectoryAndExecutableNaming.of(
-                    new PlatformTempDir(), (prefix, postfix) -> "mongod"));
+                    new PropertyOrPlatformTempDir(), (prefix, postfix) -> "mongod"));
       } else {
         artifactStoreBuilder.extraction(
             DirectoryAndExecutableNaming.builder()


### PR DESCRIPTION
…lopment

It enables building and testing your modules parallel with Gradle.
You need to set `de.flapdoodle.embed.io.tmpdir` to the project's build directory to separate Mongo binaries for your builds.

Really putting it into action by activating parallel builds depends on https://github.com/flapdoodle-oss/de.flapdoodle.embed.process/pull/130.