### PR TITLE
fix(deps): bump org.junit-pioneer:junit-pioneer from 2.0.0 to 2.0.1

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -161,7 +161,7 @@ dependencies {
       because "Dropwizard does not use the jakarta version yet so we replace it in weld with the javax version that comes as transitive dependency without explicit version."
     }
 
-    api "org.junit-pioneer:junit-pioneer:2.0.0"
+    api "org.junit-pioneer:junit-pioneer:2.0.1"
 
     // sda-commons-shared-*
     api 'commons-io:commons-io:2.13.0'


### PR DESCRIPTION
Release notes: https://github.com/junit-pioneer/junit-pioneer/releases/tag/v2.0.1