### PR TITLE
fix(shared-async): Use matching property when replacing $ref

### DIFF
--- a/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedder.java
+++ b/sda-commons-shared-asyncapi/src/main/java/org/sdase/commons/shared/asyncapi/internal/JsonSchemaEmbedder.java
@@ -119,7 +119,10 @@ public class JsonSchemaEmbedder {
       }
 
       // Rewrite reference to embedded location
-      currentObject.put(REF, new JsonReference(embedPointer.append(refNamePointer)).toString());
+      currentObject.put(
+          REF,
+          new JsonReference(embedPointer.appendProperty(refNamePointer.getMatchingProperty()))
+              .toString());
     }
   }
 


### PR DESCRIPTION
Is that the correct fix? Compare release notes:
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15

I felt this could be the location of the problem after reading https://github.com/FasterXML/jackson-core/issues/684