### PR TITLE
deps(server-cors): adding java xml bind dependency

### DIFF
--- a/sda-commons-server-cors/build.gradle
+++ b/sda-commons-server-cors/build.gradle
@@ -1,6 +1,9 @@
 dependencies {
   api project(':sda-commons-server-dropwizard')
   api project(':sda-commons-shared-tracing')
+  api 'javax.xml.bind:jaxb-api', {
+    exclude group: 'javax.activation', module: 'javax.activation-api'
+  }
 
   testImplementation project(':sda-commons-server-testing')
 }

--- a/sda-commons-server-kafka/build.gradle
+++ b/sda-commons-server-kafka/build.gradle
@@ -7,6 +7,11 @@ dependencies {
 
   api 'io.prometheus:simpleclient'
 
+  api 'javax.xml.bind:jaxb-api', {
+    exclude group: 'javax.activation', module: 'javax.activation-api'
+  }
+  api "jakarta.xml.bind:jakarta.xml.bind-api"
+
   testImplementation 'org.mockito:mockito-core'
   testImplementation 'org.mockito:mockito-junit-jupiter'
   testImplementation 'org.objenesis:objenesis'


### PR DESCRIPTION
Adding javax.xml.bind:jaxb-api dependency, to fix the warning in the tests: https://github.com/SDA-SE/sda-dropwizard-commons/pull/1469/checks?check_run_id=11056045868
