### PR TITLE
Another try to update snakeyaml

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -5,10 +5,6 @@ import data.lib.trivy
 default ignore = false
 
 ignore_cves := {
-  # Snakeyaml 1.33
-  # no update possible because of incompatibilities with current Jackson version
-  # unlikely to exploit because yaml should only be used for configuration
-  "CVE-2022-1471",
   # H2 database only used for testing, not in production
   "CVE-2022-45868",
 }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -74,8 +74,9 @@ dependencies {
     api "org.jboss.logging:jboss-logging:3.5.3.Final", {
       because "conflict between org.hibernate.validator:hibernate-validator and org.jboss.weld.se:weld-se-core"
     }
-    api "org.yaml:snakeyaml:1.33", {
+    api "org.yaml:snakeyaml:2.0", {
       because "conflict between com.github.ftrossbach:club-topicana-core and com.github.database-rider:rider-core and com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+      because "vulnerability CVE-2022-1471 in 1.33 and below"
     }
     api "net.javacrumbs.json-unit:json-unit-core:$jsonUnitVersion", {
       because "conflict between com.github.tomakehurst:wiremock-jre8 and net.javacrumbs.json-unit:json-unit-assertj"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -13,6 +13,7 @@ ext {
   swaggerCoreVersion = '1.6.9'
   swaggerCoreV3Version = '2.2.15'
   weldVersion = '3.1.9.Final'
+  jacksonVersion = '2.15.2'
   jsonUnitVersion = '2.38.0'
   scalaVersion = '2.13.11' // align transitive dependency from various modules, keep up to date
   kafkaVersion = '3.5.0'
@@ -27,6 +28,8 @@ ext {
 }
 
 dependencies {
+  // overwrite version used by Dropwizard to comply with Snakeyaml 2.0
+  api enforcedPlatform("com.fasterxml.jackson:jackson-bom:${jacksonVersion}")
   // override version from dropwizard-bom
   api enforcedPlatform("org.jetbrains.kotlin:kotlin-bom:$kotlinVersion"), {
     exclude group: 'org.jetbrains', module: 'annotations'
@@ -42,6 +45,12 @@ dependencies {
     exclude group: 'org.assertj', module: 'assertj-core'
     exclude group: 'jakarta.xml.bind', module: 'jakarta.xml.bind-api'
     exclude group: 'org.junit', module: 'junit'
+    exclude group: 'com.fasterxml.jackson'
+    exclude group: 'com.fasterxml.jackson.core'
+    exclude group: 'com.fasterxml.jackson.dataformat'
+    exclude group: 'com.fasterxml.jackson.datatype'
+    exclude group: 'com.fasterxml.jackson.jaxrs'
+    exclude group: 'com.fasterxml.jackson.module'
   }
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.12.504")
   api enforcedPlatform("io.opentelemetry:opentelemetry-bom:$openTelemetryVersion")

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/DateFormatObjectMapperTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/DateFormatObjectMapperTest.java
@@ -503,7 +503,7 @@ class DateFormatObjectMapperTest {
 
     ZonedDateTime date = om.readValue(given, ZonedDateTime.class);
 
-    ZonedDateTime expected = ZonedDateTime.of(2018, 11, 21, 13, 16, 47, 0, ZoneId.of("UTC"));
+    ZonedDateTime expected = ZonedDateTime.of(2018, 11, 21, 13, 16, 47, 0, ZoneId.of("Z"));
     assertThat(Map.of("date", date)).usingRecursiveComparison().isEqualTo(Map.of("date", expected));
   }
 
@@ -518,7 +518,7 @@ class DateFormatObjectMapperTest {
     ZonedDateTime date = om.readValue(given, ZonedDateTime.class);
 
     ZonedDateTime expected =
-        ZonedDateTime.of(LocalDateTime.of(2018, 11, 21, 13, 16, 47), ZoneId.of("UTC"));
+        ZonedDateTime.of(LocalDateTime.of(2018, 11, 21, 13, 16, 47), ZoneId.of("Z"));
     assertThat(Map.of("date", date)).usingRecursiveComparison().isEqualTo(Map.of("date", expected));
   }
 

--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedder.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedder.java
@@ -119,7 +119,10 @@ public class JsonSchemaEmbedder {
       }
 
       // Rewrite reference to embedded location
-      currentObject.put(REF, new JsonReference(embedPointer.append(refNamePointer)).toString());
+      currentObject.put(
+          REF,
+          new JsonReference(embedPointer.appendProperty(refNamePointer.getMatchingProperty()))
+              .toString());
     }
   }
 

--- a/sda-commons-shared-yaml/src/main/java/org/sdase/commons/shared/yaml/YamlUtil.java
+++ b/sda-commons-shared-yaml/src/main/java/org/sdase/commons/shared/yaml/YamlUtil.java
@@ -21,14 +21,14 @@ import java.util.TimeZone;
 /** YAML utility providing methods to interact with YAML files. */
 public class YamlUtil {
 
-  private static YAMLMapper mapper = configuredMapper();
-  private static YAMLFactory yamlFactory = new YAMLFactory();
+  private static final YAMLMapper MAPPER = configuredMapper();
+  private static final YAMLFactory YAML_FACTORY = new YAMLFactory();
 
   private YamlUtil() {}
 
   public static <T> T load(final URL resource, final Class<T> clazz) {
     try {
-      return mapper.readValue(resource, clazz);
+      return MAPPER.readValue(resource, clazz);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -36,7 +36,7 @@ public class YamlUtil {
 
   public static <T> T load(final URL resource, final TypeReference<T> typeReference) {
     try {
-      return mapper.readValue(resource, typeReference);
+      return MAPPER.readValue(resource, typeReference);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -44,7 +44,7 @@ public class YamlUtil {
 
   public static <T> T load(final InputStream resource, final Class<T> clazz) {
     try {
-      return mapper.readValue(resource, clazz);
+      return MAPPER.readValue(resource, clazz);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -52,7 +52,7 @@ public class YamlUtil {
 
   public static <T> T load(final InputStream resource, final TypeReference<T> typeReference) {
     try {
-      return mapper.readValue(resource, typeReference);
+      return MAPPER.readValue(resource, typeReference);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -60,7 +60,7 @@ public class YamlUtil {
 
   public static <T> T load(final String content, final Class<T> clazz) {
     try {
-      return mapper.readValue(content, clazz);
+      return MAPPER.readValue(content, clazz);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -68,7 +68,7 @@ public class YamlUtil {
 
   public static <T> T load(final String content, final TypeReference<T> typeReference) {
     try {
-      return mapper.readValue(content, typeReference);
+      return MAPPER.readValue(content, typeReference);
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -76,8 +76,8 @@ public class YamlUtil {
 
   public static <T> List<T> loadList(final URL resource, final Class<T> clazz) {
     try {
-      YAMLParser parser = yamlFactory.createParser(resource);
-      return mapper.readValues(parser, clazz).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(resource);
+      return MAPPER.readValues(parser, clazz).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -85,8 +85,8 @@ public class YamlUtil {
 
   public static <T> List<T> loadList(final URL resource, final TypeReference<T> typeReference) {
     try {
-      YAMLParser parser = yamlFactory.createParser(resource);
-      return mapper.<T>readValues(parser, typeReference).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(resource);
+      return MAPPER.readValues(parser, typeReference).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -94,8 +94,8 @@ public class YamlUtil {
 
   public static <T> List<T> loadList(final InputStream resource, final Class<T> clazz) {
     try {
-      YAMLParser parser = yamlFactory.createParser(resource);
-      return mapper.readValues(parser, clazz).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(resource);
+      return MAPPER.readValues(parser, clazz).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -104,8 +104,8 @@ public class YamlUtil {
   public static <T> List<T> loadList(
       final InputStream resource, final TypeReference<T> typeReference) {
     try {
-      YAMLParser parser = yamlFactory.createParser(resource);
-      return mapper.<T>readValues(parser, typeReference).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(resource);
+      return MAPPER.readValues(parser, typeReference).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -113,8 +113,8 @@ public class YamlUtil {
 
   public static <T> List<T> loadList(final String content, final Class<T> clazz) {
     try {
-      YAMLParser parser = yamlFactory.createParser(content);
-      return mapper.readValues(parser, clazz).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(content);
+      return MAPPER.readValues(parser, clazz).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -122,8 +122,8 @@ public class YamlUtil {
 
   public static <T> List<T> loadList(final String content, final TypeReference<T> typeReference) {
     try {
-      YAMLParser parser = yamlFactory.createParser(content);
-      return mapper.<T>readValues(parser, typeReference).readAll();
+      YAMLParser parser = YAML_FACTORY.createParser(content);
+      return MAPPER.readValues(parser, typeReference).readAll();
     } catch (IOException ioe) {
       throw new YamlLoadException(ioe);
     }
@@ -131,7 +131,7 @@ public class YamlUtil {
 
   public static String writeValueAsString(Object value) {
     try {
-      return mapper.writeValueAsString(value);
+      return MAPPER.writeValueAsString(value);
     } catch (JsonProcessingException jpe) {
       throw new YamlWriteException(jpe);
     }


### PR DESCRIPTION
- [x] AsyncApi generation fails and produces an invalid AsyncAPI on embedding definitions (failure in [JsonSchemaEmbedder](https://github.com/SDA-SE/sda-dropwizard-commons/blob/security/deps/snakeyaml-jackson/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedder.java), visible in [JsonSchemaEmbedderTest](https://github.com/SDA-SE/sda-dropwizard-commons/blob/security/deps/snakeyaml-jackson/sda-commons-shared-asyncapi/src/test/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedderTest.java))
- [x] needs a check with the SNAPSHOT in a real consumer (withFailOnVersionConflict enabled) to verify that the dependency resolution is consistent not only within the library
- [x] seems like the new Jackson version deserializes `ZonedDateTime` differently. Our format results in offset `Z` and zone id `UTC` before. Now both is `Z`. That means the same but fails in tests when the Java value is compared with `equals`. As it will fail many (not ideal written) API tests, the upgrade could be considered as breaking change. ([new regression tests](https://github.com/SDA-SE/sda-dropwizard-commons/commit/49dfb94156f454dc47085dcae51f8e64217e4d79) worked in master, fail here, see [required change here](https://github.com/SDA-SE/sda-dropwizard-commons/pull/2503/commits/75ea75aec6b77a87837a0da8de476ba2333db2ea))
- [x] check if above mentioned change - affecting test assertions - affects other areas as well and should be declared as a breaking change
- [x] make it a breaking change