### PR TITLE
fix(server-jackson): write invalid Json when errors happen while serialization

### DIFF
--- a/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/ObjectMapperConfigurationUtil.java
+++ b/sda-commons-server-jackson/src/main/java/org/sdase/commons/server/jackson/ObjectMapperConfigurationUtil.java
@@ -1,5 +1,6 @@
 package org.sdase.commons.server.jackson;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -155,6 +156,7 @@ public class ObjectMapperConfigurationUtil {
           .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
           .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
           .disable(SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS)
+          .disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT)
           // deserialization
           .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
           .disable(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES)

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/ProduceInvalidJsonOnFailureTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/ProduceInvalidJsonOnFailureTest.java
@@ -1,0 +1,67 @@
+package org.sdase.commons.server.jackson;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class ProduceInvalidJsonOnFailureTest {
+
+  private final ObjectMapper om = ObjectMapperConfigurationUtil.configureMapper().build();
+
+  @Test
+  void shouldNotWriteValidJsonOnSerializationError() {
+    var iterator = new FailingCloseableIterator();
+
+    var output = new ByteArrayOutputStream();
+
+    try (var generator = om.createGenerator(output)) {
+      generator.writeObject(Map.of("items", iterator));
+    } catch (Exception ignored) {
+      // nothing to do
+    }
+    var expected = new StringBuilder();
+    for (int i = 1; i < 1_001; i++) {
+      expected.append("\"").append(i).append("\",");
+    }
+    expected.deleteCharAt(expected.length() - 1);
+    var actual = output.toString(UTF_8);
+    // verify expected content
+    assertThat(actual).isEqualToIgnoringWhitespace("{\"items\":[" + expected);
+    // verify not readable
+    assertThatExceptionOfType(JsonParseException.class)
+        .isThrownBy(() -> om.readValue(actual, Object.class));
+  }
+
+  static class FailingCloseableIterator implements Iterator<String>, Closeable {
+
+    final AtomicInteger i = new AtomicInteger();
+
+    @Override
+    public void close() {
+      // do nothing on close
+    }
+
+    @Override
+    public boolean hasNext() {
+      return i.get() < 2_000;
+    }
+
+    @Override
+    public String next() {
+      var current = i.incrementAndGet();
+      if (current > 1_000) {
+        throw new IllegalStateException();
+      }
+      return "" + current;
+    }
+  }
+}


### PR DESCRIPTION
These errors are the only way to identify a serialisation error on consumer side when e.g. a Json is written directly to the response output stream. Streaming data directly from a source (e.g. a MongoCursor) into the response as chunked encoding is valuable to minimize memory resources but may lead to not identifiable errors (e.g. while mapping from entity model to API model) when the ObjectMapper creates a valid Json after the error when the generator is closed.