### PR TITLE
docs: replace deprecated OTEL_EXPORTER_JAEGER_ENDPOINT info with OTEL…

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -108,7 +108,7 @@ In order to configure Open Telemetry, you can set some environment variables:
 |-------------------------------|-----------------------------------------------|----------------------------------------------------------------------------------|
 | OTEL_PROPAGATORS              | jaeger,b3,tracecontext,baggage                | Propagators to be used as a comma-separated list                                 |
 | OTEL_SERVICE_NAME             | value from env `JAEGER_SERVICE_NAME` (if set) | The service name that will appear on tracing                                     |
-| OTEL_EXPORTER_JAEGER_ENDPOINT | http://jaeger-collector.jaeger:14250          | Full URL of the Jaeger HTTP endpoint. The URL must point to the jaeger collector |
+| OTEL_EXPORTER_OTLP_ENDPOINT   | http://jaeger-collector.jaeger:14250          | Full URL of the Jaeger HTTP endpoint. The URL must point to the jaeger collector |
 
 A full list of the configurable properties can be found in the [General SDK Configuration](https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/).
 
@@ -502,7 +502,7 @@ Changes with backward compatible fallback:
   [The official documentation](https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/#otlp-exporter)
   provides all available options.
   In an environment that previously used Jaeger, `OTEL_TRACES_EXPORTER=jaeger` and
-  `OTEL_EXPORTER_JAEGER_ENDPOINT=http://jaeger-collector.jaeger:14250` may be suitable.
+  `OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger-collector.jaeger:14250` may be suitable.
   Note that the collector endpoint may not be the same as the agent endpoint configured for Jaeger.
 
 ### Kafka


### PR DESCRIPTION
…_EXPORTER_OTLP_ENDPOINT

the env var OTEL_EXPORTER_JAEGER_ENDPOINT is deprecated and will be removed on July 2023 see: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/#jaeger-exporter
Instead we should use OTLE_EXPORTER_OTLP_ENDPOINT see: https://opentelemetry.io/docs/reference/specification/protocol/exporter/#configuration-options