### PR TITLE
feat(server-dropwizard): disable more monitoring paths with `DISABLE_HEALTHCHECK_LOGS`

### DIFF
--- a/sda-commons-server-dropwizard/README.md
+++ b/sda-commons-server-dropwizard/README.md
@@ -90,3 +90,9 @@ However they are hard to read for human beings, so better deactivate them when w
 By default, Dropwizard logs all incoming requests to the console, this includes healthchecks like `/ping` and `/healthcheck/internal`.
 As these are very frequent and can quickly pollute the logs, they can be disabled by setting the environment variable `DISABLE_HEALTHCHECK_LOGS` to `"true"`.
 This will be overwritten by any manual configuration to the FilterFactories.
+With `DISABLE_HEALTHCHECK_LOGS` active request logs for all paths related to monitoring are disabled:
+- `/ping`
+- `/healthcheck`
+- `/healthcheck/internal`
+- `/metrics`
+- `/metrics/prometheus`

--- a/sda-commons-server-dropwizard/build.gradle
+++ b/sda-commons-server-dropwizard/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 
   testImplementation project(':sda-commons-server-testing')
   testImplementation project(':sda-commons-server-healthcheck')
+  testImplementation('org.awaitility:awaitility')
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithRequestLogFilterTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithRequestLogFilterTest.java
@@ -3,6 +3,7 @@ package org.sdase.commons.server.dropwizard.bundles;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.dropwizard.Configuration;
 import io.dropwizard.logging.ConsoleAppenderFactory;
@@ -10,6 +11,9 @@ import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
 import io.dropwizard.request.logging.filter.UriFilterFactory;
 import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -28,8 +32,7 @@ class DefaultLoggingConfigurationBundleWithRequestLogFilterTest {
           RequestLoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
 
   @Test
-  @StdIo
-  void shouldApplyRequestLogFilterFactories(StdOut out) {
+  void shouldApplyRequestLogFilterFactories() {
     RequestLoggingTestApp app = DW.getApplication();
 
     DefaultServerFactory serverFactory =
@@ -38,21 +41,46 @@ class DefaultLoggingConfigurationBundleWithRequestLogFilterTest {
         (LogbackAccessRequestLogFactory) serverFactory.getRequestLogFactory();
 
     assertThat(requestLogFactory.getAppenders()).isNotEmpty();
-    ConsoleAppenderFactory consoleAppenderFactory =
-        (ConsoleAppenderFactory) requestLogFactory.getAppenders().get(0);
+    ConsoleAppenderFactory<?> consoleAppenderFactory =
+        (ConsoleAppenderFactory<?>) requestLogFactory.getAppenders().get(0);
 
     assertThat(consoleAppenderFactory.getFilterFactories()).isNotEmpty();
     UriFilterFactory uriFilterFactory =
         (UriFilterFactory) consoleAppenderFactory.getFilterFactories().get(0);
 
-    Response response =
-        createAdminTarget().path("healthcheck/internal").request().buildGet().invoke();
-
     assertThat(uriFilterFactory).isNotNull();
-    assertThat(uriFilterFactory.getUris()).containsExactly("/ping", "/healthcheck/internal");
+    assertThat(uriFilterFactory.getUris())
+        .containsExactlyInAnyOrder(
+            "/ping", "/healthcheck", "/healthcheck/internal", "/metrics", "/metrics/prometheus");
+  }
 
-    assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
-    assertThat(out.capturedLines()).noneMatch(line -> line.contains("/healthcheck/internal"));
+  @StdIo
+  @Test
+  void shouldNotLogExcludedPaths(StdOut out) {
+    List<String> pathsExpectingNoLogEntry =
+        Arrays.asList(
+            "ping", "healthcheck", "healthcheck/internal", "metrics", "metrics/prometheus");
+    List<Response> responses = new ArrayList<>();
+    try {
+      pathsExpectingNoLogEntry.forEach(
+          p -> createAdminTarget().path(p).request().buildGet().invoke());
+      responses.add(createWebTarget().path("test").request().buildGet().invoke());
+
+      assertThat(responses)
+          .extracting(Response::getStatus)
+          .allMatch(sc -> sc == OK.getStatusCode());
+
+      await()
+          .untilAsserted(() -> assertThat(out.capturedLines()).anyMatch(l -> l.contains("/test")));
+
+      assertThat(String.join("\n", out.capturedLines())).doesNotContain(pathsExpectingNoLogEntry);
+    } finally {
+      responses.forEach(Response::close);
+    }
+  }
+
+  private WebTarget createWebTarget() {
+    return DW.client().target(String.format("http://localhost:%d/", DW.getLocalPort()));
   }
 
   private WebTarget createAdminTarget() {

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutRequestLogFilterTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutRequestLogFilterTest.java
@@ -3,9 +3,16 @@ package org.sdase.commons.server.dropwizard.bundles;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static javax.ws.rs.core.Response.Status.OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.request.logging.LogbackAccessRequestLogFactory;
+import io.dropwizard.server.DefaultServerFactory;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -22,13 +29,48 @@ class DefaultLoggingConfigurationBundleWithoutRequestLogFilterTest {
           RequestLoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
 
   @Test
-  @StdIo
-  void shouldHaveDefaultHealthcheckRequestLogs(StdOut out) {
-    Response response =
-        createAdminTarget().path("healthcheck/internal").request().buildGet().invoke();
+  void shouldHaveNoRequestFilters() {
+    RequestLoggingTestApp app = DW.getApplication();
 
-    assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
-    assertThat(out.capturedLines()).anyMatch(line -> line.contains("/healthcheck/internal"));
+    DefaultServerFactory serverFactory =
+        (DefaultServerFactory) app.getConfiguration().getServerFactory();
+    LogbackAccessRequestLogFactory requestLogFactory =
+        (LogbackAccessRequestLogFactory) serverFactory.getRequestLogFactory();
+
+    assertThat(requestLogFactory.getAppenders()).isNotEmpty();
+    ConsoleAppenderFactory<?> consoleAppenderFactory =
+        (ConsoleAppenderFactory<?>) requestLogFactory.getAppenders().get(0);
+
+    assertThat(consoleAppenderFactory.getFilterFactories()).isEmpty();
+  }
+
+  @StdIo
+  @Test
+  void shouldLogMonitoringPaths(StdOut out) {
+    List<String> pathsExpectingLogEntry =
+        Arrays.asList(
+            "ping", "healthcheck", "healthcheck/internal", "metrics", "metrics/prometheus");
+    List<Response> responses = new ArrayList<>();
+    try {
+      pathsExpectingLogEntry.forEach(
+          p -> createAdminTarget().path(p).request().buildGet().invoke());
+      responses.add(createWebTarget().path("test").request().buildGet().invoke());
+
+      assertThat(responses)
+          .extracting(Response::getStatus)
+          .allMatch(sc -> sc == OK.getStatusCode());
+
+      await()
+          .untilAsserted(() -> assertThat(out.capturedLines()).anyMatch(l -> l.contains("/test")));
+
+      assertThat(String.join("\n", out.capturedLines())).contains(pathsExpectingLogEntry);
+    } finally {
+      responses.forEach(Response::close);
+    }
+  }
+
+  private WebTarget createWebTarget() {
+    return DW.client().target(String.format("http://localhost:%d/", DW.getLocalPort()));
   }
 
   private WebTarget createAdminTarget() {

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/test/RequestLoggingTestApp.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/test/RequestLoggingTestApp.java
@@ -4,9 +4,16 @@ import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+import java.util.Collections;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import org.sdase.commons.server.dropwizard.bundles.DefaultLoggingConfigurationBundle;
 import org.sdase.commons.server.healthcheck.InternalHealthCheckEndpointBundle;
 
+@Path("test")
+@Produces(MediaType.APPLICATION_JSON)
 public class RequestLoggingTestApp extends Application<Configuration> {
   private Configuration configuration;
 
@@ -18,8 +25,14 @@ public class RequestLoggingTestApp extends Application<Configuration> {
 
   @Override
   public void run(Configuration configuration, Environment environment) {
-    // nothing to run
     this.configuration = configuration;
+    environment.jersey().register(this);
+  }
+
+  @GET
+  @Path("")
+  public Object getTest() {
+    return Collections.singletonMap("test", "foo");
   }
 
   public Configuration getConfiguration() {


### PR DESCRIPTION
When `DISABLE_HEALTHCHECK_LOGS` is set, request logging of the following paths is suppressed:

- `/ping`
- `/healthcheck`  _(new)_
- `/healthcheck/internal`
- `/metrics` _(new)_
- `/metrics/prometheus`  _(new)_