### PR TITLE
chore(dependabot): ignore jetty-bom 10-12

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     include: scope
   labels:
     - 'dependencies'
+  ignore:
+    - dependency-name: "org.eclipse.jetty:jetty-bom"
+      # ignore all Dependabot updates for version 10, 11, 12
+      # Major version should be in-sync with the version used by Dropwizard
+      versions: [ "10.x", "11.x", "12.x" ]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
* prevents PRs like this: https://github.com/SDA-SE/sda-dropwizard-commons/pull/2783
* stores our ignore rules as code instead of Dependabot magic when you use `@dependabot ignore ...`