### PR TITLE
test(server-cloudevents): Migrate to Junit 5, use `hasYamlContentAndU…

### DIFF
--- a/sda-commons-server-cloudevents/src/test/java/org/sdase/commons/server/cloudevents/AsyncApiDocumentationTest.java
+++ b/sda-commons-server-cloudevents/src/test/java/org/sdase/commons/server/cloudevents/AsyncApiDocumentationTest.java
@@ -3,15 +3,15 @@ package org.sdase.commons.server.cloudevents;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.sdase.commons.server.cloudevents.app.consume.ContractCreatedEvent;
 import org.sdase.commons.server.cloudevents.app.produce.PartnerCreatedEvent;
 import org.sdase.commons.server.testing.GoldenFileAssertions;
 import org.sdase.commons.shared.asyncapi.AsyncApiGenerator;
 
-public class AsyncApiDocumentationTest {
+class AsyncApiDocumentationTest {
   @Test
-  public void generateAndVerifySpec() throws IOException {
+  void generateAndVerifySpec() throws IOException {
     String expected =
         AsyncApiGenerator.builder()
             .withAsyncApiBase(getClass().getResource("/asyncapi-template.yml"))
@@ -24,6 +24,6 @@ public class AsyncApiDocumentationTest {
     Path filePath = Paths.get("asyncapi.yaml");
 
     // check and update the file
-    GoldenFileAssertions.assertThat(filePath).hasContentAndUpdateGolden(expected);
+    GoldenFileAssertions.assertThat(filePath).hasYamlContentAndUpdateGolden(expected);
   }
 }


### PR DESCRIPTION
…pdateGolden`

Not sure if that will fix the issue but the test fails quite often on Windows.