### PR TITLE
fix(server-morphia): Only re-create indexes of mapped entity classes

### DIFF
--- a/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/IndexEnsurer.java
+++ b/sda-commons-server-morphia/src/main/java/org/sdase/commons/server/morphia/IndexEnsurer.java
@@ -4,6 +4,9 @@ import com.mongodb.MongoCommandException;
 import com.mongodb.client.ListIndexesIterable;
 import com.mongodb.client.MongoCollection;
 import dev.morphia.Datastore;
+import dev.morphia.mapping.MappedClass;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.bson.Document;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +54,13 @@ class IndexEnsurer {
     String indexName = errorMessageStartingWithIndexName.split("\\s")[0].trim();
     // indexName is the only thing we know about the failed index creation, we must look for it in
     // all collections
-    for (String collectionName : datastore.getDatabase().listCollectionNames()) {
+    // Only consider collections of mapped entities and not system collections like `system.profile`
+    List<String> collections =
+        datastore.getMapper().getMappedClasses().stream()
+            .filter(it -> it.getEntityAnnotation() != null)
+            .map(MappedClass::getCollectionName) // NOSONAR
+            .collect(Collectors.toList());
+    for (String collectionName : collections) {
       MongoCollection<Document> collection =
           this.datastore.getDatabase().getCollection(collectionName);
       ListIndexesIterable<Document> indices = collection.listIndexes();


### PR DESCRIPTION
Skipping system collections like `system.profile`