### PR TITLE
fix(server-kafka): Deprecate classes for topic comparison

### DIFF
--- a/sda-commons-server-kafka/README.md
+++ b/sda-commons-server-kafka/README.md
@@ -178,7 +178,7 @@ public class DemoApplication {
                   .withReplicationFactor(2)
                   .withPartitionCount(2)
                   .withConfig(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT).build())
-                  .checkTopicConfiguration() // enforces that topic must be configured exactly as defined above
+                  .checkTopicConfiguration() // enforces that topic must be configured exactly as defined above. Deprecated. Services can't decide on topic configurations.
                   .createTopicIfMissing()    // creates the topic if no topic has been found. Deprecated. It will be removed in the next releases
                   .withProducerConfig("producer1") // use producer config from config yaml
                   .build());

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/KafkaBundle.java
@@ -117,6 +117,8 @@ public class KafkaBundle<C extends Configuration> implements ConfiguredBundle<C>
    * Provides a {@link ExpectedTopicConfiguration} that is generated from the values within the
    * configuration yaml
    *
+   * @deprecated the {@link ExpectedTopicConfiguration} will be removed, hence, this method will be
+   *     replaced by {@link TopicConfig} getTopicConfiguration(String name)
    * @param name the name of the topic
    * @return the configured topic configuration
    * @throws ConfigurationException if no such topic exists in the configuration

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/MessageListenerRegistration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/MessageListenerRegistration.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.sdase.commons.server.kafka.config.ConsumerConfig;
 import org.sdase.commons.server.kafka.config.ListenerConfig;
+import org.sdase.commons.server.kafka.config.TopicConfig;
 import org.sdase.commons.server.kafka.consumer.strategies.MessageListenerStrategy;
 import org.sdase.commons.server.kafka.topicana.ExpectedTopicConfiguration;
 import org.sdase.commons.server.kafka.topicana.TopicConfigurationBuilder;
@@ -27,6 +28,11 @@ public class MessageListenerRegistration<K, V> {
     return keyDeserializer;
   }
 
+  /**
+   * @deprecated this feature will be removed in v3 because services can't really decide on proper
+   *     topic configurations.
+   */
+  @Deprecated
   public boolean isCheckTopicConfiguration() {
     return checkTopicConfiguration;
   }
@@ -39,6 +45,12 @@ public class MessageListenerRegistration<K, V> {
     return valueDeserializer;
   }
 
+  /**
+   * @deprecated the {@link ExpectedTopicConfiguration} will be removed, hence, this method will be
+   *     replaced by Collection&lt;{@link TopicConfig}&gt; getTopics()
+   * @return topics
+   */
+  @Deprecated
   public Collection<ExpectedTopicConfiguration> getTopics() {
     return topics;
   }
@@ -92,7 +104,11 @@ public class MessageListenerRegistration<K, V> {
      * @param topicConfiguration topic to consume given as topic configuration, e.g. predefined in
      *     config This is necessary if you want to check the topic configuration during startup
      * @return builder
+     * @deprecated the class {@link ExpectedTopicConfiguration} will be removed, hence, this method
+     *     will be replaced by forTopicConfigs(Collection&lt;{@link TopicConfig}&gt;
+     *     topicConfiguration)
      */
+    @Deprecated
     ConsumerBuilder forTopicConfigs(Collection<ExpectedTopicConfiguration> topicConfiguration);
   }
 
@@ -104,7 +120,10 @@ public class MessageListenerRegistration<K, V> {
      * thrown.
      *
      * @return builder
+     * @deprecated this feature will be removed in v3 because services can't really decide on proper
+     *     topic configurations.
      */
+    @Deprecated
     ConsumerBuilder checkTopicConfiguration();
 
     /**
@@ -239,6 +258,14 @@ public class MessageListenerRegistration<K, V> {
       return this;
     }
 
+    /**
+     * @deprecated the class {@link ExpectedTopicConfiguration} will be removed, hence, this method
+     *     will be replaced by * forTopicConfigs(Collection&lt;{@link TopicConfig}&gt;
+     *     topicConfiguration)
+     * @param topicConfiguration topic to consume given as topic configuration, e.g. predefined in
+     *     config This is necessary if you want to check the topic configuration during startup
+     */
+    @Deprecated
     @Override
     public ConsumerBuilder forTopicConfigs(
         Collection<ExpectedTopicConfiguration> topicConfiguration) {
@@ -246,6 +273,16 @@ public class MessageListenerRegistration<K, V> {
       return this;
     }
 
+    /**
+     * Define optional step to process a configuration check of the topic. If the topic differs,
+     * a @{@link org.sdase.commons.server.kafka.topicana.MismatchedTopicConfigException} will be
+     * thrown.
+     *
+     * @return builder
+     * @deprecated this feature will be removed in v3 because services can't really decide on proper
+     *     topic configurations.
+     */
+    @Deprecated
     @Override
     public ConsumerBuilder checkTopicConfiguration() {
       this.topicExistCheck = true;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/ProducerRegistration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/builder/ProducerRegistration.java
@@ -3,6 +3,7 @@ package org.sdase.commons.server.kafka.builder;
 import javax.validation.constraints.NotNull;
 import org.apache.kafka.common.serialization.Serializer;
 import org.sdase.commons.server.kafka.config.ProducerConfig;
+import org.sdase.commons.server.kafka.config.TopicConfig;
 import org.sdase.commons.server.kafka.exception.TopicMissingException;
 import org.sdase.commons.server.kafka.topicana.ExpectedTopicConfiguration;
 import org.sdase.commons.server.kafka.topicana.TopicConfigurationBuilder;
@@ -22,6 +23,12 @@ public class ProducerRegistration<K, V> {
     return producerName;
   }
 
+  /**
+   * @deprecated the {@link ExpectedTopicConfiguration} will be removed, hence, this method will be
+   *     replaced by {@link TopicConfig} getTopic()
+   * @return topic
+   */
+  @Deprecated
   public ExpectedTopicConfiguration getTopic() {
     return topic;
   }
@@ -30,6 +37,11 @@ public class ProducerRegistration<K, V> {
     return topic.getTopicName();
   }
 
+  /**
+   * @deprecated this feature will be removed in v3 because services can't really decide on proper
+   *     topic configurations.
+   */
+  @Deprecated
   public boolean isCheckTopicConfiguration() {
     return checkTopicConfiguration;
   }
@@ -67,11 +79,14 @@ public class ProducerRegistration<K, V> {
     }
 
     /**
-     * @param topic detailed definition of the topic for that messages will be produced. This
+     * @param topic detailed definition of the topic for that messages will be produced. These
      *     details are used when topic existence should be checked or topic should be created if
      *     missing. If topic differs, a {@link TopicMissingException} is thrown.
      * @return builder
+     * @deprecated the {@link ExpectedTopicConfiguration} will be removed, hence, this method will
+     *     be replaced by forTopic({@link TopicConfig})
      */
+    @Deprecated
     ProducerBuilder<K, V> forTopic(ExpectedTopicConfiguration topic);
   }
 
@@ -82,15 +97,18 @@ public class ProducerRegistration<K, V> {
      * existence is checked.
      *
      * @return builder
+     * @deprecated this feature will be removed in v3 because services can't really decide on proper
+     *     topic configurations.
      */
+    @Deprecated
     ProducerBuilder<K, V> checkTopicConfiguration();
 
     /**
+     * @return builder
      * @deprecated Using this method is highly discouraged, since it will be removed in the next
      *     version. You should now create the kafka topic manually. Check README for more detailed
      *     explanation
      *     <p>defines that the topic should be created if it does not exist
-     * @return builder
      */
     @Deprecated
     ProducerBuilder<K, V> createTopicIfMissing();
@@ -212,6 +230,15 @@ public class ProducerRegistration<K, V> {
       return target;
     }
 
+    /**
+     * @param topic detailed definition of the topic for that messages will be produced. These
+     *     details are used when topic existence should be checked or topic should be created if
+     *     missing. If topic differs, a {@link TopicMissingException} is thrown.
+     * @return builder
+     * @deprecated the {@link ExpectedTopicConfiguration} will be removed, hence, this method will
+     *     be replaced by forTopic({@link TopicConfig})
+     */
+    @Deprecated
     @Override
     public ProducerBuilder<K, V> forTopic(@NotNull ExpectedTopicConfiguration topic) {
       this.topic = topic;
@@ -228,6 +255,11 @@ public class ProducerRegistration<K, V> {
       return new FinalBuilder<>(InitialBuilder.clone(this), null, valueSerializer);
     }
 
+    /**
+     * @deprecated this feature will be removed in v3 because services can't really decide on proper
+     *     topic configurations.
+     */
+    @Deprecated
     @Override
     public ProducerBuilder<K, V> checkTopicConfiguration() {
       this.checkTopicConfiguration = true;
@@ -239,7 +271,6 @@ public class ProducerRegistration<K, V> {
      *     version. You should now create the kafka topic manually. Check README for more detailed
      *     explanation
      *     <p>defines that the topic should be created if it does not exist
-     * @return builder
      */
     @Deprecated
     @Override

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/TopicConfig.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/config/TopicConfig.java
@@ -18,14 +18,29 @@ public class TopicConfig {
     return name;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   */
+  @Deprecated
   public Integer getReplicationFactor() {
     return replicationFactor;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   */
+  @Deprecated
   public Integer getPartitions() {
     return partitions;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   */
+  @Deprecated
   public Map<String, String> getConfig() {
     return config;
   }
@@ -35,14 +50,31 @@ public class TopicConfig {
     return this;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   * @param replicationFactor
+   */
+  @Deprecated
   public void setReplicationFactor(Integer replicationFactor) {
     this.replicationFactor = replicationFactor;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   */
+  @Deprecated
   public void setPartitions(Integer partitions) {
     this.partitions = partitions;
   }
 
+  /**
+   * @deprecated since the topic creation will be removed, this method will not be necessary
+   *     anymore, and it will be removed as well
+   * @param config
+   */
+  @Deprecated
   public void setConfig(Map<String, String> config) {
     this.config = config;
   }
@@ -53,10 +85,29 @@ public class TopicConfig {
 
   public interface TopicConfigBuilder {
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param replicationFactor
+     */
+    @Deprecated
     TopicConfigBuilder withReplicationFactor(Integer replicationFactor);
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param partitions
+     */
+    @Deprecated
     TopicConfigBuilder withPartitions(Integer partitions);
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param key
+     * @param value
+     */
+    @Deprecated
     TopicConfigBuilder addConfig(String key, String value);
 
     TopicConfig build();
@@ -79,18 +130,37 @@ public class TopicConfig {
       return this;
     }
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param replicationFactor
+     */
+    @Deprecated
     @Override
     public TopicConfigBuilder withReplicationFactor(Integer replicationFactor) {
       this.replicationFactor = replicationFactor;
       return this;
     }
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param partitions
+     */
+    @Deprecated
     @Override
     public TopicConfigBuilder withPartitions(Integer partitions) {
       this.partitions = partitions;
       return this;
     }
 
+    /**
+     * @deprecated since the topic creation will be removed, this method will not be necessary
+     *     anymore, and it will be removed as well
+     * @param key
+     * @param value
+     */
+    @Deprecated
     @Override
     public TopicConfigBuilder addConfig(String key, String value) {
       config.put(key, value);

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/exception/MismatchedTopicException.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/exception/MismatchedTopicException.java
@@ -2,6 +2,8 @@ package org.sdase.commons.server.kafka.exception;
 
 import org.sdase.commons.server.kafka.topicana.ComparisonResult;
 
+/** @deprecated since no comparison will be executed on next version, this class will be removed */
+@Deprecated
 public class MismatchedTopicException extends RuntimeException {
 
   private final transient ComparisonResult comparisonResult;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/AbstractSpecifiedCount.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/AbstractSpecifiedCount.java
@@ -1,5 +1,10 @@
 package org.sdase.commons.server.kafka.topicana;
 
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public abstract class AbstractSpecifiedCount {
 
   private final int count;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ComparisonResult.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ComparisonResult.java
@@ -15,7 +15,11 @@ package org.sdase.commons.server.kafka.topicana;
 
 import java.util.*;
 
-/** Created by ftr on 11.11.17. */
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public class ComparisonResult {
 
   private final Set<String> missingTopics;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/EvaluationException.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/EvaluationException.java
@@ -13,6 +13,11 @@
  */
 package org.sdase.commons.server.kafka.topicana;
 
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public class EvaluationException extends RuntimeException {
   public EvaluationException(String message, Throwable cause) {
     super(message, cause);

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ExpectedTopicConfiguration.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ExpectedTopicConfiguration.java
@@ -17,7 +17,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Created by ftr on 10.11.17. */
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public class ExpectedTopicConfiguration {
 
   private final String topicName;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/MismatchedTopicConfigException.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/MismatchedTopicConfigException.java
@@ -13,6 +13,11 @@
  */
 package org.sdase.commons.server.kafka.topicana;
 
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public class MismatchedTopicConfigException extends RuntimeException {
 
   private final ComparisonResult result;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/PartitionCount.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/PartitionCount.java
@@ -13,7 +13,11 @@
  */
 package org.sdase.commons.server.kafka.topicana;
 
-/** Created by ftr on 10.11.17. */
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public interface PartitionCount {
 
   boolean isSpecified();

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ReplicationFactor.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/ReplicationFactor.java
@@ -13,7 +13,11 @@
  */
 package org.sdase.commons.server.kafka.topicana;
 
-/** Created by ftr on 10.11.17. */
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public interface ReplicationFactor {
 
   boolean isSpecified();

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/TopicComparer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/TopicComparer.java
@@ -42,7 +42,11 @@ import org.sdase.commons.server.kafka.KafkaProperties;
  *       broker that require auth credentials
  *   <li>Refactoring of code to reduce complexity
  * </ul>
+ *
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
  */
+@Deprecated
 public class TopicComparer {
 
   public TopicComparer() {

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/TopicConfigurationBuilder.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/topicana/TopicConfigurationBuilder.java
@@ -1,5 +1,10 @@
 package org.sdase.commons.server.kafka.topicana;
 
+/**
+ * @deprecated All classes from this package will be removed in the next version because topic
+ *     comparison is not recommended.
+ */
+@Deprecated
 public class TopicConfigurationBuilder {
 
   private TopicConfigurationBuilder() {


### PR DESCRIPTION
This feature will be removed in v3, see #2100 