### PR TITLE
chore: handle deprecations of `destination` and `buildDir`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ task codeCoverageReport(type: JacocoReport) {
 
   reports {
     xml.required = true
-    xml.destination file("${buildDir}/reports/jacoco/report.xml")
+    xml.outputLocation = project.layout.buildDirectory.file("reports/jacoco/report.xml")
   }
 
   dependsOn ":testReport"


### PR DESCRIPTION
See [deprecation note](https://docs.gradle.org/current/javadoc/org/gradle/api/reporting/ConfigurableReport.html#setDestination-java.io.File-):

```
@Deprecated
void setDestination​(java.io.File file)

Deprecated.
Use [Report.getOutputLocation()](https://docs.gradle.org/current/javadoc/org/gradle/api/reporting/Report.html#getOutputLocation--).set() instead. This method will be removed in Gradle 9.0.
```