### PR TITLE
fix(tests): fixing test execution

### DIFF
--- a/sda-commons-server-kafka/build.gradle
+++ b/sda-commons-server-kafka/build.gradle
@@ -19,5 +19,10 @@ dependencies {
   testImplementation 'org.assertj:assertj-core'
 
   testImplementation project(':sda-commons-server-kafka-testing')
+
+  test {
+    // running one test at time, to avoid problems with kafka servers concurrency
+    maxParallelForks = (int) (Runtime.runtime.availableProcessors() / 2 + 1)
+  }
 }
 


### PR DESCRIPTION
- Not running tests in parallel on Kafka module, to avoid Kafka server configuration concurrency
- Retrying async open telemetry test, to not fail on windows containers