### PR TITLE
feat(server-openapi): sort output

### DIFF
--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiBundle.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiBundle.java
@@ -101,6 +101,7 @@ public final class OpenApiBundle implements ConfiguredBundle<Configuration> {
             .prettyPrint(true)
             .resourcePackages(resourcePackages)
             .readAllResources(false)
+            .sortOutput(true)
             .filterClass(OpenAPISpecFilterSet.class.getName());
 
     // Register the resource that handles the openapi.{json|yaml} requests


### PR DESCRIPTION
This should make the output more reliable and fix random failing tests for OpenAPI comparison because the order of attributes changed.