### PR TITLE
fix: Mark Jaeger and OpenTracing bundles as deprecated

### DIFF
--- a/sda-commons-server-jaeger/README.md
+++ b/sda-commons-server-jaeger/README.md
@@ -1,6 +1,8 @@
-# SDA Commons Server Jaeger
+# SDA Commons Server Jaeger `Deprecated`
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-server-jaeger/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-server-jaeger)
+
+> **_NOTE:_** This module is deprecated. It will be replaced in version 3 by [OpenTelemetry](https://opentelemetry.io).
 
 This module provides the [`JaegerBundle`](./src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java) used to collect [OpenTracing](https://opentracing.io/) traces to [Jaeger](https://www.jaegertracing.io/).
 When traces are generated, the `JaegerBundle` forwards the traces to the Jaeger agent.

--- a/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
+++ b/sda-commons-server-jaeger/src/main/java/org/sdase/commons/server/jaeger/JaegerBundle.java
@@ -21,7 +21,12 @@ import org.sdase.commons.server.jaeger.metrics.PrometheusMetricsFactory;
  * variables.
  *
  * @see <a href="https://www.jaegertracing.io/docs/1.16/client-features/">Jaeger Configuration</a>
+ * @deprecated This bundle is deprecated. Consider using the <a
+ *     href="https://github.com/SDA-SE/sda-dropwizard-commons/blob/master/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java">SdaPlatformBundle</a>
+ *     as base bundle because it will migrate to <a
+ *     href="https://opentelemetry.io">OpenTelemetry</a> for you automatically.
  */
+@Deprecated
 public class JaegerBundle implements ConfiguredBundle<io.dropwizard.Configuration> {
 
   private static final String JAEGER_SERVICE_NAME = "JAEGER_SERVICE_NAME";

--- a/sda-commons-server-opentracing/README.md
+++ b/sda-commons-server-opentracing/README.md
@@ -1,6 +1,8 @@
-# SDA Commons Server Open Tracing
+# SDA Commons Server Open Tracing `Deprecated`
 
 [![javadoc](https://javadoc.io/badge2/org.sdase.commons/sda-commons-server-opentracing/javadoc.svg)](https://javadoc.io/doc/org.sdase.commons/sda-commons-server-opentracing)
+
+> **_NOTE:_** This module is deprecated. It will be replaced in version 3 by [OpenTelemetry](https://opentelemetry.io).
 
 This module provides the [`OpenTracingBundle`](./src/main/java/org/sdase/commons/server/opentracing/OpenTracingBundle.java) used to instrument using [OpenTracing](https://opentracing.io/).
 

--- a/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/OpenTracingBundle.java
+++ b/sda-commons-server-opentracing/src/main/java/org/sdase/commons/server/opentracing/OpenTracingBundle.java
@@ -28,6 +28,13 @@ import org.sdase.commons.server.opentracing.servlet.AdminServletSpanDecorator;
 import org.sdase.commons.server.opentracing.servlet.CustomServletSpanDecorator;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated This bundle is deprecated. Consider using the <a
+ *     href="https://github.com/SDA-SE/sda-dropwizard-commons/blob/master/sda-commons-starter/src/main/java/org/sdase/commons/starter/SdaPlatformBundle.java">SdaPlatformBundle</a>
+ *     as base bundle because it will migrate to <a
+ *     href="https://opentelemetry.io">OpenTelemetry</a> for you automatically.
+ */
+@Deprecated
 public class OpenTracingBundle implements ConfiguredBundle<Configuration> {
 
   private final Tracer tracer;


### PR DESCRIPTION
Consider using sda-commons-starter's `SdaPlatformBundle` as base instead of manually adding these bundles.