### PR TITLE
fix(openapi): embed parameter modifier for search operations

### DIFF
--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
@@ -118,10 +118,21 @@ public class EmbedParameterModifier implements ReaderListener {
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
 
-    // only when there is a single list entry that supports embedding
-    if (nestedRefs.size() == 1) {
-      // get the model definition from the array
-      return getSchemaDefinition(definitions, nestedRefs.get(0));
+    // normally a search result model contains besides other meta information a list with the
+    // initially passed filters and a list with the search results therefore the correct list must
+    // be filtered
+    var schemaDefinition =
+        nestedRefs.stream()
+            // map refs to model definition
+            .map(schemaRef -> getSchemaDefinition(definitions, schemaRef))
+            // filter the model definition with embedded properties
+            .filter(
+                schema ->
+                    schema.getProperties() != null
+                        && schema.getProperties().containsKey(EMBEDDED_PROPERTY))
+            .findFirst();
+    if (schemaDefinition.isPresent()) {
+      return schemaDefinition.get();
     }
 
     return definition;

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleIT.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleIT.java
@@ -171,6 +171,7 @@ class OpenApiBundleIT {
             NATURAL_PERSON_DEFINITION,
             PARTNER_DEFINITION,
             "HALLink",
+            "AnimalFilter",
             "Animal",
             "House",
             "HouseSearchResource",

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/AnimalFilter.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/AnimalFilter.java
@@ -1,0 +1,15 @@
+package org.sdase.commons.server.openapi.apps.test;
+
+public class AnimalFilter {
+
+  String animal;
+
+  public String getAnimal() {
+    return animal;
+  }
+
+  public AnimalFilter setAnimal(String animal) {
+    this.animal = animal;
+    return this;
+  }
+}

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/HouseSearchResource.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/HouseSearchResource.java
@@ -10,6 +10,9 @@ import java.util.List;
 @Schema(name = "HouseSearchResource")
 public class HouseSearchResource {
 
+  @ArraySchema(arraySchema = @Schema(description = "The filters to apply", required = true))
+  private List<AnimalFilter> filters = new ArrayList<>();
+
   @ArraySchema(arraySchema = @Schema(description = "A list of found houses", required = true))
   private List<HouseResource> houses = new ArrayList<>();
 
@@ -18,11 +21,17 @@ public class HouseSearchResource {
 
   @JsonCreator
   public HouseSearchResource(
+      @JsonProperty("filters") List<AnimalFilter> filters,
       @JsonProperty("houses") List<HouseResource> houses,
       @JsonProperty("totalCount") int totalCount) {
 
+    this.filters.addAll(filters);
     this.houses.addAll(houses);
     this.totalCount = totalCount;
+  }
+
+  public List<AnimalFilter> getFilters() {
+    return filters;
   }
 
   public List<HouseResource> getHouses() {

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/OpenApiBundleTestApp.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/apps/test/OpenApiBundleTestApp.java
@@ -118,7 +118,7 @@ public class OpenApiBundleTestApp extends Application<Configuration>
               mediaType = APPLICATION_JSON,
               schema = @Schema(implementation = HouseSearchResource.class)))
   public HouseSearchResource searchHouse() {
-    return new HouseSearchResource(Collections.emptyList(), 0);
+    return new HouseSearchResource(Collections.emptyList(), Collections.emptyList(), 0);
   }
 
   @GET

--- a/sda-commons-server-openapi/src/test/resources/expected-openapi.yaml
+++ b/sda-commons-server-openapi/src/test/resources/expected-openapi.yaml
@@ -112,6 +112,11 @@ components:
           type: "string"
           description: "Name of the animal"
           example: "Hasso"
+    AnimalFilter:
+      type: "object"
+      properties:
+        animal:
+          type: "string"
     HALLink:
       type: "object"
       description: "Representation of a link as defined in HAL"
@@ -170,6 +175,11 @@ components:
     HouseSearchResource:
       type: "object"
       properties:
+        filters:
+          type: "array"
+          description: "The filters to apply"
+          items:
+            $ref: "#/components/schemas/AnimalFilter"
         houses:
           type: "array"
           description: "A list of found houses"
@@ -180,6 +190,7 @@ components:
           format: "int32"
           description: "The total count of houses"
       required:
+      - "filters"
       - "houses"
       - "totalCount"
     NaturalPerson:


### PR DESCRIPTION
Hi, the response model of search operations is currently restricted to exactly one list in the `EmbedParameterModifier` when using HAL links. But regarding the [REST guide](https://sda.dev/core-concepts/communication/restful-api-guide/#RESTfulAPIGuide-SHOULD%3AProvidecomplexqueriesusingsearchresources) normally a search operation contains a list with filters that is also a part of the response besides the result list. So the filter should also handle more than one list to get the correct `embed` query parameter documented in the OpenAPI