### PR TITLE
security(deps): ignore CVE-2023-42503 brought in by `de.flapdoodle.em…

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -8,7 +8,9 @@ ignore_cves := {
   # H2 database only used for testing, not in production
   "CVE-2022-45868",
   # Quartz only used in test. Affected method: https://github.com/quartz-scheduler/quartz/issues/943
-  "CVE-2023-39017"
+  "CVE-2023-39017",
+  # Flapdoodle is only used in test.
+  "CVE-2023-42503"
 }
 
 ignore {


### PR DESCRIPTION
…bed:de.flapdoodle.embed.mongo`, since only used in test