### PR TITLE
chore: align publishing actions

### DIFF
--- a/.github/workflows/publish-release-maven-central.yml
+++ b/.github/workflows/publish-release-maven-central.yml
@@ -46,11 +46,13 @@ jobs:
           SDA_SONATYPE_PASSWORD: ${{ secrets.SDA_SONATYPE_PASSWORD }}
 
       - name: Upload to Maven Central
-        run: ./gradlew -x signMavenPublication publishMavenPublicationToMavenCentralRepository closeAndReleaseRepository
+        run: ./gradlew publishMavenPublicationToMavenCentralRepository closeAndReleaseRepository
         env:
           SDA_SONATYPE_USER: ${{ secrets.SDA_SONATYPE_USER }}
           SDA_SONATYPE_PASSWORD: ${{ secrets.SDA_SONATYPE_PASSWORD }}
           SONATYPE_STAGING_REPOSITORY_ID: ${{ steps.create-staging-repo.outputs.STAGING_PROFILE_ID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}
 
       - uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/publish-release-sda.yml
+++ b/.github/workflows/publish-release-sda.yml
@@ -30,7 +30,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}
 
       - name: Upload to SDA Nexus
-        run: ./gradlew -x signMavenPublication publishMavenPublicationToSdaInternRepository
+        run: ./gradlew publishMavenPublicationToSdaInternRepository
         env:
           SDA_NEXUS_USER: ${{ secrets.NEXUS_LOGIN_USER }}
           SDA_NEXUS_PASSWORD: ${{ secrets.NEXUS_LOGIN_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}

--- a/.github/workflows/pull-request-snapshots.yml
+++ b/.github/workflows/pull-request-snapshots.yml
@@ -18,11 +18,18 @@ jobs:
           java-version: 11
           cache: 'gradle'
 
-      - name: Build and Publish Snapshot
-        run: ./gradlew publishMavenPublicationToSdaInternRepository
+      - name: Build and Sign packages
+        run: ./gradlew --parallel signMavenPublication
         env:
-          SEMANTIC_VERSION: PR-${{ github.event.number }}-SNAPSHOT
-          SDA_NEXUS_USER: ${{ secrets.NEXUS_LOGIN_USER }}
-          SDA_NEXUS_PASSWORD: ${{ secrets.NEXUS_LOGIN_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}
+          SEMANTIC_VERSION: PR-${{ github.event.number }}-SNAPSHOT
+
+      - name: Upload to SDA Nexus
+        run: ./gradlew publishMavenPublicationToSdaInternRepository
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PRIVATE_KEY_SECRET }}
+          SDA_NEXUS_USER: ${{ secrets.NEXUS_LOGIN_USER }}
+          SDA_NEXUS_PASSWORD: ${{ secrets.NEXUS_LOGIN_PASSWORD }}
+          SEMANTIC_VERSION: PR-${{ github.event.number }}-SNAPSHOT


### PR DESCRIPTION
Background: Some JavaDoc Jars have been recreated without resigning in the Maven Central Step.