### PR TITLE
Exclude weld-probe-core from weld-bundle

### DIFF
--- a/sda-commons-server-weld/build.gradle
+++ b/sda-commons-server-weld/build.gradle
@@ -31,6 +31,12 @@ dependencies {
      * We keep the version managed by Dropwizard.
      */
     exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
+
+    /**
+     * The probe bundle is responsible for most vulnerabilities in the weld bundle.
+     * However, it is not needed at runtime as it is a developer tool.
+     */
+    exclude group: 'org.jboss.weld.probe', module: 'weld-probe-core'
   }
   api 'org.jboss.weld.servlet:weld-servlet-core', {
     /**
@@ -61,6 +67,12 @@ dependencies {
      * We keep the version managed by Dropwizard.
      */
     exclude group: 'org.jboss.spec.javax.annotation', module: 'jboss-annotations-api_1.3_spec'
+
+    /**
+     * The probe bundle is responsible for most vulnerabilities in the weld bundle.
+     * However, it is not needed at runtime as it is a developer tool.
+     */
+    exclude group: 'org.jboss.weld.probe', module: 'weld-probe-core'
   }
   api 'jakarta.inject:jakarta.inject-api'
   api 'org.glassfish:jakarta.el'


### PR DESCRIPTION
The probe bundle is responsible for most vulnerabilities in the weld bundle. However, it is not needed at runtime as it is a developer tool.

See
https://docs.jboss.org/weld/reference/3.1.9.Final/en-US/html/developmentmode.html
https://github.com/weld/core/pull/2792

weld-probe-core is also responsible for multiple breaking builds inside SIGNAL-IDUNA due to its multiple cves.