### PR TITLE
fix(deps): bump jackson-databind to 2.13.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ plugins {
   id 'org.sonarqube' version '3.3'
   id 'com.diffplug.spotless' version '6.4.1'
   id 'io.codearte.nexus-staging' version '0.30.0'
+  id 'project-report'
 }
 
 allprojects {
@@ -49,12 +50,19 @@ subprojects {
   apply plugin: 'maven-publish'
   apply plugin: 'com.diffplug.spotless'
   apply plugin: 'signing'
+  apply plugin: 'project-report'
 
   group 'org.sdase.commons'
 
   repositories {
     mavenCentral()
   }
+
+  // create file that includes all dependencies in "build/deps"
+  task allDeps(type: DependencyReportTask) {
+    outputFile(new File("${rootProject.buildDir}/deps", "${project.name}.txt"))
+  }
+  check.dependsOn allDeps
 
   // Disable publication of Gradle Module Metadata
   tasks.withType(GenerateModuleMetadata) {
@@ -213,13 +221,6 @@ configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
     all*.exclude group: 'commons-logging', module: 'commons-logging' // prefer jcl-over-slf4j
   }
 
-  configurations.all {
-    resolutionStrategy {
-      // fail eagerly on version conflict (includes transitive dependencies)
-      // e.g. multiple different versions of the same dependency (group and name are equal)
-      failOnVersionConflict()
-    }
-  }
   test {
     useJUnitPlatform()
   }
@@ -346,3 +347,5 @@ sonarqube {
 
   }
 }
+
+apply from: 'failOnVersionConflict.gradle'

--- a/failOnVersionConflict.gradle
+++ b/failOnVersionConflict.gradle
@@ -1,0 +1,137 @@
+/**
+ * This task will parse all dependency files in 'build/deps' and tries to find version conflicts.
+ * Our assumption is: Version should be aligned by enforcing versions from our platform module
+ * 'sda-commons-dependencies'. We don't care if we find different versions as long as Gradle is
+ * able to choose the right version from 'sda-commons-dependencies'.
+ */
+task failOnVersionConflict {
+  doLast {
+    // Only these scopes will be considered
+    var relevantScopes = new HashSet<String>(
+        Arrays.asList("api",
+        "compileClasspath",
+        "compileOnly",
+        "compileOnlyApi",
+        "implementation",
+        "runtimeClasspath",
+        "testCompileClasspath",
+        "testCompileOnly",
+        "testImplementation",
+        "testRuntimeClasspath",
+        "testRuntimeOnly",
+        ))
+
+    // Add some dependencies that can be ignored
+    var ignoredDuplicates = new HashSet<String>(
+        Arrays.asList("io.openapitools.hal:swagger-hal")
+        )
+
+    var baseDir = new File("${rootProject.buildDir}/deps")
+    var deps = new HashMap<String, String>();
+    for (file in baseDir.listFiles()) {
+      // var listFilesMock = List.of(new File("${rootProject.buildDir}/deps", "sda-commons-starter.txt"))
+      // for (file in listFilesMock) {
+      logger.info("File: $file")
+      var currentConfig = null;
+      var skip = true
+      file.eachLine {
+
+        // Check if a new scope is declared, e.g.
+        // runtimeClasspath - Runtime classpath of source set 'main'.
+        if (it.matches("^[a-z].*")) {
+          currentConfig = it.takeBefore(" ")
+          logger.debug("Found config: $currentConfig")
+          skip = !relevantScopes.contains(currentConfig)
+        }
+
+        if (skip) {
+          return
+        }
+
+        // Start parsing the file content
+        String line = null
+        if (it.contains("+--- ")) {
+          line = it.takeAfter("+--- ")
+        }
+        else if (it.contains("\\---")) {
+          line = it.takeAfter("\\--- ")
+        }
+        if (line != null) {
+          // ignore dependencies to other subprojects
+          if (line.startsWith("project")) {
+            return
+          }
+
+          // Extract groupId / artifactId / version
+          logger.debug("Line: $line")
+          var indexOfFirstColon = line.indexOf(':');
+          var groupId = line.substring(0, indexOfFirstColon)
+          var artifactId = line.substring(indexOfFirstColon + 1)
+          var version = null;
+          if (artifactId.contains(" -> ")) {
+            var oldArtifactId = artifactId
+            artifactId = oldArtifactId.takeBefore(' -> ')
+            version = oldArtifactId.takeAfter(' -> ')
+          }
+          else if (artifactId.contains(' (')) {
+            var oldArtifactId = artifactId
+            artifactId = oldArtifactId.takeBefore(' (')
+          }
+
+          if (artifactId.contains(':')) {
+            var oldArtifactId = artifactId
+            artifactId = oldArtifactId.takeBefore(':')
+            if (version == null) {
+              version = oldArtifactId.takeAfter(':')
+            }
+          }
+
+          if (version?.contains(' ')) {
+            version = version.takeBefore(' ')
+          }
+
+          logger.debug("g=$groupId")
+          logger.debug("a=$artifactId")
+          logger.debug("v=$version")
+
+          // Store coordinates in map to find duplicates
+          var key = "$groupId:$artifactId".toString()
+          if (!deps.containsKey(key)) {
+            deps.put(key, version)
+          }
+          else {
+            var otherVersion = deps.get(key)
+            if (otherVersion == null) {
+              deps.put(key, version)
+            }
+            else if (version != null && otherVersion != version) {
+              var message = "Version conflict for $key between versions $version and $otherVersion for scope $currentConfig";
+              if (ignoredDuplicates.contains(key.toString())) {
+                logger.debug( "Ignoring: $message")
+              }
+              else {
+                throw new GradleException(message)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Write all unique dependencies to a file
+    var depsSorted = deps.keySet().sort();
+    new File("${rootProject.buildDir}/deps", "__all.txt")
+        .withWriter('utf-8') {
+          for (dep in depsSorted) {
+            var version = deps.get(dep)
+            it.writeLine("$dep:$version")
+          }
+        }
+  }
+}
+
+// Make sure we can find the dependency files for all subprojects
+failOnVersionConflict.dependsOn(subprojects.allDeps)
+
+// execute task with 'check'
+check.dependsOn failOnVersionConflict

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -21,25 +21,47 @@ ext {
   dbRiderVersion = '1.32.3'
   kotlinVersion = '1.6.10'
   kotlinxCoroutinesVersion = '1.6.0'
+  jacksonBomVersion = '2.13.2.20220328'
   jacksonVersion = '2.13.2'
+  jacksonDatabindVersion = '2.13.2.2'
 }
 
 dependencies {
-  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonVersion") // override version from dropwizard-bom
+  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:$jacksonBomVersion") // override version from dropwizard-bom
   api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion") // override version from dropwizard-bom
   api enforcedPlatform("org.jetbrains.kotlinx:kotlinx-coroutines-bom:$kotlinxCoroutinesVersion")
   api enforcedPlatform("io.dropwizard:dropwizard-bom:$dropwizardVersion")
   api enforcedPlatform("io.dropwizard:dropwizard-dependencies:$dropwizardVersion"), {
     exclude group: 'com.fasterxml.jackson'
+    exclude group: 'com.fasterxml.jackson.core'
     exclude group: 'com.fasterxml.jackson.dataformat'
     exclude group: 'com.fasterxml.jackson.datatype'
     exclude group: 'com.fasterxml.jackson.jaxrs'
     exclude group: 'com.fasterxml.jackson.module'
+    exclude group: 'org.awaitility', module: 'awaitility'
   }
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.12.191")
   api enforcedPlatform("io.github.resilience4j:resilience4j-bom:1.7.0")
 
   constraints {
+    api "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
+    api "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
+    api "com.fasterxml.jackson.core:jackson-databind:$jacksonDatabindVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:$jacksonVersion"
+    api "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-guava:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:$jacksonVersion"
+    api "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:$jacksonVersion"
+    api "com.fasterxml.jackson.module:jackson-module-afterburner:$jacksonVersion"
+    api "com.fasterxml.jackson.module:jackson-module-jaxb-annotations:$jacksonVersion"
+    api "com.fasterxml.jackson.module:jackson-module-parameter-names:$jacksonVersion"
+    api "com.fasterxml.jackson.module:jackson-module-scala_2.13:$jacksonVersion"
+
     // overall conflicts
     api "commons-codec:commons-codec:1.15", {
       because "conflict between org.apache.httpcomponents:httpclient:4.5.12 and org.dbunit:dbunit:2.7.0"
@@ -56,7 +78,7 @@ dependencies {
     api "net.javacrumbs.json-unit:json-unit-core:$jsonUnitVersion", {
       because "conflict between com.github.tomakehurst:wiremock-jre8 and net.javacrumbs.json-unit:json-unit-assertj"
     }
-    api "com.fasterxml.jackson:jackson-bom:$jacksonVersion", {
+    api "com.fasterxml.jackson:jackson-bom:$jacksonBomVersion", {
       because "wiremock, dropwizard and others use outdated versions"
     }
 
@@ -97,6 +119,9 @@ dependencies {
     api "dev.morphia.morphia:core:$morphiaVersion"
     api "dev.morphia.morphia:validation:$morphiaVersion"
     api "org.bouncycastle:bcpkix-jdk15on:1.70" // use the same version as bcprov-jdk15on in DW
+
+    // sda-commons-server-openapi
+    api "com.jayway.jsonpath:json-path:2.6.0"
 
     // sda-commons-server-swagger
     api "io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.9"

--- a/sda-commons-dependency-check/build.gradle
+++ b/sda-commons-dependency-check/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   api project(':sda-commons-server-auth')
   api project(':sda-commons-server-auth-testing')
   api project(':sda-commons-server-circuitbreaker')
+  api project(':sda-commons-server-cloudevents')
   api project(':sda-commons-server-consumer')
   api project(':sda-commons-server-cors')
   api project(':sda-commons-server-key-mgmt')


### PR DESCRIPTION
Choosing a completely different approach to finding version conflicts.

What's wrong with the built in `failOnVersionConflict`?
* it does not seem to detect conflicts between different configurations/scopes
* it detects conflicts that are handled later by using `enforcedPlatform`

My feeling is that `enforcedPlatform` and `failOnVersionConflict` do not really play well together. I tried to get some help in [Gradle's forum](https://discuss.gradle.org/t/enforcedplatform-not-working-struggling-with-failonversionconflict/42516/2) but got no answers.

The version of `failOnVersionConflict` that I wrote here will:
* collect all effective versions from all (relevant) configurations/scopes, i.e. the version that was determined after constraints of `enforcedPlatform` were applied
* fail if different versions are used

I plugged the task into the build cycle. It will break the build if a version conflict is detected.

**Update**

The same behaviour should be supported by Gradle out-of-the-box. The feature is called "consistent resolution" and is described [here](https://docs.gradle.org/current/userguide/resolution_strategy_tuning.html#sec:java_consistency).

Unfortunately the feature does not work when activated in our project. See [bug report at Gradle](https://github.com/gradle/gradle/issues/20345) and our [pull request](https://github.com/SDA-SE/sda-dropwizard-commons/pull/1535).