### PR TITLE
test: @RegisterExtension fields must not be private

### DIFF
--- a/sda-commons-client-jersey-example/src/test/java/org/sdase/commons/client/jersey/JerseyClientExampleIT.java
+++ b/sda-commons-client-jersey-example/src/test/java/org/sdase/commons/client/jersey/JerseyClientExampleIT.java
@@ -28,12 +28,12 @@ class JerseyClientExampleIT {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<JerseyClientExampleConfiguration> DW =
+  static final DropwizardAppExtension<JerseyClientExampleConfiguration> DW =
       new DropwizardAppExtension<>(
           JerseyClientExampleApplication.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
@@ -39,12 +39,12 @@ class ApiClientConfigurationTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTest.java
@@ -67,7 +67,7 @@ public class ApiClientTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   public static final Car LIGHT_BLUE_CAR =
@@ -78,7 +78,7 @@ public class ApiClientTest {
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTimeoutTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTimeoutTest.java
@@ -34,12 +34,12 @@ class ApiClientTimeoutTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientWithoutConsumerTokenTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientWithoutConsumerTokenTest.java
@@ -29,7 +29,7 @@ class ApiClientWithoutConsumerTokenTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   private static final ObjectMapper OM = new ObjectMapper();
@@ -40,7 +40,7 @@ class ApiClientWithoutConsumerTokenTest {
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientWithoutConsumerTokenTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
@@ -39,16 +39,16 @@ import org.sdase.commons.client.jersey.wiremock.testing.WireMockClassExtension;
 class ClientConfiguredProxyTest {
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension CONTENT_WIRE =
+  static final WireMockClassExtension CONTENT_WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final WireMockClassExtension PROXY_WIRE =
+  static final WireMockClassExtension PROXY_WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientErrorUtilTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientErrorUtilTest.java
@@ -37,7 +37,7 @@ import org.sdase.commons.shared.api.error.ApiInvalidParam;
 class ClientErrorUtilTest {
 
   @RegisterExtension
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   private static final ObjectMapper OM = new ObjectMapper();

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
@@ -36,17 +36,17 @@ import org.sdase.commons.server.testing.SystemPropertyClassExtension;
 class ClientProxyTest {
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension CONTENT_WIRE =
+  static final WireMockClassExtension CONTENT_WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final WireMockClassExtension PROXY_WIRE =
+  static final WireMockClassExtension PROXY_WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(2)
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty("http.proxyPort", () -> "" + PROXY_WIRE.port());
 

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/GenericClientTimeoutTest.java
@@ -32,12 +32,12 @@ class GenericClientTimeoutTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> dw =
+  static final DropwizardAppExtension<ClientTestConfig> dw =
       new DropwizardAppExtension<>(ClientTestApp.class, resourceFilePath("test-config.yaml"));
 
   private ClientTestApp app;

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/JerseyClientBundleNoopTracingTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/JerseyClientBundleNoopTracingTest.java
@@ -25,12 +25,12 @@ class JerseyClientBundleNoopTracingTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/filter/AddRequestHeaderFilterTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/filter/AddRequestHeaderFilterTest.java
@@ -19,7 +19,7 @@ import org.sdase.commons.client.jersey.wiremock.testing.WireMockClassExtension;
 class AddRequestHeaderFilterTest {
 
   @RegisterExtension
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @BeforeEach

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientCacheDisabledTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientCacheDisabledTest.java
@@ -38,12 +38,12 @@ class OidcClientCacheDisabledTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientDisabledTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientDisabledTest.java
@@ -39,13 +39,13 @@ class OidcClientDisabledTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(
           wireMockConfig().dynamicPort().httpServerFactory(new JettyHttpServerFactory()));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcClientTest.java
@@ -42,13 +42,13 @@ class OidcClientTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(
           wireMockConfig().dynamicPort().httpServerFactory(new JettyHttpServerFactory()));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ClientTestConfig> DW =
+  static final DropwizardAppExtension<ClientTestConfig> DW =
       new DropwizardAppExtension<>(
           ClientTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
@@ -22,15 +22,15 @@ class AuthNoopTracerTest {
 
   @Order(0)
   @RegisterExtension
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)
-  private static final OpaClassExtension OPA = new OpaClassExtension();
+  static final OpaClassExtension OPA = new OpaClassExtension();
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           AuthAndOpaBundleTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionIT.java
@@ -29,11 +29,11 @@ class AuthClassExtensionIT {
 
   @Order(0)
   @RegisterExtension
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @Order(1)
   @RegisterExtension
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionProgrammaticIT.java
@@ -21,11 +21,11 @@ class AuthClassExtensionProgrammaticIT {
 
   @Order(0)
   @RegisterExtension
-  private static AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @Order(1)
   @RegisterExtension
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthDisabledJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthDisabledJUnit5IT.java
@@ -18,11 +18,11 @@ class AuthDisabledJUnit5IT {
 
   @Order(0)
   @RegisterExtension
-  private static AuthClassExtension AUTH = AuthClassExtension.builder().withDisabledAuth().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().withDisabledAuth().build();
 
   @Order(1)
   @RegisterExtension
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthRuleCustomizationJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthRuleCustomizationJUnit5IT.java
@@ -23,7 +23,7 @@ class AuthRuleCustomizationJUnit5IT {
 
   @Order(0)
   @RegisterExtension
-  private static final AuthClassExtension AUTH =
+  static final AuthClassExtension AUTH =
       AuthClassExtension.builder()
           .withKeyId(null)
           .withIssuer("customIssuer") // NOSONAR
@@ -35,7 +35,7 @@ class AuthRuleCustomizationJUnit5IT {
 
   @Order(1)
   @RegisterExtension
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
@@ -32,7 +32,7 @@ class CustomKeyLoaderConfigIT {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   static {
@@ -43,7 +43,7 @@ class CustomKeyLoaderConfigIT {
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class,
           ResourceHelpers.resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
@@ -38,18 +38,18 @@ import org.sdase.commons.server.testing.SystemPropertyClassExtension;
 class KeyLoaderProxyIT {
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension PROXY_WIRE =
+  static final WireMockClassExtension PROXY_WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty("http.proxyPort", () -> "" + PROXY_WIRE.port());
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<AuthTestConfig> DW =
+  static final DropwizardAppExtension<AuthTestConfig> DW =
       new DropwizardAppExtension<>(
           AuthTestApp.class,
           ResourceHelpers.resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaClassExtensionIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaClassExtensionIT.java
@@ -30,15 +30,15 @@ public class AuthAndOpaClassExtensionIT {
 
   @RegisterExtension
   @Order(0)
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           AuthAndOpaBundleTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
@@ -35,15 +35,15 @@ class AuthAndOpaIT {
 
   @RegisterExtension
   @Order(0)
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<AuthAndOpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           AuthAndOpaBundleTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionIT.java
@@ -24,7 +24,7 @@ import org.sdase.commons.server.opa.testing.test.ConstraintModel;
 
 class OpaClassExtensionIT {
 
-  @RegisterExtension private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  @RegisterExtension static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   private final String path = "resources";
   private final String method = "GET";

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionProgrammaticIT.java
@@ -19,11 +19,11 @@ public class OpaClassExtensionProgrammaticIT {
 
   @RegisterExtension
   @Order(0)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
@@ -14,7 +14,7 @@ import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
 class OpaConnectionMisconfiguredIT {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class, resourceFilePath("test-opa-config.yaml"));
 

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledIT.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.opa.testing.test.OpaBundleTestApp;
 class OpaDisabledIT {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledJUnit5IT.java
@@ -19,11 +19,11 @@ class OpaDisabledJUnit5IT {
 
   @RegisterExtension
   @Order(0)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaIT.java
@@ -31,11 +31,11 @@ class OpaIT {
 
   @RegisterExtension
   @Order(0)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaJwtPrincipalInjectIT.java
@@ -24,15 +24,15 @@ class OpaJwtPrincipalInjectIT {
 
   @RegisterExtension
   @Order(0)
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)
-  private static final OpaClassExtension OPA = new OpaClassExtension();
+  static final OpaClassExtension OPA = new OpaClassExtension();
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<OpaJwtPrincipalInjectApp.Config> DW =
+  static final DropwizardAppExtension<OpaJwtPrincipalInjectApp.Config> DW =
       new DropwizardAppExtension<>(
           OpaJwtPrincipalInjectApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaProgrammaticIT.java
@@ -20,11 +20,11 @@ class OpaProgrammaticIT {
 
   @RegisterExtension
   @Order(0)
-  private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
@@ -28,16 +28,16 @@ class OpaRequestsIT {
 
   @RegisterExtension
   @Order(0)
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           ResourceHelpers.resourceFilePath("test-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaResponsesIT.java
@@ -29,12 +29,12 @@ class OpaResponsesIT {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           ResourceHelpers.resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaTimeoutIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaTimeoutIT.java
@@ -23,12 +23,12 @@ class OpaTimeoutIT {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
+  static final DropwizardAppExtension<OpaBundeTestAppConfiguration> DW =
       new DropwizardAppExtension<>(
           OpaBundleTestApp.class,
           ResourceHelpers.resourceFilePath("test-opa-config.yaml"),

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/PolicyExistsHealthCheckIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/PolicyExistsHealthCheckIT.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.opa.health.PolicyExistsHealthCheck;
 
 class PolicyExistsHealthCheckIT {
 
-  @RegisterExtension private static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
+  @RegisterExtension static final OpaClassExtension OPA_EXTENSION = new OpaClassExtension();
 
   private PolicyExistsHealthCheck policyExistsHealthCheck;
 

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/config/AuthConfigTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/config/AuthConfigTest.java
@@ -58,7 +58,7 @@ class AuthConfigTest {
   }
 
   @RegisterExtension
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty("KEYS", KEYS_JSON)
           .setProperty("ISSUERS", ISSUERS);

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/JwksKeySourceIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/auth/key/JwksKeySourceIT.java
@@ -22,7 +22,7 @@ import org.sdase.commons.server.auth.test.KeyProviderTestApp;
 class JwksKeySourceIT {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(KeyProviderTestApp.class, null, randomPorts());
 
   @Test

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
@@ -41,12 +41,12 @@ class OpaBundleBodyInputExtensionTest {
 
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<TestConfiguration> DW_WITH_EXTENSION =
+  static final DropwizardAppExtension<TestConfiguration> DW_WITH_EXTENSION =
       new DropwizardAppExtension<>(
           TestApplicationWithExtension.class,
           null,
@@ -58,7 +58,7 @@ class OpaBundleBodyInputExtensionTest {
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<TestConfiguration> DW_WITHOUT_EXTENSION =
+  static final DropwizardAppExtension<TestConfiguration> DW_WITHOUT_EXTENSION =
       new DropwizardAppExtension<>(
           TestApplicationWithoutExtension.class,
           null,

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
@@ -42,14 +42,14 @@ import org.sdase.commons.server.opa.config.OpaConfig;
 class OpaBundleClientConfigurationIT {
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension static OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<TestConfiguration> DW =
+  static final DropwizardAppExtension<TestConfiguration> DW =
       new DropwizardAppExtension<>(
           TestApplication.class,
           null,

--- a/sda-commons-server-circuitbreaker/src/test/java/org/sdase/commons/server/circuitbreaker/CircuitBreakerBundleTestIT.java
+++ b/sda-commons-server-circuitbreaker/src/test/java/org/sdase/commons/server/circuitbreaker/CircuitBreakerBundleTestIT.java
@@ -26,12 +26,12 @@ import org.sdase.commons.server.prometheus.PrometheusBundle;
 class CircuitBreakerBundleTestIT {
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<AppConfiguration> DW =
+  static final DropwizardAppExtension<AppConfiguration> DW =
       new DropwizardAppExtension<>(
           TestApp.class, ResourceHelpers.resourceFilePath("test-config.yml"));
 

--- a/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
+++ b/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
@@ -19,13 +19,13 @@ class ConsumerTokenBundleOptionalTokenTest {
 
   @RegisterExtension
   @Order(0)
-  private static final DropwizardAppExtension<ConsumerTokenTestConfig> DW =
+  static final DropwizardAppExtension<ConsumerTokenTestConfig> DW =
       new DropwizardAppExtension<>(
           ConsumerTokenTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ConsumerTokenTestConfig> DW_OPTIONAL =
+  static final DropwizardAppExtension<ConsumerTokenTestConfig> DW_OPTIONAL =
       new DropwizardAppExtension<>(
           ConsumerTokenOptionalTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleTest.java
+++ b/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleTest.java
@@ -18,13 +18,13 @@ class ConsumerTokenBundleTest {
 
   @RegisterExtension
   @Order(0)
-  private static final DropwizardAppExtension<ConsumerTokenTestConfig> DW =
+  static final DropwizardAppExtension<ConsumerTokenTestConfig> DW =
       new DropwizardAppExtension<>(
           ConsumerTokenTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<ConsumerTokenTestConfig> DW_REQUIRED =
+  static final DropwizardAppExtension<ConsumerTokenTestConfig> DW_REQUIRED =
       new DropwizardAppExtension<>(
           ConsumerTokenRequiredTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-cors/src/test/java/org/sdase/commons/server/cors/CorsTestIT.java
+++ b/sda-commons-server-cors/src/test/java/org/sdase/commons/server/cors/CorsTestIT.java
@@ -25,26 +25,26 @@ class CorsTestIT {
 
   @RegisterExtension
   @Order(0)
-  private static final DropwizardAppExtension<CorsTestConfiguration> DW_ALLOW =
+  static final DropwizardAppExtension<CorsTestConfiguration> DW_ALLOW =
       new DropwizardAppExtension<>(
           CorsAllowTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<CorsTestConfiguration> DW_DENY =
+  static final DropwizardAppExtension<CorsTestConfiguration> DW_DENY =
       new DropwizardAppExtension<>(
           CorsDenyTestApp.class, ResourceHelpers.resourceFilePath("test-config-deny.yaml"));
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<CorsTestConfiguration> DW_RESTRICTED =
+  static final DropwizardAppExtension<CorsTestConfiguration> DW_RESTRICTED =
       new DropwizardAppExtension<>(
           CorsRestrictedTestApp.class,
           ResourceHelpers.resourceFilePath("test-config-restricted.yaml"));
 
   @RegisterExtension
   @Order(3)
-  private static final DropwizardAppExtension<CorsTestConfiguration> DW_PATTERN =
+  static final DropwizardAppExtension<CorsTestConfiguration> DW_PATTERN =
       new DropwizardAppExtension<>(
           CorsRestrictedTestApp.class,
           ResourceHelpers.resourceFilePath("test-config-pattern.yaml"));

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithConsoleAppenderTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithConsoleAppenderTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("with-console-appender-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithEmptyConfigTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithEmptyConfigTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("with-empty-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest.java
@@ -24,7 +24,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithJsonLoggingEnabledTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithUnconfiguredConsoleAppenderTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("with-unconfigured-console-appender-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutAppendersKeyTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithoutAppendersKeyTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("without-appenders-key-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithoutConsoleAppenderTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("without-console-appender-config.yaml"));
 

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/DefaultLoggingConfigurationBundleWithoutLoggingKeyTest.java
@@ -18,7 +18,7 @@ import org.sdase.commons.server.dropwizard.bundles.test.LoggingTestApp;
 class DefaultLoggingConfigurationBundleWithoutLoggingKeyTest {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           LoggingTestApp.class, resourceFilePath("without-logging-key-config.yaml"));
 

--- a/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
+++ b/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
@@ -18,7 +18,7 @@ import org.sdase.commons.shared.api.error.ApiInvalidParam;
 class ErrorHandlingExampleIT {
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(ErrorHandlingExampleApplication.class, null, randomPorts());
 
   @Test

--- a/sda-commons-server-healthcheck-example/src/test/java/org/sdase/commons/server/healthcheck/example/HealthExampleIT.java
+++ b/sda-commons-server-healthcheck-example/src/test/java/org/sdase/commons/server/healthcheck/example/HealthExampleIT.java
@@ -25,13 +25,13 @@ class HealthExampleIT {
   // Wiremock to mock external service
   @RegisterExtension
   @Order(0)
-  private static final WireMockClassExtension WIRE =
+  static final WireMockClassExtension WIRE =
       new WireMockClassExtension(wireMockConfig().dynamicPort());
 
   // create example application
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<HealthExampleConfiguration> DW =
+  static final DropwizardAppExtension<HealthExampleConfiguration> DW =
       new DropwizardAppExtension<>(
           HealthExampleApplication.class,
           null,

--- a/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/PersonManagerTest.java
+++ b/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/PersonManagerTest.java
@@ -33,7 +33,7 @@ class PersonManagerTest {
 
   /** DAOTest rule creates the database and provide means to access it */
   @RegisterExtension
-  private final DAOTestExtension daoTestExtension =
+  final DAOTestExtension daoTestExtension =
       DAOTestExtension.newBuilder()
           .setProperty(AvailableSettings.URL, URL)
           .setProperty(AvailableSettings.USER, USER)

--- a/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateNoPackageScanIT.java
+++ b/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateNoPackageScanIT.java
@@ -37,7 +37,7 @@ class HibernateNoPackageScanIT {
   static final String DB_URI = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1";
 
   @RegisterExtension
-  private static final DropwizardAppExtension<HibernateITestConfiguration> DW =
+  static final DropwizardAppExtension<HibernateITestConfiguration> DW =
       new DropwizardAppExtension<>(
           HibernateNoPackageScanApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
 

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleMetadataContextProducerIntegrationTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleMetadataContextProducerIntegrationTest.java
@@ -33,11 +33,11 @@ class KafkaBundleMetadataContextProducerIntegrationTest {
 
   @RegisterExtension
   @Order(0)
-  private static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource();
+  static final SharedKafkaTestResource KAFKA = new SharedKafkaTestResource();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithConfigIT.java
@@ -61,7 +61,7 @@ class KafkaBundleWithConfigIT {
 
   @RegisterExtension
   @Order(0)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           // we only need one consumer offsets partition
           .withBrokerProperty("offsets.topic.num.partitions", "1")
@@ -79,7 +79,7 @@ class KafkaBundleWithConfigIT {
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslPlainIT.java
@@ -32,7 +32,7 @@ class KafkaBundleWithSaslPlainIT {
 
   @RegisterExtension
   @Order(1)
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty(
               JaasUtils.JAVA_LOGIN_CONFIG_PARAM,
@@ -40,7 +40,7 @@ class KafkaBundleWithSaslPlainIT {
 
   @RegisterExtension
   @Order(2)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           .registerListener(
               new SaslPlainListener().withUsername("kafkaclient").withPassword("client-secret"))
@@ -52,7 +52,7 @@ class KafkaBundleWithSaslPlainIT {
 
   @RegisterExtension
   @Order(3)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSaslScramIT.java
@@ -32,7 +32,7 @@ class KafkaBundleWithSaslScramIT {
 
   @RegisterExtension
   @Order(1)
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty(
               JaasUtils.JAVA_LOGIN_CONFIG_PARAM,
@@ -40,7 +40,7 @@ class KafkaBundleWithSaslScramIT {
 
   @RegisterExtension
   @Order(2)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaClassExtensionScram()
           .registerListener(
               new SaslScramListener().withUsername("kafkaclient").withPassword("client-secret"))
@@ -52,7 +52,7 @@ class KafkaBundleWithSaslScramIT {
 
   @RegisterExtension
   @Order(3)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslIT.java
@@ -31,7 +31,7 @@ class KafkaBundleWithSslIT {
 
   @RegisterExtension
   @Order(1)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           .registerListener(
               new SslListener()
@@ -50,7 +50,7 @@ class KafkaBundleWithSslIT {
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslTruststoreIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaBundleWithSslTruststoreIT.java
@@ -32,7 +32,7 @@ class KafkaBundleWithSslTruststoreIT {
 
   @RegisterExtension
   @Order(1)
-  private static final SystemPropertyClassExtension PROP =
+  static final SystemPropertyClassExtension PROP =
       new SystemPropertyClassExtension()
           .setProperty(
               "javax.net.ssl.trustStore",
@@ -41,7 +41,7 @@ class KafkaBundleWithSslTruststoreIT {
 
   @RegisterExtension
   @Order(2)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           // Register and configure SSL authentication on cluster.
           .registerListener(
@@ -60,7 +60,7 @@ class KafkaBundleWithSslTruststoreIT {
 
   @RegisterExtension
   @Order(3)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaPrometheusMonitoringIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/KafkaPrometheusMonitoringIT.java
@@ -39,7 +39,7 @@ class KafkaPrometheusMonitoringIT {
 
   @RegisterExtension
   @Order(0)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           // we only need one consumer offsets partition
           .withBrokerProperty("offsets.topic.num.partitions", "1")
@@ -53,7 +53,7 @@ class KafkaPrometheusMonitoringIT {
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
       new DropwizardAppExtension<>(
           KafkaTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
@@ -21,7 +21,7 @@ class KafkaWithoutHealthCheckIT {
 
   @RegisterExtension
   @Order(0)
-  private static final SharedKafkaTestResource KAFKA =
+  static final SharedKafkaTestResource KAFKA =
       new SharedKafkaTestResource()
           // we only need one consumer offsets partition
           .withBrokerProperty("offsets.topic.num.partitions", "1")
@@ -31,7 +31,7 @@ class KafkaWithoutHealthCheckIT {
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<KafkaTestConfiguration> DW =
+  static final DropwizardAppExtension<KafkaTestConfiguration> DW =
       new DropwizardAppExtension<>(
           KafkaWithoutHealthCheckTestApplication.class,
           resourceFilePath("test-config-default.yml"),

--- a/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
+++ b/sda-commons-server-openapi-example/src/test/java/org/sdase/commons/server/openapi/example/people/rest/OpenApiIT.java
@@ -23,7 +23,7 @@ class OpenApiIT {
   // Connect provider for the tests
   @RegisterExtension
   @Order(0)
-  private static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
+  static final AuthClassExtension AUTH = AuthClassExtension.builder().build();
 
   @RegisterExtension
   @Order(1)

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleMultipleApplicationsIT.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/server/openapi/OpenApiBundleMultipleApplicationsIT.java
@@ -21,13 +21,13 @@ class OpenApiBundleMultipleApplicationsIT {
 
   @RegisterExtension
   @Order(0)
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
           OpenApiBundleTestApp.class, resourceFilePath("test-config.yaml"));
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Configuration> DW_ANOTHER_APP =
+  static final DropwizardAppExtension<Configuration> DW_ANOTHER_APP =
       new DropwizardAppExtension<>(AnotherTestApp.class, resourceFilePath("test-config.yaml"));
 
   @Test

--- a/sda-commons-server-opentelemetry-example/src/test/java/org/sdase/server/opentelemetry/example/OpenTelemetryTracingAppIT.java
+++ b/sda-commons-server-opentelemetry-example/src/test/java/org/sdase/server/opentelemetry/example/OpenTelemetryTracingAppIT.java
@@ -19,12 +19,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class OpenTelemetryTracingAppIT {
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Configuration> APP =
+  static final DropwizardAppExtension<Configuration> APP =
       new DropwizardAppExtension<>(OpenTelemetryTracingApp.class, new Configuration());
 
   @RegisterExtension
   @Order(0)
-  private static final OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
+  static final OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
 
   @Test
   void shouldGetInstrumented() {

--- a/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
+++ b/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
@@ -33,7 +33,7 @@ class PrometheusBundleTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(PrometheusBundleTest.class);
 
   @RegisterExtension
-  private static final DropwizardAppExtension<Configuration> DW =
+  static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(PrometheusTestApplication.class, null, randomPorts());
 
   private static final String REST_URI = "http://localhost:%d";

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleSignerOverrideTest.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleSignerOverrideTest.java
@@ -18,12 +18,12 @@ class S3BundleSignerOverrideTest {
 
   @RegisterExtension
   @Order(0)
-  private static final S3ClassExtension S3 =
+  static final S3ClassExtension S3 =
       S3ClassExtension.builder().putObject("bucket", "key", "data").build();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Config> DW =
+  static final DropwizardAppExtension<Config> DW =
       new DropwizardAppExtension<>(
           TestApp.class,
           null,

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/S3BundleTest.java
@@ -26,14 +26,14 @@ class S3BundleTest {
 
   @RegisterExtension
   @Order(0)
-  private static final S3ClassExtension S3 =
+  static final S3ClassExtension S3 =
       S3ClassExtension.builder().putObject("bucket", "key", "data").build();
 
   @RegisterExtension static final OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Config> DW =
+  static final DropwizardAppExtension<Config> DW =
       new DropwizardAppExtension<>(
           TestApp.class,
           null,

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithExternalHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithExternalHealthCheckIT.java
@@ -22,12 +22,11 @@ class S3WithExternalHealthCheckIT {
 
   @RegisterExtension
   @Order(0)
-  private static final S3ClassExtension S3 =
-      S3ClassExtension.builder().createBucket("testbucket").build();
+  static final S3ClassExtension S3 = S3ClassExtension.builder().createBucket("testbucket").build();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Config> DW =
+  static final DropwizardAppExtension<Config> DW =
       new DropwizardAppExtension<>(
           S3WithExternalHealthCheckTestApp.class,
           resourceFilePath("test-config.yml"),

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithHealthCheckIT.java
@@ -22,12 +22,11 @@ class S3WithHealthCheckIT {
 
   @RegisterExtension
   @Order(0)
-  private static final S3ClassExtension S3 =
-      S3ClassExtension.builder().createBucket("testbucket").build();
+  static final S3ClassExtension S3 = S3ClassExtension.builder().createBucket("testbucket").build();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Config> DW =
+  static final DropwizardAppExtension<Config> DW =
       new DropwizardAppExtension<Config>(
           S3WithHealthCheckTestApp.class,
           resourceFilePath("test-config.yml"),

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithoutHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithoutHealthCheckIT.java
@@ -21,12 +21,11 @@ import org.sdase.commons.server.s3.testing.S3ClassExtension;
 class S3WithoutHealthCheckIT {
   @RegisterExtension
   @Order(0)
-  private static final S3ClassExtension S3 =
-      S3ClassExtension.builder().createBucket("testbucket").build();
+  static final S3ClassExtension S3 = S3ClassExtension.builder().createBucket("testbucket").build();
 
   @RegisterExtension
   @Order(1)
-  private static final DropwizardAppExtension<Config> DW =
+  static final DropwizardAppExtension<Config> DW =
       new DropwizardAppExtension<>(
           S3WithoutHealthCheckTestApp.class,
           resourceFilePath("test-config.yml"),

--- a/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/SpringDataMongoBundleTracingIT.java
+++ b/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/SpringDataMongoBundleTracingIT.java
@@ -34,15 +34,15 @@ class SpringDataMongoBundleTracingIT {
 
   @RegisterExtension
   @Order(0)
-  private static final OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
+  static final OpenTelemetryExtension OTEL = OpenTelemetryExtension.create();
 
   @RegisterExtension
   @Order(1)
-  private static final MongoDbClassExtension MONGODB = MongoDbClassExtension.builder().build();
+  static final MongoDbClassExtension MONGODB = MongoDbClassExtension.builder().build();
 
   @RegisterExtension
   @Order(2)
-  private static final DropwizardAppExtension<MyConfiguration> DW =
+  static final DropwizardAppExtension<MyConfiguration> DW =
       new DropwizardAppExtension<>(
           TracingTestApp.class,
           null,


### PR DESCRIPTION
according to the official JUnit 5 documentation: https://junit.org/junit5/docs/5.1.1/api/org/junit/jupiter/api/extension/RegisterExtension.html