### PR TITLE
Feat/ignore CVE 2023 4586

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -10,7 +10,9 @@ ignore_cves := {
   # Quartz only used in test. Affected method: https://github.com/quartz-scheduler/quartz/issues/943
   "CVE-2023-39017",
   # Flapdoodle is only used in test.
-  "CVE-2023-42503"
+  "CVE-2023-42503",
+  # Netty is used by Zookeeper which is only used in test.
+  "CVE-2023-4586"
 }
 
 ignore {

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,6 @@ allprojects {
   apply plugin: 'idea'
   idea.module.inheritOutputDirs = true
 
-  dependencyLocking { lockAllConfigurations() }
-
   // Task for creating gradle.lockfile per module. Needed for Trivy vulnerability scan.
   task resolveAndLockAll {
     doFirst {
@@ -193,6 +191,19 @@ subprojects {
 configure(subprojects.findAll { !javaPlatformModules.contains(it.name) }) {
   apply plugin: 'java-library'
   apply plugin: 'jacoco'
+
+  // activate dependency locking for most configurations
+  var ignoredConfigurationPatternsForDependencyLocking = Set.of("test.*", "jacoco.*")
+  configurations.matching { configuration ->
+    var match = !ignoredConfigurationPatternsForDependencyLocking.any { configuration.name.matches(it) }
+    if (!match) {
+      println "Ignoring dependency locking for '${it.name}:${configuration.name}'"
+    }
+    return match
+  }.each {configuration ->
+    println "Activating dependency locking for '${it.name}:${configuration.name}'"
+    configuration.resolutionStrategy.activateDependencyLocking()
+  }
 
   java {
     // preferring `sourceCompatibility` over `toolchains` to be able to do builds with different


### PR DESCRIPTION
CVE-2023-4586 affects Netty which is used by Zookeeper.
As ZK is only used for Kafka testing this CVE does not affect production code and can be ignored.