### PR TITLE
fix(server-openapi): Fix NPE in the log for lists of String

### DIFF
--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
@@ -115,6 +115,7 @@ public class EmbedParameterModifier implements ReaderListener {
 
             // get the model reference name
             .map(this::getOriginalRef)
+            .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
     // only when there is a single list entry that supports embedding

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/OpenApiBundleTestApp.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/OpenApiBundleTestApp.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -117,5 +119,23 @@ public class OpenApiBundleTestApp extends Application<Configuration>
               schema = @Schema(implementation = HouseSearchResource.class)))
   public HouseSearchResource searchHouse() {
     return new HouseSearchResource(Collections.emptyList(), 0);
+  }
+
+  @GET
+  @Path("/partners")
+  @Produces(APPLICATION_JSON)
+  @Operation()
+  @ApiResponse(
+      responseCode = "200",
+      description = "get",
+      content =
+          @Content(
+              mediaType = APPLICATION_JSON,
+              schema = @Schema(implementation = PartnerSearchResultResource.class)))
+  public PartnerSearchResultResource searchPartners() {
+    return new PartnerSearchResultResource()
+        .setPartners(Arrays.asList("one", "two"))
+        .setTimestamp(ZonedDateTime.now())
+        .setTotalResults(100);
   }
 }

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/PartnerSearchResultResource.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/PartnerSearchResultResource.java
@@ -1,0 +1,52 @@
+package org.sdase.commons.server.openapi.apps.test;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class PartnerSearchResultResource {
+
+  @Schema(
+      required = true,
+      description =
+          "The limiting timestamp until the consent has been selected by a user to be "
+              + "included in the search result.",
+      example = "2020-06-08T15:26:55Z")
+  private ZonedDateTime timestamp;
+
+  @Schema(
+      required = true,
+      description = "The number of total partner found for the request",
+      example = "123")
+  private long totalResults;
+
+  @Schema(description = "The list of all partners based on the query request.", required = true)
+  private List<String> partners;
+
+  public ZonedDateTime getTimestamp() {
+    return timestamp;
+  }
+
+  public PartnerSearchResultResource setTimestamp(ZonedDateTime timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+  public long getTotalResults() {
+    return totalResults;
+  }
+
+  public PartnerSearchResultResource setTotalResults(long totalResults) {
+    this.totalResults = totalResults;
+    return this;
+  }
+
+  public List<String> getPartners() {
+    return partners;
+  }
+
+  public PartnerSearchResultResource setPartners(List<String> partners) {
+    this.partners = partners;
+    return this;
+  }
+}


### PR DESCRIPTION
The error occurred under certain conditions when using the `Schema` annotation for a list of `String`. E.g.

```
  @Schema(description = "The list of all partners based on the query request.", required = true)
  private List<String> partners;
```
