### PR TITLE
refactor(server-kafka): remove unnecessary implementation

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/producer/KafkaMessageProducer.java
@@ -30,13 +30,6 @@ public class KafkaMessageProducer<K, V> implements MessageProducer<K, V> {
   }
 
   @Override
-  public Future<RecordMetadata> send(K key, V value, Headers headers) {
-    ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, null, key, value, headers);
-    msgCounter.increase(producerName, producerRecord.topic());
-    return producer.send(producerRecord);
-  }
-
-  @Override
   public Future<RecordMetadata> send(K key, V value, Headers headers, Callback callback) {
     ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, null, key, value, headers);
     msgCounter.increase(producerName, producerRecord.topic());


### PR DESCRIPTION
The same behaviour is covered in the default method of the interface.