### PR TITLE
fix(deps): Bump Kafka version to 2.8.2 solving CVE-2022-34917

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -16,7 +16,7 @@ ext {
   openTracingUtilVersion = '0.33.0'
   jsonUnitVersion = '2.35.0'
   scalaVersion = '2.13.9' // align transitive dependency from various modules, keep up to date
-  kafkaVersion = '2.8.1'
+  kafkaVersion = '2.8.2'
   kafkaJunitVersion = '3.2.4' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5
   dbRiderVersion = '1.34.0'
   kotlinVersion = '1.7.10'


### PR DESCRIPTION
* fixes [CVE-2022-34917](https://nvd.nist.gov/vuln/detail/CVE-2022-34917)
* [Release Notes](https://archive.apache.org/dist/kafka/2.8.2/RELEASE_NOTES.html)