### PR TITLE
fix(server-dropwizard): log level not limited by appender threshold

### DIFF
--- a/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
+++ b/sda-commons-server-dropwizard/src/main/java/org/sdase/commons/server/dropwizard/logging/ConsoleAppenderInjectorSourceProvider.java
@@ -25,7 +25,8 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
   private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final String DEFAULT_LOG_FORMAT =
       "[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n";
-  private static final String DEFAULT_THRESHOLD = "INFO";
+  private static final String DEFAULT_THRESHOLD = "TRACE";
+  private static final String DEFAULT_LOGGING_LEVEL = "INFO";
 
   private final ConfigurationSourceProvider delegate;
 
@@ -65,7 +66,12 @@ public class ConsoleAppenderInjectorSourceProvider implements ConfigurationSourc
     root.putIfAbsent("logging", new HashMap<String, Object>());
     @SuppressWarnings("unchecked")
     Map<String, Object> logging = (Map<String, Object>) root.get("logging");
+    applyLoggingLevel(logging);
     applyLoggingAppenders(logging);
+  }
+
+  private void applyLoggingLevel(Map<String, Object> logging) {
+    logging.putIfAbsent("level", DEFAULT_LOGGING_LEVEL);
   }
 
   private void applyLoggingAppenders(Map<String, Object> logging) {

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
@@ -28,6 +28,8 @@ class DefaultLoggingConfigurationBundleWithEmptyConfigTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("INFO");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -40,7 +42,7 @@ class DefaultLoggingConfigurationBundleWithEmptyConfigTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
@@ -34,6 +34,8 @@ class DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("WARN");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -46,7 +48,7 @@ class DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isInstanceOf(EventJsonLayoutBaseFactory.class);
 
     EventJsonLayoutBaseFactory layout =

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
@@ -28,6 +28,8 @@ class DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("INFO");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -40,7 +42,7 @@ class DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
@@ -28,6 +28,8 @@ class DefaultLoggingConfigurationBundleWithoutAppendersKeyTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("WARN");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -40,7 +42,7 @@ class DefaultLoggingConfigurationBundleWithoutAppendersKeyTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
@@ -28,6 +28,8 @@ class DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("INFO");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -40,7 +42,7 @@ class DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
@@ -28,6 +28,8 @@ class DefaultLoggingConfigurationBundleWithoutLoggingKeyTest {
     DefaultLoggingFactory defaultLoggingFactory =
         (DefaultLoggingFactory) app.getConfiguration().getLoggingFactory();
 
+    assertThat(defaultLoggingFactory.getLevel()).isEqualTo("INFO");
+
     List<AppenderFactory<ILoggingEvent>> consoleAppenderFactories =
         defaultLoggingFactory.getAppenders().stream()
             .filter(a -> a instanceof ConsoleAppenderFactory)
@@ -40,7 +42,7 @@ class DefaultLoggingConfigurationBundleWithoutLoggingKeyTest {
 
     assertThat(consoleAppenderFactory.getLogFormat())
         .isEqualTo("[%d] [%-5level] [%X{Trace-Token}] %logger{36} - %msg%n");
-    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("INFO");
+    assertThat(consoleAppenderFactory.getThreshold()).isEqualTo("TRACE");
     assertThat(consoleAppenderFactory.getLayout()).isNull();
   }
 }

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/LogLevelSystemPropertyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/LogLevelSystemPropertyTest.java
@@ -1,0 +1,38 @@
+package org.sdase.commons.server.dropwizard.bundles;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.SetSystemProperty;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
+import org.sdase.commons.server.dropwizard.bundles.test.RequestLoggingTestApp;
+
+@SetSystemProperty(key = "dw.logging.level", value = "DEBUG")
+class LogLevelSystemPropertyTest {
+
+  @RegisterExtension
+  static final DropwizardAppExtension<Configuration> DW =
+      new DropwizardAppExtension<>(
+          RequestLoggingTestApp.class, resourceFilePath("with-empty-config.yaml"));
+
+  @StdIo
+  @Test
+  void shouldProduceDebugOutput(StdOut out) {
+
+    try (Response testResponse = createWebTarget().path("test").request().get()) {
+
+      assertThat(out.capturedLines()).anyMatch(l -> l.contains("[DEBUG]"));
+    }
+  }
+
+  private WebTarget createWebTarget() {
+    return DW.client().target(String.format("http://localhost:%d/", DW.getLocalPort()));
+  }
+}


### PR DESCRIPTION
Actual log output level is depended on "logging.level" and "logging.appenders.threshold". This fix will set appender threshold to "TRACE". This will allow full control of log output using logging.level. All logging default values can be overwritten.