### PR TITLE
chore: Use Java 11 for Fossa

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -32,11 +32,11 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha }} # checkout commit that triggered this workflow
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@1df8dbefe2a8cbc99770194893dd902763bee34b # v3.9.0
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
           cache: 'gradle'
 
       - name: Install Fossa


### PR DESCRIPTION
Preparation for v3 - needed to update Spotless (https://github.com/SDA-SE/sda-dropwizard-commons/pull/2079)