### PR TITLE
feat(client-jersey): Remove dependency to sda-commons-server-opentele…

### DIFF
--- a/sda-commons-client-jersey/build.gradle
+++ b/sda-commons-client-jersey/build.gradle
@@ -2,7 +2,6 @@ dependencies {
   api project(':sda-commons-server-dropwizard')
   api project(':sda-commons-shared-tracing')
   api project(':sda-commons-shared-error')
-  api project(':sda-commons-server-opentelemetry')
 
   api 'io.dropwizard:dropwizard-client'
   api 'jakarta.servlet:jakarta.servlet-api'
@@ -12,6 +11,9 @@ dependencies {
   api 'javax.xml.bind:jaxb-api', {
     exclude group: 'javax.activation', module: 'javax.activation-api'
   }
+  api 'io.opentelemetry:opentelemetry-api'
+
+  implementation 'io.opentelemetry.instrumentation:opentelemetry-apache-httpclient-4.3'
 
   testImplementation project(':sda-commons-server-testing')
   testImplementation project(':sda-commons-client-jersey-wiremock-testing')
@@ -22,6 +24,5 @@ dependencies {
   testImplementation 'org.awaitility:awaitility'
   testImplementation 'org.assertj:assertj-core'
 
-  implementation 'io.opentelemetry.instrumentation:opentelemetry-apache-httpclient-4.3:1.16.0-alpha'
   testImplementation 'io.opentelemetry:opentelemetry-sdk-testing'
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/JerseyClientBundleNoopTracingTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/JerseyClientBundleNoopTracingTest.java
@@ -1,0 +1,75 @@
+package org.sdase.commons.client.jersey;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.MetricFilter;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sdase.commons.client.jersey.test.ClientTestApp;
+import org.sdase.commons.client.jersey.test.ClientTestConfig;
+import org.sdase.commons.client.jersey.test.MockApiClient;
+import org.sdase.commons.client.jersey.wiremock.testing.WireMockClassExtension;
+
+class JerseyClientBundleNoopTracingTest {
+
+  @RegisterExtension
+  @Order(0)
+  private static final WireMockClassExtension WIRE =
+      new WireMockClassExtension(wireMockConfig().dynamicPort());
+
+  @RegisterExtension
+  @Order(1)
+  private static final DropwizardAppExtension<ClientTestConfig> DW =
+      new DropwizardAppExtension<>(
+          ClientTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("mockBaseUrl", WIRE::baseUrl));
+
+  @BeforeEach
+  void resetRequests() {
+    WIRE.resetRequests();
+    ClientTestApp app = DW.getApplication();
+
+    // reset the metrics since we don't use it in this test
+    DW.getEnvironment().metrics().removeMatching(MetricFilter.ALL);
+
+    WIRE.stubFor(
+        get("/api/cars")
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-type", "application/json")
+                    .withBody("[]"))); // real value not important
+
+    var cars =
+        app.getJerseyClientBundle()
+            .getClientFactory()
+            .platformClient()
+            .api(MockApiClient.class)
+            .atTarget(WIRE.baseUrl())
+            .getCars();
+    assertThat(cars).isNotNull();
+  }
+
+  @Test
+  void tracerShouldBeNoop() throws ClassNotFoundException {
+    OpenTelemetry actual = GlobalOpenTelemetry.get();
+    assertThat(actual)
+        .extracting("delegate")
+        .extracting("propagators")
+        .extracting("textMapPropagator")
+        .isInstanceOf(Class.forName("io.opentelemetry.context.propagation.NoopTextMapPropagator"));
+  }
+}

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
@@ -1,0 +1,63 @@
+package org.sdase.commons.server;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sdase.commons.server.opa.testing.AbstractOpa.onAnyRequest;
+
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sdase.commons.server.auth.testing.AuthClassExtension;
+import org.sdase.commons.server.opa.testing.OpaClassExtension;
+import org.sdase.commons.server.opa.testing.test.AuthAndOpaBundeTestAppConfiguration;
+import org.sdase.commons.server.opa.testing.test.AuthAndOpaBundleTestApp;
+
+class AuthNoopTracerTest {
+
+  @Order(0)
+  @RegisterExtension
+  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+
+  @RegisterExtension
+  @Order(1)
+  private static final OpaClassExtension OPA = new OpaClassExtension();
+
+  @RegisterExtension
+  @Order(2)
+  private static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
+      new DropwizardAppExtension<>(
+          AuthAndOpaBundleTestApp.class,
+          resourceFilePath("test-config.yaml"),
+          config("opa.baseUrl", OPA::getUrl));
+
+  @BeforeEach
+  void makeRequest() {
+    OPA.mock(onAnyRequest().allow());
+    try (var response =
+        DW.client()
+            .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
+            .path("resources")
+            .request()
+            .headers(AUTH.auth().buildAuthHeader())
+            .get()) {
+      assertThat(response).extracting(Response::getStatus).isEqualTo(200);
+    }
+    OPA.verify(1, "GET", "/resources");
+  }
+
+  @Test
+  void tracerShouldBeNoop() throws ClassNotFoundException {
+    OpenTelemetry actual = GlobalOpenTelemetry.get();
+    assertThat(actual)
+        .extracting("delegate")
+        .extracting("propagators")
+        .extracting("textMapPropagator")
+        .isInstanceOf(Class.forName("io.opentelemetry.context.propagation.NoopTextMapPropagator"));
+  }
+}

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -1,17 +1,19 @@
 dependencies {
   api project(':sda-commons-server-dropwizard')
   api project(':sda-commons-shared-error')
-  api project(':sda-commons-server-opentelemetry')
   api project(':sda-commons-shared-tracing')
+
   api 'io.dropwizard:dropwizard-auth'
   api 'io.dropwizard:dropwizard-client'
-  api 'jakarta.servlet:jakarta.servlet-api'
 
   api 'com.auth0:java-jwt'
   api 'org.bouncycastle:bcpkix-jdk15on'
   api 'javax.xml.bind:jaxb-api', {
     exclude group: 'javax.activation', module: 'javax.activation-api'
   }
+  api 'io.opentelemetry:opentelemetry-api'
+
+  implementation 'io.opentelemetry.instrumentation:opentelemetry-apache-httpclient-4.3'
 
   testImplementation project(':sda-commons-server-testing')
   testImplementation project(':sda-commons-client-jersey-wiremock-testing')

--- a/sda-commons-server-auth/build.gradle
+++ b/sda-commons-server-auth/build.gradle
@@ -18,4 +18,5 @@ dependencies {
   testImplementation project(':sda-commons-server-testing')
   testImplementation project(':sda-commons-client-jersey-wiremock-testing')
   testImplementation 'org.awaitility:awaitility'
+  testImplementation 'io.opentelemetry:opentelemetry-sdk-testing'
 }

--- a/sda-commons-server-opentelemetry/src/main/java/org/sdase/commons/server/opentelemetry/client/TracedHttpClientInitialBuilder.java
+++ b/sda-commons-server-opentelemetry/src/main/java/org/sdase/commons/server/opentelemetry/client/TracedHttpClientInitialBuilder.java
@@ -11,7 +11,10 @@ import org.apache.http.impl.client.HttpClientBuilder;
  * {@link JerseyClientBuilder#setApacheHttpClientBuilder(io.dropwizard.client.HttpClientBuilder)}
  * and preferably be set as soon as creating a new {@link JerseyClientBuilder} instance in order to
  * avoid rewriting custom configuration.
+ *
+ * @deprecated no replacement planned
  */
+@Deprecated(forRemoval = true)
 public class TracedHttpClientInitialBuilder extends io.dropwizard.client.HttpClientBuilder {
   private OpenTelemetry openTelemetry;
 

--- a/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/client/TracedHttpClientInitialBuilderTest.java
+++ b/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/client/TracedHttpClientInitialBuilderTest.java
@@ -1,0 +1,25 @@
+package org.sdase.commons.server.opentelemetry.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.setup.Environment;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class TracedHttpClientInitialBuilderTest {
+  @Test
+  void shouldUseGivenOtel() {
+    var givenPropagators = Mockito.mock(ContextPropagators.class, Mockito.RETURNS_DEEP_STUBS);
+    var given = Mockito.mock(OpenTelemetry.class, Mockito.RETURNS_DEEP_STUBS);
+    Mockito.when(given.getPropagators()).thenReturn(givenPropagators);
+    @SuppressWarnings("removal")
+    var actual =
+        new TracedHttpClientInitialBuilder(
+                Mockito.mock(Environment.class, Mockito.RETURNS_DEEP_STUBS))
+            .usingTelemetryInstance(given)
+            .createBuilder();
+    assertThat(actual).extracting("propagators").isSameAs(givenPropagators);
+  }
+}

--- a/sda-commons-server-s3/build.gradle
+++ b/sda-commons-server-s3/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   api project(':sda-commons-server-healthcheck')
   api 'com.amazonaws:aws-java-sdk-s3'
   api 'org.slf4j:jcl-over-slf4j'
+  api 'io.opentelemetry:opentelemetry-api'
 
   implementation 'io.opentelemetry.instrumentation:opentelemetry-aws-sdk-1.11'
 


### PR DESCRIPTION
…metry

This change prevents that applications that don't use our "sda-commons-starter" activate collection of Telemetry collection.

## Why was OTEL activated before?

sda-commons-server-opentelemetry defines a dependency to `io.opentelemetry:opentelemetry-sdk-extension-autoconfigure`. This causes `GlobalOpenTelemetry` to return an active instance of `OpenTelemetry` instead of the `noop` implementation.

## What is the result of this change?

* Applications that use "sda-commons-starter" will still get an active `OpenTelemetry` instance
* Applications that only use the jersey-client bundle or other bundles will not pull in "sda-commons-server-opentelemetry" anymore - thus use the `noop` implementation of `OpenTelemetry`

## BREAKING CHANGE?

Strictly speaking this is a breaking change because I changed the dependencies and moved one class to "sda-commons-client-jersey". As we had several complaints in the past: Should we make this a BREAKING CHANGE commit?