### PR TITLE
fix(server-kafka): Health check reuses AdminClient

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/KafkaHealthCheck.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/health/KafkaHealthCheck.java
@@ -1,12 +1,9 @@
 package org.sdase.commons.server.kafka.health;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.annotation.Async;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.sdase.commons.server.kafka.KafkaConfiguration;
 import org.sdase.commons.server.kafka.KafkaProperties;
 import org.slf4j.LoggerFactory;
@@ -18,19 +15,16 @@ public class KafkaHealthCheck extends HealthCheck {
 
   private final KafkaConfiguration config;
 
+  private final AdminClient adminClient;
+
   public KafkaHealthCheck(KafkaConfiguration config) {
     this.config = config;
+    this.adminClient = AdminClient.create(KafkaProperties.forAdminClient(config));
   }
 
   @Override
   protected Result check() {
-    // Set logger for config to WARN, as it would otherwise print the full
-    // config on every health check to the log.
-    Logger logger = (Logger) LoggerFactory.getLogger(AdminClientConfig.class);
-    Level oldLevel = logger.getLevel();
-    logger.setLevel(Level.WARN);
-
-    try (AdminClient adminClient = AdminClient.create(KafkaProperties.forAdminClient(config))) {
+    try {
       adminClient
           .listTopics()
           .names()
@@ -38,9 +32,11 @@ public class KafkaHealthCheck extends HealthCheck {
     } catch (Exception e) {
       LOGGER.warn("Kafka health check failed", e);
       return Result.unhealthy("Connection to broker failed within 2 seconds");
-    } finally {
-      logger.setLevel(oldLevel);
     }
     return Result.healthy();
+  }
+
+  public void shutdown() {
+    adminClient.close();
   }
 }


### PR DESCRIPTION
Fixes #1449

Tested here:
* https://github.com/SDA-SE/partner-consent-stack/pull/296
* https://github.com/SDA-SE/gitops-sdadev-consent/pull/104
* https://argo.sdadev.sda-se.io/applications/consent-stack-pr-104?resource=