### PR TITLE
fix(server-kafka): remove blank settings from Kafka config properties

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaProperties.java
@@ -1,6 +1,8 @@
 package org.sdase.commons.server.kafka;
 
+import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -61,7 +63,7 @@ public class KafkaProperties extends Properties {
     props.putAll(configureSecurity(configuration.getSecurity()));
 
     if (configuration.getConfig() != null) {
-      props.putAll(configuration.getConfig());
+      props.putAll(noBlankValues(configuration.getConfig()));
     }
 
     return props;
@@ -99,7 +101,7 @@ public class KafkaProperties extends Properties {
     props.put(
         AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG,
         configuration.getAdminConfig().getAdminClientRequestTimeoutMs());
-    props.putAll(configuration.getAdminConfig().getConfig());
+    props.putAll(noBlankValues(configuration.getAdminConfig().getConfig()));
     return props;
   }
 
@@ -138,5 +140,11 @@ public class KafkaProperties extends Properties {
       default:
         throw new IllegalArgumentException("Unsupported SASL mechanism " + saslMechanism);
     }
+  }
+
+  private static Map<String, String> noBlankValues(Map<String, String> original) {
+    return original.entrySet().stream()
+        .filter(e -> StringUtils.isNotBlank(e.getValue()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesCleanupTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/config/KafkaPropertiesCleanupTest.java
@@ -1,0 +1,46 @@
+package org.sdase.commons.server.kafka.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.sdase.commons.server.kafka.KafkaConfiguration;
+import org.sdase.commons.server.kafka.KafkaProperties;
+
+class KafkaPropertiesCleanupTest {
+
+  @Test
+  void itShouldRemoveBlankValuesForAdminConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    config.getConfig().put("setting-a", null);
+    config.getConfig().put("setting-b", "");
+    config.getConfig().put("setting-c", "  ");
+
+    config.getAdminConfig().getConfig().put("admin-setting-a", null);
+    config.getAdminConfig().getConfig().put("admin-setting-b", "");
+    config.getAdminConfig().getConfig().put("admin-setting-c", "  ");
+
+    assertThat(KafkaProperties.forAdminClient(config))
+        .doesNotContainKeys(
+            "setting-a",
+            "setting-b",
+            "setting-c",
+            "admin-setting-a",
+            "admin-setting-b",
+            "admin-setting-c");
+  }
+
+  @Test
+  void itShouldRemoveBlankValuesForConfig() {
+    KafkaConfiguration config = new KafkaConfiguration();
+
+    config.getConfig().put("setting-a", null);
+    config.getConfig().put("setting-b", "");
+    config.getConfig().put("setting-c", "  ");
+
+    assertThat(KafkaProperties.forProducer(config))
+        .doesNotContainKeys("setting-a", "setting-b", "setting-c");
+    assertThat(KafkaProperties.forConsumer(config))
+        .doesNotContainKeys("setting-a", "setting-b", "setting-c");
+  }
+}


### PR DESCRIPTION
The Kafka client will reject such configuration but services may prepare optional config in the config.yml.

A new test has been created to avoid rebase issues with upcoming v3 branch.

There is also an option to specify config for specific consumers and producers. They are fetched from the KafkaBundle directly. As it is not very likely, that optional settings without defaults are used in that cases and it will cause major merge conflicts with v3 when changing the KafkaBundle, this PR does not clean up consumer and producer specific settings.