### PR TITLE
chore: Bump publish-unit-test-result-action to 2.3.0

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -73,7 +73,7 @@ jobs:
           path: artifacts
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@b9f6c61d965bcaa18acc02d6daf706373a448f02 # tag=v1.40
+        uses: EnricoMi/publish-unit-test-result-action@a3caf02865c0604ad3dc1ecfcc5cdec9c41b7936 # tag=v2.3.0
         with:
           junit_files: artifacts/**/build/test-results/**/*.xml
 


### PR DESCRIPTION
Not sure what went wrong. `with.files` has already been changed to `with.junit_files`. Compare release notes: https://github.com/EnricoMi/publish-unit-test-result-action/releases