### PR TITLE
fix(deps): Upgrade Jackson to 2.13.2

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -21,11 +21,13 @@ ext {
   dbRiderVersion = '1.32.3'
   kotlinVersion = '1.6.10'
   kotlinxCoroutinesVersion = '1.6.0'
+  jacksonVersion = '2.13.2'
 }
 
 dependencies {
-  api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:${kotlinVersion}") // override version from dropwizard-bom
-  api enforcedPlatform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:${kotlinxCoroutinesVersion}")
+  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion") // override version from dropwizard-bom
+  api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion") // override version from dropwizard-bom
+  api enforcedPlatform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$kotlinxCoroutinesVersion")
   api enforcedPlatform("io.dropwizard:dropwizard-bom:$dropwizardVersion")
   api enforcedPlatform("io.dropwizard:dropwizard-dependencies:$dropwizardVersion")
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.12.181")


### PR DESCRIPTION
Overriding Dropwizard's version 2.10.x

Upgrade is related to https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

According to comments of issue at Jackson Databind the upgrade does **not** fix the CVE.
https://github.com/FasterXML/jackson-databind/issues/2816