### PR TITLE
fix(deps): bump org.springframework.data:spring-data-mongodb from 3.4…

### DIFF
--- a/sda-commons-server-spring-data-mongo/build.gradle
+++ b/sda-commons-server-spring-data-mongo/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
   // See compatibility matrix:
   // https://docs.spring.io/spring-data/mongodb/docs/current/reference/html/#compatibility.matrix
-  api 'org.springframework.data:spring-data-mongodb:3.4.6'
+  api 'org.springframework.data:spring-data-mongodb:3.4.11'
   api 'org.mongodb:mongodb-driver-core:4.6.1'
   api 'org.mongodb:mongodb-driver-sync:4.6.1'
   api "io.opentelemetry:opentelemetry-api"


### PR DESCRIPTION
... from 3.4.6 to 3.4.11

Release Notes:
* [3.4.7](https://github.com/spring-projects/spring-data-mongodb/releases/tag/3.4.7)
* [3.4.8](https://github.com/spring-projects/spring-data-mongodb/releases/tag/3.4.8)
* [3.4.9](https://github.com/spring-projects/spring-data-mongodb/releases/tag/3.4.9)
* [3.4.10](https://github.com/spring-projects/spring-data-mongodb/releases/tag/3.4.10)
* [3.4.11](https://github.com/spring-projects/spring-data-mongodb/releases/tag/3.4.11)