### PR TITLE
Update PolicyExistsHealthCheck.java

### DIFF
--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/health/PolicyExistsHealthCheck.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/opa/health/PolicyExistsHealthCheck.java
@@ -26,7 +26,7 @@ public class PolicyExistsHealthCheck extends HealthCheck {
       // send a get request to the policy path. The get will not provide any input.
       // Normally, the policy should response with a deny decision.
       // If there is an exception, the check will be unhealthy
-      OpaResponse opaResponse = client.request().post(Entity.json(null), OpaResponse.class);
+      OpaResponse opaResponse = client.request().get(OpaResponse.class);
 
       if (opaResponse == null
           || opaResponse.getResult() == null


### PR DESCRIPTION
A client post request leads to a warning by OPA-Agent, when FAIL_ON_UNKOWN_PROPERTIES is set by SPI this call will result in an exception. A GET-call solves this conflict.