### PR TITLE
fix(sda-commons-server-auth): add a warning message, if `AUTH_KEYS` a…

### DIFF
--- a/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
+++ b/sda-commons-server-auth/src/main/java/org/sdase/commons/server/auth/AuthBundle.java
@@ -77,6 +77,9 @@ public class AuthBundle<T extends Configuration> implements ConfiguredBundle<T> 
 
     Client client = createKeyLoaderClient(environment, config, currentTelemetryInstance);
     PublicKeyLoader keyLoader = new PublicKeyLoader();
+
+    validateAuthKeys(config);
+
     config.getKeys().stream()
         .map(k -> this.createKeySources(k, client))
         .forEach(keyLoader::addKeySource);
@@ -106,6 +109,12 @@ public class AuthBundle<T extends Configuration> implements ConfiguredBundle<T> 
 
     environment.jersey().register(JwtAuthExceptionMapper.class);
     environment.jersey().register(ForbiddenExceptionMapper.class);
+  }
+
+  private static void validateAuthKeys(AuthConfig config) {
+    if (!config.isDisableAuth() && config.getKeys().isEmpty()) {
+      LOG.warn("Authentication may not be configured correctly. AUTH_KEYS are missing.");
+    }
   }
 
   private Client createKeyLoaderClient(

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/AuthBundleTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/AuthBundleTest.java
@@ -62,9 +62,18 @@ class AuthBundleTest {
   }
 
   @Test
-  void validateEmptyConfig() {
+  void shouldWarnAboutMissingAuthKeys() {
     authBundle.run(null, environment);
-    verify(mockAppender, never()).doAppend(any());
+    verify(mockAppender, times(1))
+        .doAppend(
+            ArgumentMatchers.argThat(
+                argument -> {
+                  assertThat(argument.getMessage())
+                      .isEqualTo(
+                          "Authentication may not be configured correctly. AUTH_KEYS are missing.");
+                  assertThat(argument.getLevel()).isEqualTo(Level.WARN);
+                  return true;
+                }));
   }
 
   @Test


### PR DESCRIPTION
…re not provided