### PR TITLE
fix(server-s3-testing): fix `SdkClientException` in `S3MockExtension` during test execution

### DIFF
--- a/sda-commons-server-s3-testing/src/main/java/org/sdase/commons/server/s3/testing/S3Mock.java
+++ b/sda-commons-server-s3-testing/src/main/java/org/sdase/commons/server/s3/testing/S3Mock.java
@@ -1,5 +1,7 @@
 package org.sdase.commons.server.s3.testing;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
@@ -101,6 +103,7 @@ public class S3Mock {
             new AwsClientBuilder.EndpointConfiguration(
                 getEndpoint(), Regions.DEFAULT_REGION.getName()))
         .withPathStyleAccessEnabled(true)
+        .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
         .build();
   }
 

--- a/sda-commons-server-s3-testing/src/test/java/org/sdase/commons/server/s3/testing/S3ClassExtensionTest.java
+++ b/sda-commons-server-s3-testing/src/test/java/org/sdase/commons/server/s3/testing/S3ClassExtensionTest.java
@@ -3,9 +3,6 @@ package org.sdase.commons.server.s3.testing;
 import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
 import java.io.File;
@@ -33,12 +30,6 @@ class S3ClassExtensionTest {
 
   @BeforeEach
   void setUp() {
-    // The S3 Mock doesn't require authentication, however we still pass it
-    // here to check that the server is at least ignoring it
-    AWSCredentials credentials = new BasicAWSCredentials("user", "s3cr3t");
-    ClientConfiguration clientConfiguration = new ClientConfiguration();
-    clientConfiguration.setSignerOverride("AWSS3V4SignerType");
-
     s3Client = S3_EXTENSION.getClient();
   }
 

--- a/sda-commons-server-s3-testing/src/test/java/org/sdase/commons/server/s3/testing/S3MockRuleTest.java
+++ b/sda-commons-server-s3-testing/src/test/java/org/sdase/commons/server/s3/testing/S3MockRuleTest.java
@@ -3,9 +3,6 @@ package org.sdase.commons.server.s3.testing;
 import static io.dropwizard.testing.ResourceHelpers.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3Object;
 import java.io.File;
@@ -33,12 +30,6 @@ public class S3MockRuleTest {
 
   @Before
   public void setUp() {
-    // The S3 Mock doesn't require authentication, however we still pass it
-    // here to check that the server is at least ignoring it
-    AWSCredentials credentials = new BasicAWSCredentials("user", "s3cr3t");
-    ClientConfiguration clientConfiguration = new ClientConfiguration();
-    clientConfiguration.setSignerOverride("AWSS3V4SignerType");
-
     s3Client = S3_MOCK.getClient();
   }
 


### PR DESCRIPTION
Since S3Mock accepts any authentication provider without validating it, this PR is setting up Anonymous authentication mechanism to avoid unnecessary stack traces like:
`com.amazonaws.SdkClientException: Failed to connect to service endpoint`