### PR TITLE
feat(deps): bump MongoDB version to 4.4.x for all environments

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -25,13 +25,13 @@ jobs:
           cache: 'gradle'
 
       - name: Start MongoDB
-        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:4.0
+        run: docker run -d -e MONGO_INITDB_ROOT_USERNAME=test -e MONGO_INITDB_ROOT_PASSWORD=example -p 27017:27017 --name test_mongo mongo:4.4
 
       - name: Test with Gradle
         run: ./gradlew :sda-commons-server-morphia-example:test
 
       - name: Assert use of MongoDB
-        run: "docker logs test_mongo | grep -F 'build index on: testdb.'"
+        run: "docker logs test_mongo | grep -F 'createCollection' | grep -F 'testdb.'"
 
       - name: Stop MongoDB
         run: docker stop test_mongo

--- a/sda-commons-server-mongo-testing/README.md
+++ b/sda-commons-server-mongo-testing/README.md
@@ -60,7 +60,7 @@ database using the `MongoClient`.
 
 
 ### JUnit 5
-This module provides the [`MongoDbExtension`](src/main/java/org/sdase/commons/server/mongo/testing/MongoDbExtension.java),
+This module provides the [`MongoDbClassExtension`](src/main/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtension.java),
 a JUnit 5 test extension that is used to automatically bootstrap a MongoDB instance for integration tests.
 
 This is accomplished using [Flapdoodle embedded MongoDB](https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo),
@@ -119,18 +119,12 @@ By default, scripting using JavaScript is disabled.
 You should avoid using it, as it can cause security issues.
 If you still need to use it, activate it using the build `enableScripting()`.
 
-### Operating Systems and MongoDB versions
+### MongoDB version
 
-Flapdoodles embedded MongoDB version < 4.x may result in
-`java.lang.IllegalStateException: java.io.IOException: Could not start process: <EOF>` during start-up
-of a MongoDB server instance. Therefore the operating system is determined and the default MongoDB
-version is set.
-
-On Windows systems the version will be set to 4.x and on all other system it will be
-3.6.x. If one needs a specific version the version can be set like this `MongoDbRule.builder().withVersion(specificMongoDbVersion).build()` or
+Flapdoodles embedded MongoDB version is set to 4.4.x by default.
+If one needs a specific version the version can be set like this
+`MongoDbRule.builder().withVersion(specificMongoDbVersion).build()` or
 `MongoDbClassExtension.builder().withVersion(specificMongoDbVersion).build()`.
-
-This is a temporary solution until all systems run on MongoDB >= version 4.x.
 
 ### Configuration in a special CI-environment
 

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDb.java
@@ -1,7 +1,6 @@
 package org.sdase.commons.server.mongo.testing;
 
-import static de.flapdoodle.embed.mongo.distribution.Version.Main.V3_6;
-import static de.flapdoodle.embed.mongo.distribution.Version.Main.V4_0;
+import static de.flapdoodle.embed.mongo.distribution.Version.Main.V4_4;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 import com.mongodb.MongoClient;
@@ -104,8 +103,8 @@ public interface MongoDb {
 
   abstract class Builder<T extends MongoDb> {
 
-    public static final Version.Main DEFAULT_VERSION = V3_6;
-    public static final Version.Main WINDOWS_VERSION = V4_0;
+    public static final Version.Main DEFAULT_VERSION = V4_4;
+    public static final Version.Main WINDOWS_VERSION = DEFAULT_VERSION;
 
     protected static final long DEFAULT_TIMEOUT_MS = MINUTES.toMillis(1L);
 

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbVersionTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbVersionTest.java
@@ -50,14 +50,8 @@ public class MongoDbVersionTest {
     MongoDbRule mongoDbRule = MongoDbRule.builder().build();
     if (SystemUtils.IS_OS_WINDOWS) {
       assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
     } else {
       assertThat(mongoDbRule).extracting("version").isEqualTo(MongoDbRule.Builder.DEFAULT_VERSION);
-      assertThat(mongoDbRule)
-          .extracting("version")
-          .isNotEqualTo(MongoDbRule.Builder.WINDOWS_VERSION);
     }
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbClassExtensionTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbClassExtensionTest.java
@@ -170,16 +170,10 @@ class StartLocalMongoDbClassExtensionTest {
       assertThat(mongoDbClassExtension)
           .extracting("version")
           .isEqualTo(MongoDbClassExtension.Builder.WINDOWS_VERSION);
-      assertThat(mongoDbClassExtension)
-          .extracting("version")
-          .isNotEqualTo(MongoDbClassExtension.Builder.DEFAULT_VERSION);
     } else {
       assertThat(mongoDbClassExtension)
           .extracting("version")
           .isEqualTo(MongoDbClassExtension.Builder.DEFAULT_VERSION);
-      assertThat(mongoDbClassExtension)
-          .extracting("version")
-          .isNotEqualTo(MongoDbClassExtension.Builder.WINDOWS_VERSION);
     }
   }
 }


### PR DESCRIPTION
All MongoDB tests use a MongoDB 4.4.x by default now.
In case of issues, the version can be downgraded in the test by configuration temporarily:
`MongoDbClassExtension.builder().withVersion(specificMongoDbVersion).build()`.
In the midterm, the code should be fixed to be compatible with MongoDB 4.4.