### PR TITLE
feat(sda-commons-server-kafka): marking createTopicIfMissing method as deprecated

### DIFF
--- a/sda-commons-server-kafka-example/src/main/java/org/sdase/commons/server/kafka/KafkaExampleProducerApplication.java
+++ b/sda-commons-server-kafka-example/src/main/java/org/sdase/commons/server/kafka/KafkaExampleProducerApplication.java
@@ -49,7 +49,7 @@ public class KafkaExampleProducerApplication extends Application<KafkaExampleCon
     return kafka.registerProducer(
         ProducerRegistration.builder()
             .forTopic(kafka.getTopicConfiguration("example0"))
-            .createTopicIfMissing()
+            .createTopicIfMissing() // Deprecated. It will be removed in next releases
             .withDefaultProducer()
             .withKeySerializer(new KafkaJsonSerializer<Key>(configuredObjectMapper))
             .withValueSerializer(new KafkaJsonSerializer<Value>(configuredObjectMapper))
@@ -65,7 +65,7 @@ public class KafkaExampleProducerApplication extends Application<KafkaExampleCon
     return kafka.registerProducer(
         ProducerRegistration.builder()
             .forTopic(kafka.getTopicConfiguration("example1"))
-            .createTopicIfMissing()
+            .createTopicIfMissing() // Deprecated. It will be removed in next releases
             .withDefaultProducer()
             .withKeySerializer(new LongSerializer())
             .withValueSerializer(new LongSerializer())

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
@@ -235,6 +235,7 @@ public class KafkaBundle<C extends Configuration> implements ConfiguredBundle<C>
 
     checkInit();
 
+    // this functionality will be removed in the next releases
     if (registration.isCreateTopicIfMissing()) {
       createNotExistingTopics(Collections.singletonList(registration.getTopic()));
     }

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/ProducerRegistration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/ProducerRegistration.java
@@ -34,6 +34,12 @@ public class ProducerRegistration<K, V> {
     return checkTopicConfiguration;
   }
 
+  /**
+   * @deprecated Using this method is highly discouraged, since it will be removed in the next
+   *     version. You should now create the kafka topic manually. Check README for more detailed
+   *     explanation
+   */
+  @Deprecated
   public boolean isCreateTopicIfMissing() {
     return createTopicIfMissing;
   }
@@ -80,10 +86,13 @@ public class ProducerRegistration<K, V> {
     ProducerBuilder<K, V> checkTopicConfiguration();
 
     /**
-     * defines that the topic should be created if it does not exist
-     *
+     * @deprecated Using this method is highly discouraged, since it will be removed in the next
+     *     version. You should now create the kafka topic manually. Check README for more detailed
+     *     explanation
+     *     <p>defines that the topic should be created if it does not exist
      * @return builder
      */
+    @Deprecated
     ProducerBuilder<K, V> createTopicIfMissing();
 
     /**
@@ -225,6 +234,14 @@ public class ProducerRegistration<K, V> {
       return this;
     }
 
+    /**
+     * @deprecated Using this method is highly discouraged, since it will be removed in the next
+     *     version. You should now create the kafka topic manually. Check README for more detailed
+     *     explanation
+     *     <p>defines that the topic should be created if it does not exist
+     * @return builder
+     */
+    @Deprecated
     @Override
     public ProducerBuilder<K, V> createTopicIfMissing() {
       this.createTopicIfMissing = true;

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppDisabledKafkaServerIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppDisabledKafkaServerIT.java
@@ -69,7 +69,7 @@ public class AppDisabledKafkaServerIT {
         bundle.registerProducer(
             ProducerRegistration.builder()
                 .forTopic("Topic")
-                .createTopicIfMissing()
+                .createTopicIfMissing() // Deprecated. It will be removed in next releases
                 .withDefaultProducer()
                 .build());
     assertNull(producer.send("test", "test"));

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppWithoutKafkaServerIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/AppWithoutKafkaServerIT.java
@@ -61,7 +61,7 @@ public class AppWithoutKafkaServerIT {
     bundle.registerProducer(
         ProducerRegistration.builder()
             .forTopic(topicName)
-            .createTopicIfMissing()
+            .createTopicIfMissing() // Deprecated. It will be removed in next releases
             .withDefaultProducer()
             .build());
   }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
@@ -137,7 +137,7 @@ public class KafkaBundleWithConfigIT {
         kafkaBundle.registerProducer(
             ProducerRegistration.builder()
                 .forTopic(kafkaBundle.getTopicConfiguration("topicId2"))
-                .createTopicIfMissing()
+                .createTopicIfMissing() // Deprecated. It will be removed in next releases
                 .withDefaultProducer()
                 .withKeySerializer(new StringSerializer())
                 .withValueSerializer(new StringSerializer())

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaTopicIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaTopicIT.java
@@ -150,7 +150,7 @@ class KafkaTopicIT {
         bundle.registerProducer(
             ProducerRegistration.builder()
                 .forTopic(topic)
-                .createTopicIfMissing()
+                .createTopicIfMissing() // Deprecated. It will be removed in next releases
                 .withDefaultProducer()
                 .build());
     assertThat(producer).isNotNull();
@@ -163,7 +163,7 @@ class KafkaTopicIT {
         bundle.registerProducer(
             ProducerRegistration.builder()
                 .forTopic(topicName)
-                .createTopicIfMissing()
+                .createTopicIfMissing() // Deprecated. It will be removed in next releases
                 .withDefaultProducer()
                 .build());
     assertThat(producer).isNotNull();
@@ -184,7 +184,7 @@ class KafkaTopicIT {
                 bundle.registerProducer(
                     ProducerRegistration.builder()
                         .forTopic(topic)
-                        .createTopicIfMissing()
+                        .createTopicIfMissing() // Deprecated. It will be removed in next releases
                         .withDefaultProducer()
                         .build()))
         .isInstanceOf(TopicCreationException.class);
@@ -330,7 +330,7 @@ class KafkaTopicIT {
         bundle.registerProducer(
             ProducerRegistration.builder()
                 .forTopic(topic)
-                .createTopicIfMissing()
+                .createTopicIfMissing() // Deprecated. It will be removed in next releases
                 .withDefaultProducer()
                 .build());
     assertThat(producer).isNotNull();


### PR DESCRIPTION
Marking as deprecated, because we don't want that the topics be created programmatically. Instead, the developers should created it or aks for the DeVops team to do so. The purpose of this approach is to avoid topic misconfiguration and so the company has more control about created resources