### PR TITLE
feat(server-kafka): keep metadata context when producing Kafka messages

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/KafkaHelper.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/KafkaHelper.java
@@ -2,7 +2,7 @@ package org.sdase.commons.server.kafka.consumer;
 
 import java.util.Map.Entry;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 
@@ -30,7 +30,7 @@ public class KafkaHelper {
    * @param <V> the type of the Value
    * @return the name of the producer as used in log messages that is hidden within the metrics
    */
-  public static <K, V> String getClientId(KafkaProducer<K, V> producer) {
+  public static <K, V> String getClientId(Producer<K, V> producer) {
     Entry<MetricName, ? extends Metric> entry =
         producer.metrics().entrySet().stream().findFirst().orElse(null);
     return entry != null ? entry.getKey().tags().get("client-id") : "";

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
@@ -1,7 +1,7 @@
 package org.sdase.commons.server.kafka.producer;
 
 import java.util.concurrent.Future;
-import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.header.Headers;
@@ -9,17 +9,17 @@ import org.sdase.commons.server.kafka.prometheus.ProducerTopicMessageCounter;
 
 public class KafkaMessageProducer<K, V> implements MessageProducer<K, V> {
 
-  private String topic;
+  private final String topic;
 
-  private KafkaProducer<K, V> producer;
+  private final Producer<K, V> producer;
 
-  private ProducerTopicMessageCounter msgCounter;
+  private final ProducerTopicMessageCounter msgCounter;
 
-  private String producerName;
+  private final String producerName;
 
   public KafkaMessageProducer(
       String topic,
-      KafkaProducer<K, V> producer,
+      Producer<K, V> producer,
       ProducerTopicMessageCounter msgCounter,
       String producerName) {
     this.producer = producer;

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MetadataContextAwareKafkaProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/MetadataContextAwareKafkaProducer.java
@@ -1,0 +1,145 @@
+package org.sdase.commons.server.kafka.producer;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Future;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.sdase.commons.server.dropwizard.metadata.MetadataContext;
+
+/**
+ * A {@link Producer} that delegates all implementations to a delegate. {@link
+ * ProducerRecord#headers()} are extended with information of the {@linkplain
+ * MetadataContext#current() current} {@link
+ * org.sdase.commons.server.dropwizard.metadata.MetadataContext}.
+ *
+ * @param <K> the type of the message key
+ * @param <V> the type of the message value
+ */
+public class MetadataContextAwareKafkaProducer<K, V> implements Producer<K, V> {
+
+  private final Producer<K, V> delegate;
+
+  private final Set<String> metadataFields;
+
+  /**
+   * @param delegate the actual {@link Producer} that is used to interact with the Kafka cluster.
+   * @param metadataFields the configured fields that are used as metadata
+   */
+  public MetadataContextAwareKafkaProducer(Producer<K, V> delegate, Set<String> metadataFields) {
+    this.delegate = delegate;
+    this.metadataFields = Optional.ofNullable(metadataFields).orElse(Set.of());
+  }
+
+  @Override
+  public void initTransactions() {
+    delegate.initTransactions();
+  }
+
+  @Override
+  public void beginTransaction() throws ProducerFencedException {
+    delegate.beginTransaction();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void sendOffsetsToTransaction(
+      Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId)
+      throws ProducerFencedException {
+    delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(
+      Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata)
+      throws ProducerFencedException {
+    delegate.sendOffsetsToTransaction(offsets, groupMetadata);
+  }
+
+  @Override
+  public void commitTransaction() throws ProducerFencedException {
+    delegate.commitTransaction();
+  }
+
+  @Override
+  public void abortTransaction() throws ProducerFencedException {
+    delegate.abortTransaction();
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> producerRecord) {
+    return delegate.send(withMetadataContext(producerRecord));
+  }
+
+  @Override
+  public Future<RecordMetadata> send(ProducerRecord<K, V> producerRecord, Callback callback) {
+    return delegate.send(withMetadataContext(producerRecord), callback);
+  }
+
+  @Override
+  public void flush() {
+    delegate.flush();
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(String topic) {
+    return delegate.partitionsFor(topic);
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    return delegate.metrics();
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public void close(Duration timeout) {
+    delegate.close(timeout);
+  }
+
+  private ProducerRecord<K, V> withMetadataContext(ProducerRecord<K, V> producerRecord) {
+    if (metadataFields.isEmpty()) {
+      return producerRecord;
+    }
+    var headers = new RecordHeaders(producerRecord.headers());
+    MetadataContext metadataContext = MetadataContext.current();
+    for (String metadataField : metadataFields) {
+      List<String> valuesByKey = metadataContext.valuesByKey(metadataField);
+      if (valuesByKey == null) {
+        continue;
+      }
+      valuesByKey.stream()
+          .filter(StringUtils::isNotBlank)
+          .map(String::trim)
+          .distinct()
+          .map(v -> v.getBytes(StandardCharsets.UTF_8))
+          .forEach(v -> headers.add(metadataField, v));
+    }
+    return new ProducerRecord<>(
+        producerRecord.topic(),
+        producerRecord.partition(),
+        producerRecord.timestamp(),
+        producerRecord.key(),
+        producerRecord.value(),
+        headers);
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleMetadataContextProducerIntegrationTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleMetadataContextProducerIntegrationTest.java
@@ -1,0 +1,191 @@
+package org.sdase.commons.server.kafka;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.sdase.commons.server.dropwizard.metadata.DetachedMetadataContext;
+import org.sdase.commons.server.dropwizard.metadata.MetadataContext;
+import org.sdase.commons.server.kafka.builder.ProducerRegistration;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
+import org.sdase.commons.server.kafka.producer.MessageProducer;
+
+@SetSystemProperty(key = "METADATA_FIELDS", value = "tenant-id")
+class KafkaBundleMetadataContextProducerIntegrationTest {
+
+  @RegisterExtension
+  @Order(0)
+  private static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource();
+
+  @RegisterExtension
+  @Order(1)
+  private static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
+      new DropwizardAppExtension<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString),
+
+          // performance improvements in the tests
+          config("kafka.config.heartbeat\\.interval\\.ms", "250"),
+          config("kafka.adminConfig.adminClientRequestTimeoutMs", "30000"));
+
+  private static final String TOPIC = "metadata-producer";
+
+  private int messagesBefore = 0;
+
+  private MessageProducer<String, String> kafkaProducer;
+
+  @BeforeAll
+  static void createTopic() {
+    KAFKA.getKafkaTestUtils().createTopic(TOPIC, 1, (short) 1);
+  }
+
+  @BeforeEach
+  void before() {
+    messagesBefore = KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC).size();
+
+    KafkaTestApplication app = DROPWIZARD_APP_EXTENSION.getApplication();
+    KafkaBundle<KafkaTestConfiguration> kafkaBundle = app.kafkaBundle();
+
+    ProducerRegistration<String, String> producerRegistration =
+        ProducerRegistration.builder()
+            .forTopic(TOPIC)
+            .withDefaultProducer()
+            .withKeySerializer(new StringSerializer())
+            .withValueSerializer(new StringSerializer())
+            .build();
+    kafkaProducer = kafkaBundle.registerProducer(producerRegistration);
+  }
+
+  @BeforeEach
+  @AfterEach
+  void clearMetadata() {
+    MetadataContext.createContext(new DetachedMetadataContext());
+  }
+
+  @Test
+  void shouldSendMetadataContext() {
+    DetachedMetadataContext given = new DetachedMetadataContext();
+    given.put("tenant-id", List.of("t-1"));
+    MetadataContext.createContext(given);
+
+    kafkaProducer.send("key", "value");
+
+    await()
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<byte[], byte[]>> consumerRecords =
+                  KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC);
+              assertThat(consumerRecords).hasSize(messagesBefore + 1);
+              assertThat(consumerRecords.get(consumerRecords.size() - 1).headers())
+                  .extracting(Header::key, Header::value)
+                  .contains(tuple("tenant-id", "t-1".getBytes(StandardCharsets.UTF_8)));
+            });
+  }
+
+  @Test
+  void shouldKeepDefinedHeaders() {
+    DetachedMetadataContext given = new DetachedMetadataContext();
+    given.put("tenant-id", List.of("t-1"));
+    MetadataContext.createContext(given);
+    var headers = new RecordHeaders();
+    headers.add("custom", "custom-value".getBytes(StandardCharsets.UTF_8));
+
+    kafkaProducer.send("key", "value", headers);
+
+    await()
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<byte[], byte[]>> consumerRecords =
+                  KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC);
+              assertThat(consumerRecords).hasSize(messagesBefore + 1);
+              assertThat(consumerRecords.get(consumerRecords.size() - 1).headers())
+                  .extracting(Header::key, Header::value)
+                  .contains(
+                      tuple("tenant-id", "t-1".getBytes(StandardCharsets.UTF_8)),
+                      tuple("custom", "custom-value".getBytes(StandardCharsets.UTF_8)));
+            });
+  }
+
+  @Test
+  void shouldPreferHeadersFromMetadataContext() {
+    DetachedMetadataContext given = new DetachedMetadataContext();
+    given.put("tenant-id", List.of("t-1"));
+    MetadataContext.createContext(given);
+    var headers = new RecordHeaders();
+    headers.add("tenant-id", "custom-tenant".getBytes(StandardCharsets.UTF_8));
+
+    kafkaProducer.send("key", "value", headers);
+
+    await()
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<byte[], byte[]>> consumerRecords =
+                  KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC);
+              assertThat(consumerRecords).hasSize(messagesBefore + 1);
+              assertThat(consumerRecords.get(consumerRecords.size() - 1).headers())
+                  .extracting(Header::key, Header::value)
+                  .contains(tuple("tenant-id", "t-1".getBytes(StandardCharsets.UTF_8)));
+            });
+  }
+
+  @Test
+  void shouldSendMetadataContextNormalized() {
+    DetachedMetadataContext given = new DetachedMetadataContext();
+    given.put("tenant-id", List.of("t-1", "  ", " t-2 "));
+    MetadataContext.createContext(given);
+
+    kafkaProducer.send("key", "value");
+
+    await()
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<byte[], byte[]>> consumerRecords =
+                  KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC);
+              assertThat(consumerRecords).hasSize(messagesBefore + 1);
+              assertThat(consumerRecords.get(consumerRecords.size() - 1).headers())
+                  .extracting(Header::key, Header::value)
+                  .contains(
+                      tuple("tenant-id", "t-1".getBytes(StandardCharsets.UTF_8)),
+                      tuple("tenant-id", "t-2".getBytes(StandardCharsets.UTF_8)));
+            });
+  }
+
+  @Test
+  void shouldNotSendUnknownFieldsOfMetadataContext() {
+    DetachedMetadataContext given = new DetachedMetadataContext();
+    given.put("shop-id", List.of("s-1"));
+    MetadataContext.createContext(given);
+
+    kafkaProducer.send("key", "value");
+
+    await()
+        .untilAsserted(
+            () -> {
+              List<ConsumerRecord<byte[], byte[]>> consumerRecords =
+                  KAFKA.getKafkaTestUtils().consumeAllRecordsFromTopic(TOPIC);
+              assertThat(consumerRecords).hasSize(messagesBefore + 1);
+              assertThat(consumerRecords.get(consumerRecords.size() - 1).headers())
+                  .extracting(Header::key, Header::value)
+                  .doesNotContain(tuple("shop-id", "s-1".getBytes(StandardCharsets.UTF_8)));
+            });
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.LongDeserializer;
@@ -233,7 +234,7 @@ class KafkaBundleWithConfigIT {
       assertThrows(
           ConfigurationException.class,
           () -> {
-            try (KafkaProducer<String, String> producer =
+            try (Producer<String, String> ignored =
                 kafkaBundle.createProducer(
                     keySerializer, keySerializer, "notExistingProducerConfig")) {
               // empty
@@ -244,7 +245,7 @@ class KafkaBundleWithConfigIT {
 
   @Test
   void shouldReturnProducerByProducerConfigName() {
-    try (KafkaProducer<String, String> producer =
+    try (Producer<String, String> producer =
         kafkaBundle.createProducer(new StringSerializer(), new StringSerializer(), PRODUCER_1)) {
       assertThat(producer).isNotNull();
       assertThat(KafkaHelper.getClientId(producer)).isEqualTo(PRODUCER_1);
@@ -253,7 +254,7 @@ class KafkaBundleWithConfigIT {
 
   @Test
   void shouldReturnProducerByProducerConfig() {
-    try (KafkaProducer<String, String> producer =
+    try (Producer<String, String> producer =
         kafkaBundle.createProducer(
             null,
             null,
@@ -751,7 +752,7 @@ class KafkaBundleWithConfigIT {
 
   @Test
   void shouldSetProducerNameCorrectlyWithProducerConfig() {
-    try (KafkaProducer<String, String> p1 =
+    try (Producer<String, String> p1 =
         kafkaBundle.createProducer(
             new StringSerializer(),
             new StringSerializer(),
@@ -762,7 +763,7 @@ class KafkaBundleWithConfigIT {
 
   @Test
   void shouldSetProducerNameCorrectlyWithProducerConfigFromYaml() {
-    try (KafkaProducer<String, String> p1 =
+    try (Producer<String, String> p1 =
         kafkaBundle.createProducer(new StringSerializer(), new StringSerializer(), PRODUCER_1)) {
       assertThat(KafkaHelper.getClientId(p1)).isEqualTo(PRODUCER_1);
     }
@@ -770,7 +771,7 @@ class KafkaBundleWithConfigIT {
 
   @Test
   void shouldSetProducerNameCorrectlyWithProducerConfigFromYamlWithExplicitClientId() {
-    try (KafkaProducer<String, String> p1 =
+    try (Producer<String, String> p1 =
         kafkaBundle.createProducer(new StringSerializer(), new StringSerializer(), PRODUCER_2)) {
       assertThat(KafkaHelper.getClientId(p1)).isEqualTo("p2");
     }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/MetadataContextAwareKafkaProducerTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/producer/MetadataContextAwareKafkaProducerTest.java
@@ -1,0 +1,312 @@
+package org.sdase.commons.server.kafka.producer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.utils.Time;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.sdase.commons.server.dropwizard.metadata.DetachedMetadataContext;
+import org.sdase.commons.server.dropwizard.metadata.MetadataContext;
+
+class MetadataContextAwareKafkaProducerTest {
+
+  static final Set<String> metadataFields = Set.of("tenant-id");
+
+  @SuppressWarnings("unchecked")
+  Producer<String, String> delegateProducerMock = mock(Producer.class);
+
+  MetadataContextAwareKafkaProducer<String, String> producer =
+      new MetadataContextAwareKafkaProducer<>(delegateProducerMock, metadataFields);
+
+  @AfterEach
+  void reset() {
+    MetadataContext.createContext(new DetachedMetadataContext());
+  }
+
+  @Test
+  void shouldNotModifyWithoutConfiguredFields() {
+    var noMetadataProducer = new MetadataContextAwareKafkaProducer<>(delegateProducerMock, null);
+
+    var arg1 = new ProducerRecord<>("topic", 1, 10L, "k", "v");
+    var result = new CompletableFuture<RecordMetadata>();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<ProducerRecord<String, String>> sentRecord =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    when(delegateProducerMock.send(sentRecord.capture())).thenReturn(result);
+
+    var actual = noMetadataProducer.send(arg1);
+
+    assertThat(actual).isSameAs(result);
+    verify(delegateProducerMock, times(1)).send(arg1);
+    assertThat(sentRecord.getValue()).isSameAs(arg1);
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldNotModifyWithoutConfiguredFieldsWithCallback() {
+    var noMetadataProducer = new MetadataContextAwareKafkaProducer<>(delegateProducerMock, null);
+
+    var arg1 = new ProducerRecord<>("topic", 1, 10L, "k", "v");
+    var result = new CompletableFuture<RecordMetadata>();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<ProducerRecord<String, String>> sentRecord =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+    Callback callback = (m, e) -> {};
+
+    when(delegateProducerMock.send(sentRecord.capture(), eq(callback))).thenReturn(result);
+
+    var actual = noMetadataProducer.send(arg1, callback);
+
+    assertThat(actual).isSameAs(result);
+    verify(delegateProducerMock, times(1)).send(arg1, callback);
+    assertThat(sentRecord.getValue()).isSameAs(arg1);
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @ParameterizedTest
+  @MethodSource("sendTestData")
+  void shouldModifyHeadersOnSend(
+      Map<String, List<String>> context,
+      Map<String, String> headers,
+      Map<String, List<String>> expectedHeaders) {
+    var givenContext = new DetachedMetadataContext();
+    givenContext.putAll(context);
+    MetadataContext.createContext(givenContext);
+
+    var givenRecord = new ProducerRecord<>("topic", 1, 10L, "k", "v", toHeaders(headers));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<ProducerRecord<String, String>> sentRecord =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    var result = new CompletableFuture<RecordMetadata>();
+
+    when(delegateProducerMock.send(sentRecord.capture())).thenReturn(result);
+
+    var actual = producer.send(givenRecord);
+
+    assertThat(actual).isSameAs(result);
+
+    verify(delegateProducerMock, times(1)).send(any());
+    verifyNoMoreInteractions(delegateProducerMock);
+    assertThat(sentRecord.getValue())
+        .extracting(
+            ProducerRecord::topic,
+            ProducerRecord::partition,
+            ProducerRecord::timestamp,
+            ProducerRecord::key,
+            ProducerRecord::value)
+        .contains("topic", 1, 10L, "k", "v");
+    assertThat(sentRecord.getValue().headers())
+        .extracting(Header::key, h -> new String(h.value(), UTF_8))
+        .containsExactlyInAnyOrderElementsOf(
+            expectedHeaders.entrySet().stream()
+                .flatMap(e -> e.getValue().stream().map(v -> tuple(e.getKey(), v)))
+                .collect(Collectors.toList()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("sendTestData")
+  void shouldModifyHeadersOnSendWithPassedThroughCallback(
+      Map<String, List<String>> context,
+      Map<String, String> headers,
+      Map<String, List<String>> expectedHeaders) {
+    var givenContext = new DetachedMetadataContext();
+    givenContext.putAll(context);
+    MetadataContext.createContext(givenContext);
+
+    var givenRecord = new ProducerRecord<>("topic", 1, 10L, "k", "v", toHeaders(headers));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<ProducerRecord<String, String>> sentRecord =
+        ArgumentCaptor.forClass(ProducerRecord.class);
+
+    var result = new CompletableFuture<RecordMetadata>();
+    Callback callback = (m, e) -> {};
+
+    when(delegateProducerMock.send(sentRecord.capture(), eq(callback))).thenReturn(result);
+
+    var actual = producer.send(givenRecord, callback);
+
+    assertThat(actual).isSameAs(result);
+
+    verify(delegateProducerMock, times(1)).send(any(), eq(callback));
+    verifyNoMoreInteractions(delegateProducerMock);
+    assertThat(sentRecord.getValue())
+        .extracting(
+            ProducerRecord::topic,
+            ProducerRecord::partition,
+            ProducerRecord::timestamp,
+            ProducerRecord::key,
+            ProducerRecord::value)
+        .contains("topic", 1, 10L, "k", "v");
+    assertThat(sentRecord.getValue().headers())
+        .extracting(Header::key, h -> new String(h.value(), UTF_8))
+        .containsExactlyInAnyOrderElementsOf(
+            expectedHeaders.entrySet().stream()
+                .flatMap(e -> e.getValue().stream().map(v -> tuple(e.getKey(), v)))
+                .collect(Collectors.toList()));
+  }
+
+  private static List<Header> toHeaders(Map<String, String> headers) {
+    return headers.entrySet().stream()
+        .map(e -> new RecordHeader(e.getKey(), e.getValue().getBytes(UTF_8)))
+        .collect(Collectors.toList());
+  }
+
+  static Stream<Arguments> sendTestData() {
+    // given context, given headers, expected headers
+    return Stream.of(
+        Arguments.of(
+            Map.of("tenant-id", List.of("t1")), Map.of(), Map.of("tenant-id", List.of("t1"))),
+        Arguments.of(Map.of("unknown", List.of("unknown-value")), Map.of(), Map.of()),
+        Arguments.of(Map.of(), Map.of(), Map.of()),
+        Arguments.of(
+            Map.of("tenant-id", List.of("t1")),
+            Map.of("something", "great"),
+            Map.of("something", List.of("great"), "tenant-id", List.of("t1"))),
+        Arguments.of(
+            Map.of("tenant-id", List.of("t1")),
+            Map.of("tenant-id", "custom"),
+            Map.of("tenant-id", List.of("custom", "t1"))),
+        Arguments.of(
+            Map.of("tenant-id", List.of("t1", "  ", " t2 ")),
+            Map.of(),
+            Map.of("tenant-id", List.of("t1", "t2"))));
+  }
+
+  @Test
+  void shouldDelegateInitTransactions() {
+    producer.initTransactions();
+    verify(delegateProducerMock, times(1)).initTransactions();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateBeginTransaction() {
+    producer.beginTransaction();
+    verify(delegateProducerMock, times(1)).beginTransaction();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateSendOffsetsToTransactionDeprecated() {
+    Map<TopicPartition, OffsetAndMetadata> arg1 =
+        Map.of(new TopicPartition("topic", 1), mock(OffsetAndMetadata.class));
+    String arg2 = "group-id";
+    producer.sendOffsetsToTransaction(arg1, arg2);
+    //noinspection deprecation
+    verify(delegateProducerMock, times(1)).sendOffsetsToTransaction(arg1, arg2);
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateSendOffsetsToTransaction() {
+    Map<TopicPartition, OffsetAndMetadata> arg1 =
+        Map.of(new TopicPartition("topic", 1), mock(OffsetAndMetadata.class));
+    ConsumerGroupMetadata arg2 = mock(ConsumerGroupMetadata.class);
+    producer.sendOffsetsToTransaction(arg1, arg2);
+    verify(delegateProducerMock, times(1)).sendOffsetsToTransaction(arg1, arg2);
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateCommitTransaction() {
+    producer.commitTransaction();
+    verify(delegateProducerMock, times(1)).commitTransaction();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateAbortTransaction() {
+    producer.abortTransaction();
+    verify(delegateProducerMock, times(1)).abortTransaction();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateFlush() {
+    producer.flush();
+    verify(delegateProducerMock, times(1)).flush();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegatePartitionsFor() {
+    var result = List.of(mock(PartitionInfo.class));
+    when(delegateProducerMock.partitionsFor("topic")).thenReturn(result);
+    var actual = producer.partitionsFor("topic");
+    assertThat(actual).isSameAs(result);
+    verify(delegateProducerMock, times(1)).partitionsFor("topic");
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateMetrics() {
+    MetricName name = new MetricName("m", "g", "d", Map.of());
+    Map<MetricName, ? extends Metric> result =
+        Map.of(
+            name,
+            new KafkaMetric(
+                new Object(), name, (Measurable) (c, n) -> 1d, new MetricConfig(), Time.SYSTEM));
+    when(delegateProducerMock.metrics()).thenAnswer(i -> result);
+    var actual = producer.metrics();
+    assertThat(actual).isSameAs(result);
+    verify(delegateProducerMock, times(1)).metrics();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateClose() {
+    producer.close();
+    verify(delegateProducerMock, times(1)).close();
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+
+  @Test
+  void shouldDelegateCloseWithDuration() {
+    var arg = Duration.of(1, ChronoUnit.MINUTES);
+    producer.close(arg);
+    verify(delegateProducerMock, times(1)).close(arg);
+    verifyNoMoreInteractions(delegateProducerMock);
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE: All `KafkaBundle.createProducer` methods return a `Producer` instead of its implementation `KafkaProducer` now. The public API of the `KafkaProducer` is exactly the same as in the interface.