### PR TITLE
chore: MongoDB workflow publishes unit test results

### DIFF
--- a/.github/workflows/mongodb.yml
+++ b/.github/workflows/mongodb.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Test with Gradle
         run: ./gradlew :sda-commons-server-spring-data-mongo:test
 
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        if: failure() # only upload if previous step failed
+        with:
+          name: mongodb-test-results
+          path: |
+            build/reports/
+            */build/test-results/**/*.xml
+          retention-days: 7
+
       - name: Assert use of MongoDB
         run: "docker logs test_mongo | grep -F 'createCollection' | grep -F 'default_db.'"
 


### PR DESCRIPTION
Adding another step to the "mongodb" workflow because the workflow [fails](https://github.com/SDA-SE/sda-dropwizard-commons/actions/runs/6070029607/job/16465329950) (always? sometimes?) on master.