### PR TITLE
feat(server-kafka): increment poll intervall on errors

### DIFF
--- a/sda-commons-server-kafka/build.gradle
+++ b/sda-commons-server-kafka/build.gradle
@@ -8,6 +8,8 @@ dependencies {
   api 'io.prometheus:simpleclient'
 
   testImplementation 'org.mockito:mockito-core'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
+  testImplementation 'org.objenesis:objenesis'
 
   testImplementation 'org.assertj:assertj-core'
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/ListenerConfig.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/ListenerConfig.java
@@ -7,6 +7,8 @@ public class ListenerConfig {
   private int instances = 1;
   private long topicMissingRetryMs = 0;
   private long pollInterval = 100;
+  private long pollIntervalFactorOnError = 4;
+  private long maxPollInterval = 25_000;
 
   private ListenerConfig() {
     // empty constructor for jackson
@@ -44,10 +46,28 @@ public class ListenerConfig {
     this.pollInterval = pollInterval;
   }
 
+  public long getPollIntervalFactorOnError() {
+    return pollIntervalFactorOnError;
+  }
+
+  public void setPollIntervalFactorOnError(long pollIntervalFactorOnError) {
+    this.pollIntervalFactorOnError = pollIntervalFactorOnError;
+  }
+
+  public long getMaxPollInterval() {
+    return maxPollInterval;
+  }
+
+  public void setMaxPollInterval(long maxPollInterval) {
+    this.maxPollInterval = maxPollInterval;
+  }
+
   public static class ListenerConfigBuilder {
 
     private long topicMissingRetryMs = 0;
     private long pollInterval = 100;
+    private long pollIntervalFactorOnError = 4;
+    private long maxPollInterval = 25_000;
 
     public ListenerConfigBuilder withTopicMissingRetryMs(@NotNull long ms) {
       this.topicMissingRetryMs = ms;
@@ -59,11 +79,23 @@ public class ListenerConfig {
       return this;
     }
 
+    public ListenerConfigBuilder withMaxPollInterval(@NotNull long ms) {
+      this.maxPollInterval = ms;
+      return this;
+    }
+
+    public ListenerConfigBuilder withPollIntervalFactorOnError(@NotNull long factor) {
+      this.pollIntervalFactorOnError = factor;
+      return this;
+    }
+
     public ListenerConfig build(@NotNull int numberInstances) {
       ListenerConfig build = new ListenerConfig();
-      build.topicMissingRetryMs = topicMissingRetryMs;
-      build.pollInterval = pollInterval;
-      build.instances = numberInstances;
+      build.setTopicMissingRetryMs(topicMissingRetryMs);
+      build.setPollInterval(pollInterval);
+      build.setMaxPollInterval(maxPollInterval);
+      build.setPollIntervalFactorOnError(pollIntervalFactorOnError);
+      build.setInstances(numberInstances);
       return build;
     }
   }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerErrorIntervalTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerErrorIntervalTest.java
@@ -1,0 +1,135 @@
+package org.sdase.commons.server.kafka.consumer;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.server.kafka.config.ListenerConfig;
+import org.sdase.commons.server.kafka.consumer.strategies.MessageListenerStrategy;
+
+@SuppressWarnings("unchecked")
+class MessageListenerErrorIntervalTest {
+  static final String TOPIC_NAME = "test";
+  MessageListener<String, String> messageListener;
+  KafkaConsumer<String, String> consumerMock = mock(KafkaConsumer.class);
+  MessageListenerStrategy<String, String> messageListenerStrategyMock =
+      mock(MessageListenerStrategy.class);
+  Map<TopicPartition, List<ConsumerRecord<String, String>>> recordMock;
+  ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+  @BeforeEach
+  void setUp() {
+    Node nodeMock = mock(Node.class);
+    when(consumerMock.partitionsFor(TOPIC_NAME))
+        .thenReturn(
+            Collections.singletonList(
+                new PartitionInfo(
+                    TOPIC_NAME, 1, nodeMock, new Node[] {nodeMock}, new Node[] {nodeMock})));
+    ConsumerRecord<String, String> singleRecordMock = mock(ConsumerRecord.class);
+    recordMock =
+        Collections.singletonMap(
+            new TopicPartition(TOPIC_NAME, 1), Collections.singletonList(singleRecordMock));
+    ListenerConfig listenerConfig =
+        ListenerConfig.builder()
+            .withPollInterval(1)
+            .withMaxPollInterval(10)
+            .withPollIntervalFactorOnError(3)
+            .build(1);
+    messageListener =
+        new MessageListener<>(
+            Collections.singletonList(TOPIC_NAME),
+            consumerMock,
+            listenerConfig,
+            messageListenerStrategyMock);
+    verify(consumerMock).subscribe(anyCollection());
+  }
+
+  @AfterEach
+  void tearDown() {
+    executorService.shutdown();
+  }
+
+  @Test
+  void shouldKeepConfiguredIntervalOnSuccess() {
+    try {
+      when(consumerMock.poll(any())).thenReturn(new ConsumerRecords<>(recordMock));
+      executorService.submit(messageListener);
+      await()
+          .untilAsserted(
+              () -> verify(consumerMock, atLeast(10)).poll(Duration.of(1, ChronoUnit.MILLIS)));
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+
+  @Test
+  void shouldIncreaseIntervalOnError() {
+    try {
+      when(consumerMock.poll(any())).thenReturn(new ConsumerRecords<>(recordMock));
+      doThrow(new RuntimeException())
+          .doThrow(new RuntimeException())
+          .when(messageListenerStrategyMock)
+          .processRecords(any(), eq(consumerMock));
+      executorService.submit(messageListener);
+      await()
+          .untilAsserted(
+              () -> {
+                verify(consumerMock, times(1)).poll(Duration.of(1, ChronoUnit.MILLIS));
+                verify(consumerMock, times(1)).poll(Duration.of(3, ChronoUnit.MILLIS));
+                verify(consumerMock, times(1)).poll(Duration.of(9, ChronoUnit.MILLIS));
+                verify(consumerMock, atLeast(2)).poll(Duration.of(10, ChronoUnit.MILLIS));
+              });
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+
+  @Test
+  void shouldIncreaseIntervalOnErrorAndResetOnSuccess() {
+    try {
+      when(consumerMock.poll(any())).thenReturn(new ConsumerRecords<>(recordMock));
+      doThrow(new RuntimeException())
+          .doThrow(new RuntimeException())
+          .doThrow(new RuntimeException())
+          .doThrow(new RuntimeException())
+          .doThrow(new RuntimeException())
+          .doNothing()
+          .when(messageListenerStrategyMock)
+          .processRecords(any(), eq(consumerMock));
+      executorService.submit(messageListener);
+      await()
+          .untilAsserted(
+              () -> {
+                verify(consumerMock, atLeast(2)).poll(Duration.of(1, ChronoUnit.MILLIS));
+                verify(consumerMock, times(1)).poll(Duration.of(3, ChronoUnit.MILLIS));
+                verify(consumerMock, times(1)).poll(Duration.of(9, ChronoUnit.MILLIS));
+                verify(consumerMock, times(3)).poll(Duration.of(10, ChronoUnit.MILLIS));
+              });
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+}


### PR DESCRIPTION
When error occurs while consuming a Kafka message, the poll interval is exponentially increased to avoid frequent retries of failed message handling, e.g. due to missing downstream services or unavailable other resources.

This change mitigates some flooding logs and excessive resource consumption occurred in a production environment.

@SDA-SE/sda-commons-maintainer We could set the introduced `pollIntervalFactorOnError` to 1 to be 100% backward compatible with the old implementation. But in my opinion it improves 99% of the services when we don't poll excessively on error. So I would like to increase the poll interval on error by default for all services. What are reasonable values?