### PR TITLE
fix(deps): exclude Jetty from dropwizard-dependencies

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -38,6 +38,10 @@ dependencies {
     exclude group: 'org.jetbrains', module: 'annotations'
     because("this version is outdated, but the main dependency does not have yet an updated version")
   }
+  api enforcedPlatform("org.eclipse.jetty:jetty-bom:9.4.53.v20231009"), {
+    because "CVE-2023-40167 in 9.4.51.v20230217, " +
+        "CVE-2023-36478 in 9.4.52.v20230823"
+  }
   api enforcedPlatform("io.dropwizard:dropwizard-bom:$dropwizardVersion")
   api enforcedPlatform("io.dropwizard:dropwizard-dependencies:$dropwizardVersion"), {
     exclude group: 'org.awaitility', module: 'awaitility'
@@ -51,16 +55,13 @@ dependencies {
     exclude group: 'com.fasterxml.jackson.jaxrs'
     exclude group: 'com.fasterxml.jackson.module'
     exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
+    exclude group: 'org.eclipse.jetty'
   }
   api enforcedPlatform("com.amazonaws:aws-java-sdk-bom:1.12.569")
   api enforcedPlatform("io.opentelemetry:opentelemetry-bom:$openTelemetryVersion")
   api enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:${openTelemetryVersion}-alpha")
   api enforcedPlatform("io.netty:netty-bom:4.1.100.Final"), {
     because "various CVEs in earlier versions"
-  }
-  api enforcedPlatform("org.eclipse.jetty:jetty-bom:9.4.53.v20231009"), {
-    because "CVE-2023-40167 in 9.4.51.v20230217, " +
-        "CVE-2023-36478 in 9.4.52.v20230823"
   }
 
   constraints {


### PR DESCRIPTION
Jetty 9.4.52 was still picked up by consuming services.