### PR TITLE
test(server-dropwizard): Disable tests that set env vars for Java16+

### DIFF
--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookupTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/SystemPropertyAndEnvironmentLookupTest.java
@@ -3,6 +3,8 @@ package org.sdase.commons.server.dropwizard.bundles;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.junitpioneer.jupiter.SetSystemProperty;
 
@@ -14,12 +16,14 @@ class SystemPropertyAndEnvironmentLookupTest {
     assertThat(new SystemPropertyAndEnvironmentLookup().lookup("FOO")).isEqualTo("bar");
   }
 
+  @DisabledForJreRange(min = JRE.JAVA_16)
   @Test
   @SetEnvironmentVariable(key = "FOO", value = "bar")
   void shouldLookupEnvironmentVariables() {
     assertThat(new SystemPropertyAndEnvironmentLookup().lookup("FOO")).isEqualTo("bar");
   }
 
+  @DisabledForJreRange(min = JRE.JAVA_16)
   @Test
   @SetEnvironmentVariable(key = "FOO", value = "bar_env")
   @SetSystemProperty(key = "FOO", value = "bar_prop")


### PR DESCRIPTION
Preparation for Java 17 / version 3. 🦓 

Let's get the PR green: https://github.com/SDA-SE/sda-dropwizard-commons/pull/1643