### PR TITLE
fix(deps): bump dropwizardVersion from 2.1.5 to 2.1.6

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -7,7 +7,7 @@ javaPlatform {
 }
 
 ext {
-  dropwizardVersion = '2.1.5'
+  dropwizardVersion = '2.1.6'
   morphiaVersion = '1.6.1'
   prometheusVersion = '0.16.0'
   swaggerCoreVersion = '1.6.10'


### PR DESCRIPTION
Bumps `dropwizardVersion` from 2.1.5 to 2.1.6.

Updates `io.dropwizard:dropwizard-bom` & `io.dropwizard:dropwizard-dependencies` from 2.1.5 to 2.1.6
- [Release notes](https://github.com/dropwizard/dropwizard/releases)
- [Commits](https://github.com/dropwizard/dropwizard/compare/v2.1.5...v2.1.6)