### PR TITLE
 fix(deps): bump org.xerial.snappy:snappy-java from 1.1.8.4 to 1.1.10.1

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -179,7 +179,7 @@ dependencies {
           anymore.
         '''
     }
-    api "org.xerial.snappy:snappy-java:1.1.8.4", {
+    api "org.xerial.snappy:snappy-java:1.1.10.1", {
       because "conflict between org.apache.kafka:kafka-clients and org.apache.curator:curator-test upgrade"
     }
     api "org.scala-lang.modules:scala-java8-compat_2.13:1.0.2", {


### PR DESCRIPTION
Release Notes:

* https://github.com/xerial/snappy-java/releases/tag/v1.1.9.0
* https://github.com/xerial/snappy-java/releases/tag/v1.1.9.1
* https://github.com/xerial/snappy-java/releases/tag/v1.1.10.0
* https://github.com/xerial/snappy-java/releases/tag/v1.1.10.1

It looks like [this PR](https://github.com/SDA-SE/sda-dropwizard-commons/pull/1098) has deactivated all minor updates.
> OK, I won't notify you about version 1.1.x again, unless you re-open this PR or update to a 1.1.x release yourself.

I hope that this PR will reactivate Dependabot's updates again.