### PR TITLE
fix(deps): bump Open Telemetry from 1.16.0 to 1.19.0

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -20,11 +20,10 @@ ext {
   kotlinVersion = '1.8.21'
   kotlinxCoroutinesVersion = '1.7.0'
   resilience4jVersion = '1.7.1'
-  otelAgentAlphaVersion = '1.16.0-alpha'
-  openTelemetryAlphaVersion = '1.16.0-alpha'
-  openTelemetryVersion= '1.16.0' // Matching version: https://github.com/open-telemetry/opentelemetry-java
-  openTelemetryAlphaVersion = '1.16.0-alpha'
-  otelInstrumentationAlphaVersion = '1.16.0-alpha'
+  otelAgentAlphaVersion = '1.19.0-alpha'
+  openTelemetryVersion= '1.19.0' // Matching version: https://github.com/open-telemetry/opentelemetry-java
+  openTelemetryAlphaVersion = '1.19.0-alpha'
+  otelInstrumentationAlphaVersion = '1.19.0-alpha'
 }
 
 dependencies {


### PR DESCRIPTION
Release Notes:
* https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.17.0
* https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.18.0
* https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v1.19.0

Only the update to 1.20.0 will break the builds.