### PR TITLE
chore: handle deprecations of `reportOn` and `buildDir`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -293,9 +293,11 @@ configure(subprojects.findAll { javaPlatformModules.contains(it.name) }) {
 
 // Reconfigure the testReport task to display the results of all modules into a single report
 task testReport(type: TestReport) {
-  destinationDirectory = file("$buildDir/reports/allTests")
+  destinationDirectory = project.layout.buildDirectory.dir("reports/allTests")
   // Include the results from the `test` task in all subprojects
-  reportOn subprojects.findAll { !javaPlatformModules.contains(it.name) }*.test
+  testResults.from(
+      subprojects.findAll { !javaPlatformModules.contains(it.name) }*.test.binaryResultsDirectory
+      )
 }
 
 // Create a combined XML report of all modules in the root project


### PR DESCRIPTION
alternative to #2724

More Info:
* [deprecation of reportOn](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestReport.html#reportOn-java.lang.Object...-)
* [deprecation of buildDir](https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecated_project_builddir_can_cause_script_compilation_failure)
