### PR TITLE
fix(deps): bump kafkaVersion from 2.8.2 to 3.2.3

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -16,7 +16,7 @@ ext {
   openTracingUtilVersion = '0.33.0'
   jsonUnitVersion = '2.36.0'
   scalaVersion = '2.13.9' // align transitive dependency from various modules, keep up to date
-  kafkaVersion = '2.8.2'
+  kafkaVersion = '3.2.3'
   kafkaJunitVersion = '3.2.4' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5
   dbRiderVersion = '1.34.0'
   kotlinVersion = '1.7.20'
@@ -185,6 +185,9 @@ dependencies {
       because "conflict between org.apache.kafka:kafka_2.13, io.findify:s3mock_2.13 and com.kjetland:mbknor-jackson-jsonschema_2.13:+ upgrade"
     }
     api "org.scala-lang:scala-reflect:$scalaVersion", {
+      because "conflict between io.findify:s3mock_2.13 and org.apache.kafka:kafka_2.13"
+    }
+    api "com.typesafe.scala-logging:scala-logging_2.13:3.9.4", {
       because "conflict between io.findify:s3mock_2.13 and org.apache.kafka:kafka_2.13"
     }
   }

--- a/sda-commons-server-kafka-testing/build.gradle
+++ b/sda-commons-server-kafka-testing/build.gradle
@@ -7,9 +7,17 @@ dependencies {
 
   api project(':sda-commons-server-testing')
 
-  api 'com.salesforce.kafka.test:kafka-junit4'
-  api 'com.salesforce.kafka.test:kafka-junit5'
   api 'org.apache.kafka:kafka_2.13'
+  api 'com.salesforce.kafka.test:kafka-junit4', {
+    exclude group: 'org.apache.curator', module: 'curator-test'
+  }
+  api 'com.salesforce.kafka.test:kafka-junit5', {
+    exclude group: 'org.apache.curator', module: 'curator-test'
+  }
+  api 'org.apache.curator:curator-test', {
+    exclude group: 'org.xerial.snappy', module: 'snappy-java'
+  }
+  api 'org.xerial.snappy:snappy-java'
   api 'org.awaitility:awaitility'
   api 'org.apache.commons:commons-lang3'
 


### PR DESCRIPTION
Bumps `kafkaVersion` from 2.8.2 to 3.2.3.

Updates `kafka_2.13` from 2.8.2 to 3.2.3

Updates `kafka-clients` from 2.8.2 to 3.2.3

---
updated-dependencies:
- dependency-name: org.apache.kafka:kafka_2.13 dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.apache.kafka:kafka-clients dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>