### PR TITLE
chore(dependabot): ignore major and minor updates for Zookeeper

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       # ignore all Dependabot updates for version 10, 11, 12
       # Major version should be in-sync with the version used by Dropwizard
       versions: [ "10.x", "11.x", "12.x" ]
+    - dependency-name: "org.apache.zookeeper:zookeeper"
+      # version should be in-sync with the version used by Kafka
+      update-types: ["version-update:semver-major", "version-update:semver-minor"]
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
trying to get rid of #2789

Here's the documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#specifying-dependencies-and-versions-to-ignore