### PR TITLE
feat(server-kafka): add flush to message producer interface and implementation

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
@@ -230,6 +230,9 @@ public class KafkaBundle<C extends Configuration> implements ConfiguredBundle<C>
         public Future<RecordMetadata> send(K key, V value, Headers headers) {
           return null;
         }
+
+        @Override
+        public void flush() {}
       };
     }
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
@@ -230,9 +230,6 @@ public class KafkaBundle<C extends Configuration> implements ConfiguredBundle<C>
         public Future<RecordMetadata> send(K key, V value, Headers headers) {
           return null;
         }
-
-        @Override
-        public void flush() {}
       };
     }
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
@@ -48,6 +48,6 @@ public class KafkaMessageProducer<K, V> implements MessageProducer<K, V> {
 
   @Override
   public void flush() {
-    this.producer.flush();
+    producer.flush();
   }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
@@ -45,4 +45,9 @@ public class KafkaMessageProducer<K, V> implements MessageProducer<K, V> {
   public void close() {
     producer.close();
   }
+
+  @Override
+  public void flush() {
+    this.producer.flush();
+  }
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MessageProducer.java
@@ -23,5 +23,10 @@ public interface MessageProducer<K, V> {
 
   Future<RecordMetadata> send(K key, V value, Headers headers);
 
-  void flush();
+  /**
+   * This method is a blank default implementation in order to avoid it being a breaking change. The
+   * implementing class must override this to add behaviour to it. The implementation should call
+   * the flush() method of the producer.
+   */
+  default void flush() {}
 }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MessageProducer.java
@@ -22,4 +22,6 @@ public interface MessageProducer<K, V> {
   Future<RecordMetadata> send(K key, V value);
 
   Future<RecordMetadata> send(K key, V value, Headers headers);
+
+  void flush();
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
@@ -1,5 +1,8 @@
 package org.sdase.commons.server.kafka.producer;
 
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,22 +10,20 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.sdase.commons.server.kafka.prometheus.ProducerTopicMessageCounter;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 @ExtendWith(MockitoExtension.class)
 class KafkaMessageProducerTest {
 
-  @Mock
-  KafkaProducer<String, String> mockProducer;
+  @Mock KafkaProducer<String, String> mockProducer;
 
   @Test
   void shouldDelegateFlushCallToProducer() {
-    //given
-    KafkaMessageProducer<String, String> kafkaMessageProducer = new KafkaMessageProducer<>("topicName", mockProducer, new ProducerTopicMessageCounter(), "producerName");
-    //when
+    // given
+    KafkaMessageProducer<String, String> kafkaMessageProducer =
+        new KafkaMessageProducer<>(
+            "topicName", mockProducer, new ProducerTopicMessageCounter(), "producerName");
+    // when
     kafkaMessageProducer.flush();
-    //then
+    // then
     verify(mockProducer, times(1)).flush();
   }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
@@ -1,0 +1,28 @@
+package org.sdase.commons.server.kafka.producer;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sdase.commons.server.kafka.prometheus.ProducerTopicMessageCounter;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaMessageProducerTest {
+
+  @Mock
+  KafkaProducer<String, String> mockProducer;
+
+  @Test
+  void shouldDelegateFlushCallToProducer() {
+    //given
+    KafkaMessageProducer<String, String> kafkaMessageProducer = new KafkaMessageProducer<>("topicName", mockProducer, new ProducerTopicMessageCounter(), "producerName");
+    //when
+    kafkaMessageProducer.flush();
+    //then
+    verify(mockProducer, times(1)).flush();
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
@@ -2,7 +2,10 @@ package org.sdase.commons.server.kafka.producer;
 
 import static org.mockito.Mockito.*;
 
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Headers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -24,5 +27,22 @@ class KafkaMessageProducerTest {
     kafkaMessageProducer.flush();
     // then
     verify(mockProducer, times(1)).flush();
+  }
+
+  @Test
+  void callingFlushShouldNotThrowExceptionAndMakeSonarHappy() {
+    MessageProducer messageProducer =
+        new MessageProducer() {
+          @Override
+          public Future<RecordMetadata> send(Object key, Object value) {
+            return null;
+          }
+
+          @Override
+          public Future<RecordMetadata> send(Object key, Object value, Headers headers) {
+            return null;
+          }
+        };
+    messageProducer.flush();
   }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducerTest.java
@@ -1,7 +1,6 @@
 package org.sdase.commons.server.kafka.producer;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.junit.jupiter.api.Test;
@@ -20,7 +19,7 @@ class KafkaMessageProducerTest {
     // given
     KafkaMessageProducer<String, String> kafkaMessageProducer =
         new KafkaMessageProducer<>(
-            "topicName", mockProducer, new ProducerTopicMessageCounter(), "producerName");
+            "topicName", mockProducer, mock(ProducerTopicMessageCounter.class), "producerName");
     // when
     kafkaMessageProducer.flush();
     // then


### PR DESCRIPTION
This PR exposes the producer.flush() method for clients to use.

BREAKING CHANGE:  MessageProducer Interface is extended.