### PR TITLE
fix(deps): bump org.apache.zookeeper:zookeeper from 3.5.9 to 3.6.4

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -179,7 +179,7 @@ dependencies {
     // Kafka
     api "org.apache.kafka:kafka_2.13:$kafkaVersion"
     api "org.apache.kafka:kafka-clients:$kafkaVersion"
-    api "org.apache.zookeeper:zookeeper:3.5.9"
+    api "org.apache.zookeeper:zookeeper:3.6.4" // same as https://central.sonatype.com/artifact/org.apache.kafka/kafka_2.13/3.5.0
     api "com.github.ftrossbach:club-topicana-core:0.1.0"
     api "com.salesforce.kafka.test:kafka-junit5:$kafkaJunitVersion"
     api "org.apache.curator:curator-test:5.5.0", {


### PR DESCRIPTION
Bumped to the same version used in [Kafka 3.5.0](https://central.sonatype.com/artifact/org.apache.kafka/kafka_2.13/3.5.0)