### PR TITLE
fix(client-jersey): Remove deprecated methods `withConnectionTimeout`…

### DIFF
--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
@@ -16,7 +16,6 @@ import com.codahale.metrics.MetricFilter;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import io.dropwizard.util.Duration;
 import javax.ws.rs.core.Response;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -114,23 +113,5 @@ public class ApiClientConfigurationTest {
     assertThat(client.createCar(new Car().setSign("HH UV 42")))
         .extracting(Response::getStatus)
         .isEqualTo(SC_CREATED);
-  }
-
-  @Test
-  public void shouldNotModifyExistingConfiguration() {
-    HttpClientConfiguration config = new HttpClientConfiguration();
-    config.setTimeout(Duration.milliseconds(50));
-    config.setConnectionTimeout(Duration.milliseconds(50));
-
-    app.getJerseyClientBundle()
-        .getClientFactory()
-        .externalClient(config)
-        .withConnectionTimeout(java.time.Duration.ofDays(1))
-        .withReadTimeout(java.time.Duration.ofDays(1))
-        .api(MockApiClient.class)
-        .atTarget(WIRE.baseUrl());
-
-    assertThat(config.getTimeout()).isEqualTo(Duration.milliseconds(50));
-    assertThat(config.getConnectionTimeout()).isEqualTo(Duration.milliseconds(50));
   }
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTimeoutTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTimeoutTest.java
@@ -16,7 +16,6 @@ import static org.sdase.commons.client.jersey.test.util.ClientRequestExceptionCo
 import com.codahale.metrics.MetricFilter;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -84,11 +83,13 @@ public class ApiClientTimeoutTest {
   @Test
   @Retry(5)
   public void runIntoConfiguredConnectionTimeout() {
+    HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+    clientConfiguration.setConnectionTimeout(io.dropwizard.util.Duration.seconds(2));
+
     MockApiClient client =
         app.getJerseyClientBundle()
             .getClientFactory()
-            .externalClient()
-            .withConnectionTimeout(Duration.ofSeconds(2))
+            .externalClient(clientConfiguration)
             .api(MockApiClient.class)
             .atTarget("http://192.168.123.123");
 
@@ -137,11 +138,12 @@ public class ApiClientTimeoutTest {
     WIRE.stubFor(
         get("/api/cars").willReturn(aResponse().withStatus(200).withBody("").withFixedDelay(5000)));
 
+    HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+    clientConfiguration.setTimeout(io.dropwizard.util.Duration.seconds(4));
     MockApiClient client =
         app.getJerseyClientBundle()
             .getClientFactory()
-            .externalClient()
-            .withReadTimeout(Duration.ofSeconds(4))
+            .externalClient(clientConfiguration)
             .api(MockApiClient.class)
             .atTarget(WIRE.baseUrl());
 

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
@@ -15,7 +15,6 @@ import static org.sdase.commons.client.jersey.test.util.ClientRequestExceptionCo
 
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import io.dropwizard.testing.junit.DropwizardAppRule;
-import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.Client;
@@ -81,11 +80,13 @@ public class GenericClientTimeoutTest {
   @Test
   @Retry(5)
   public void runIntoConfiguredConnectionTimeout() {
+    HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+    clientConfiguration.setConnectionTimeout(io.dropwizard.util.Duration.seconds(2));
+
     Client client =
         app.getJerseyClientBundle()
             .getClientFactory()
-            .externalClient()
-            .withConnectionTimeout(Duration.ofSeconds(2))
+            .externalClient(clientConfiguration)
             .buildGenericClient("test");
 
     CompletableFuture<Response> future =
@@ -140,11 +141,12 @@ public class GenericClientTimeoutTest {
     WIRE.stubFor(
         get("/timeout").willReturn(aResponse().withStatus(200).withBody("").withFixedDelay(5000)));
 
+    HttpClientConfiguration clientConfiguration = new HttpClientConfiguration();
+    clientConfiguration.setTimeout(io.dropwizard.util.Duration.seconds(4));
     Client client =
         app.getJerseyClientBundle()
             .getClientFactory()
-            .externalClient()
-            .withReadTimeout(Duration.ofSeconds(4))
+            .externalClient(clientConfiguration)
             .buildGenericClient("test");
 
     CompletableFuture<Response> future =


### PR DESCRIPTION
… and `withReadTimeout`

BREAKING CHANGE: Please provide a `HttpClientConfiguration` instead and set the `connectionTimeout` or `timeout` properties respectively.