### PR TITLE
fix(deps): Bump okhttp to 4.9.3 fixing CVE-2021-0341

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     // sda-commons-server-jaeger
     api "io.jaegertracing:jaeger-client:1.8.0"
     api "com.google.code.gson:gson:2.9.0" // fixes vulnerability in transitive dependency 2.8.6
+    api "com.squareup.okhttp3:okhttp:4.9.3" // fixes CVE-2021-0341 (bump from 4.9.0 used in jaeger-thrift:1.8.0)
 
     // sda-commons-server-mongo-testing
     api "de.flapdoodle.embed:de.flapdoodle.embed.mongo:3.4.6"


### PR DESCRIPTION
See release notes:
https://github.com/square/okhttp/blob/master/docs/changelogs/changelog_4x.md