### PR TITLE
feat(server-jackson): extend validation exception mapper to detect fo…

### DIFF
--- a/sda-commons-server-jackson/build.gradle
+++ b/sda-commons-server-jackson/build.gradle
@@ -5,6 +5,7 @@ dependencies {
   api 'io.openapitools.jackson.dataformat:jackson-dataformat-hal'
 
   testImplementation project(':sda-commons-server-testing')
+  testImplementation project(':sda-commons-shared-forms')
   testImplementation 'com.kjetland:mbknor-jackson-jsonschema_2.13', {
     /**
      * Dropwizard comes with jakarta.validation-api instead of javax.validation-api.

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/JacksonConfigurationTestApp.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/test/JacksonConfigurationTestApp.java
@@ -1,38 +1,29 @@
 package org.sdase.commons.server.jackson.test;
 
 import static java.util.Collections.singletonList;
+import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.openapitools.jackson.dataformat.hal.HALLink;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Date;
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.GET;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotAcceptableException;
-import javax.ws.rs.NotAllowedException;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.NotSupportedException;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.assertj.core.util.Lists;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.sdase.commons.server.dropwizard.ContextAwareEndpoint;
 import org.sdase.commons.server.jackson.JacksonConfigurationBundle;
 import org.sdase.commons.shared.api.error.ApiException;
@@ -50,6 +41,7 @@ public class JacksonConfigurationTestApp extends Application<Configuration>
   @Override
   public void initialize(Bootstrap<Configuration> bootstrap) {
     bootstrap.addBundle(JacksonConfigurationBundle.builder().build());
+    bootstrap.addBundle(new io.dropwizard.forms.MultiPartBundle());
   }
 
   @Override
@@ -195,6 +187,39 @@ public class JacksonConfigurationTestApp extends Application<Configuration>
   public Response createRequiredQueryValidationResource(
       @QueryParam("q") @Valid @NotEmpty String searchString) {
     return Response.ok(searchString).build();
+  }
+
+  @POST
+  @Path("/requiredForm")
+  @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response createRequiredFormValidationResource(@NotBlank @FormParam("foo") String foo) {
+    return Response.created(
+            uriInfo
+                .getBaseUriBuilder()
+                .path(JacksonConfigurationTestApp.class)
+                .path(JacksonConfigurationTestApp.class, "createRequiredFormValidationResource")
+                .path("1")
+                .build())
+        .build();
+  }
+
+  @POST
+  @Path("/requiredFormData")
+  @Consumes(MULTIPART_FORM_DATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response createRequiredFormDataValidationResource(
+      @NotNull @FormDataParam("text") String text,
+      @NotNull @Valid @FormDataParam("file") InputStream file,
+      @Valid @FormDataParam("file") FormDataContentDisposition fileDisposition) {
+    return Response.created(
+            uriInfo
+                .getBaseUriBuilder()
+                .path(JacksonConfigurationTestApp.class)
+                .path(JacksonConfigurationTestApp.class, "createRequiredFormDataValidationResource")
+                .path("1")
+                .build())
+        .build();
   }
 
   @POST


### PR DESCRIPTION
…rm parameter annotation names

Hello SDA-SE,

this PR aims to fix the following issue: In the API error that is created by your JerseyValidationExceptionMapper, only the names of JSON fields from the payload or from query params are extracted from JerseyViolatationExceptions, not however from @FormDataParam and @FormParam parameters. This leads to errors such as the following for missing or invalid multipart form data (@FormDataParam):
{
    "title": "Request parameters are not valid.",
    "invalidParams": [
        {
            "field": "",
            "reason": "must not be null",
            "errorCode": "NOT_NULL"
        }
    ]
}

For simple form parameters (@FormParam), the message says "field": "N/A".
This PR fixes this by also extracting the names of form and form data parameters from the violation exception. 
Do with this what you will. If you like it, please approve. If not, please tell my why or what I could do better.

Thanks & best regards