### PR TITLE
fix(deps): bump openTelemetryVersion from 1.27.0 to 1.29.0

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -22,7 +22,7 @@ ext {
   kotlinVersion = '1.9.10'
   kotlinxCoroutinesVersion = '1.7.3'
   resilience4jVersion = '1.7.1'
-  openTelemetryVersion= '1.27.0'
+  openTelemetryVersion= '1.29.0'
   // should be aligned with transitive dependency of Spring Data MongoDB
   mongoDbDriverVersion = '4.6.1'
 }
@@ -177,7 +177,7 @@ dependencies {
     api 'commons-io:commons-io:2.13.0'
 
     // sda-commons-server-opentelemetry
-    api "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}-alpha"
+    api "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:${openTelemetryVersion}"
     api "io.opentelemetry.instrumentation:opentelemetry-apache-httpclient-4.3:${openTelemetryVersion}-alpha"
     api "io.opentelemetry:opentelemetry-exporter-otlp:$openTelemetryVersion"
     api "io.opentelemetry:opentelemetry-exporter-jaeger:$openTelemetryVersion"

--- a/sda-commons-server-opentelemetry/src/main/java/org/sdase/commons/server/opentelemetry/OpenTelemetryBundle.java
+++ b/sda-commons-server-opentelemetry/src/main/java/org/sdase/commons/server/opentelemetry/OpenTelemetryBundle.java
@@ -84,7 +84,7 @@ public class OpenTelemetryBundle implements ConfiguredBundle<Configuration> {
     try {
       return AutoConfiguredOpenTelemetrySdk.builder()
           .addPropertiesSupplier(SdaConfigPropertyProvider::getProperties)
-          .setResultAsGlobal(true)
+          .setResultAsGlobal()
           .build()
           .getOpenTelemetrySdk();
     } catch (IllegalStateException | ConfigurationException e) {


### PR DESCRIPTION
## Release Notes and noteworthy changes

* [1.29.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.29.0)
  * Fix gradle java version requirement warning (https://github.com/open-telemetry/opentelemetry-java/pull/5624)
  * --> @SDA-SE/bedrock Does OpenTelemetry require Java 17?
* [1.28.0](https://github.com/open-telemetry/opentelemetry-java/releases/tag/v1.28.0)
  * [opentelemetry-sdk-extension-autoconfigure](https://github.com/open-telemetry/opentelemetry-java/blob/v1.28.0/sdk-extensions/autoconfigure) is now stable! See "SDK Extension" notes below for changes made prior to stabilization.
  * DEPRECATION: opentelemetry-exporter-jaeger and opentelemetry-exporter-jaeger-thrift are now deprecated with the last release planned for 1.34.0 (January 2024) (https://github.com/open-telemetry/opentelemetry-java/pull/5190)
