### PR TITLE
test: close responses to enable reusing connections

### DIFF
--- a/docs/migration-guides/MIGRATION_GUIDE_v5_to_v6.md
+++ b/docs/migration-guides/MIGRATION_GUIDE_v5_to_v6.md
@@ -47,6 +47,23 @@ You can check the full migration guide in the
 official
 documentation: [Migration from Apache HttpClient 4.x APIs](https://hc.apache.org/httpcomponents-client-5.2.x/migration-guide/preparation.html)
 
+**Closing Responses**
+
+The Apache 5 connector seems to be more sensitive and might get stuck if you don't
+close your `Response` objects. Make sure to use *try-with-resources* or
+`finally` when you use Jersey clients (either in tests or in production!). 
+
+Example:
+
+```java
+try (Response response = DW.client()
+    .target("http://localhost:" + DW.getLocalPort())
+    .path("/example")
+    .request(APPLICATION_JSON)
+    .get()) {
+  assertThat(response.getStatus()).isEqualTo(200);
+}
+```
 
 ### Jetty 11
 
@@ -63,7 +80,6 @@ You can check the migration guide
 to [v6.0](https://github.com/hibernate/hibernate-orm/blob/6.0/migration-guide.adoc#60-migration-guide)
 and
 to [v6.1](https://github.com/hibernate/hibernate-orm/blob/6.1/migration-guide.adoc#61-migration-guide).
-
 
 ## Modules
 The following modules contain changes:

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientConfigurationTest.java
@@ -98,9 +98,9 @@ class ApiClientConfigurationTest {
             .withHeader("Content-Encoding", matching("gzip"))
             .willReturn(created()));
 
-    assertThat(client.createCar(new Car().setSign("HH UV 42")))
-        .extracting(Response::getStatus)
-        .isEqualTo(SC_CREATED);
+    try (Response response = client.createCar(new Car().setSign("HH UV 42"))) {
+      assertThat(response.getStatus()).isEqualTo(SC_CREATED);
+    }
   }
 
   @Test
@@ -120,9 +120,9 @@ class ApiClientConfigurationTest {
             .withHeader("Transfer-Encoding", equalTo("chunked"))
             .willReturn(created()));
 
-    assertThat(client.createCar(new Car().setSign("HH UV 42")))
-        .extracting(Response::getStatus)
-        .isEqualTo(SC_CREATED);
+    try (Response response = client.createCar(new Car().setSign("HH UV 42"))) {
+      assertThat(response.getStatus()).isEqualTo(SC_CREATED);
+    }
   }
 
   @Test

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ApiClientTest.java
@@ -141,7 +141,7 @@ public class ApiClientTest {
         new FormDataMultiPart()
             .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
             .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
-      Response response =
+      try (Response response =
           app.getJerseyClientBundle()
               .getClientFactory()
               .platformClient()
@@ -151,9 +151,10 @@ public class ApiClientTest {
               .path("multi-part")
               .register(MultiPartFeature.class)
               .request(MediaType.APPLICATION_JSON)
-              .post(Entity.entity(multiPart, multiPart.getMediaType()));
-      assertThat(response.getStatus()).isEqualTo(200);
-      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+              .post(Entity.entity(multiPart, multiPart.getMediaType()))) {
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+      }
 
       String contentType =
           WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
@@ -190,9 +191,10 @@ public class ApiClientTest {
         new FormDataMultiPart()
             .field("test", "test-value", MediaType.TEXT_PLAIN_TYPE)
             .field("anotherTest", "another-test-value", MediaType.TEXT_PLAIN_TYPE)) {
-      Response response = createMockApiClient().sendMultiPart(multiPart);
-      assertThat(response.getStatus()).isEqualTo(200);
-      assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+      try (Response response = createMockApiClient().sendMultiPart(multiPart)) {
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("Content-type")).isEqualTo("application/json");
+      }
 
       String contentType =
           WIRE.getAllServeEvents().get(0).getRequest().contentTypeHeader().firstValue();
@@ -233,35 +235,38 @@ public class ApiClientTest {
 
   @Test
   void loadCarsWithResponseDetails() {
-    Response response = createMockApiClient().requestCars();
+    try (Response response = createMockApiClient().requestCars()) {
 
-    assertThat(response.getStatus()).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withHeader("Trace-Token", matchingUuid()) // NOSONAR
-            .withoutHeader(HttpHeaders.AUTHORIZATION));
+      assertThat(response.getStatus()).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Trace-Token", matchingUuid()) // NOSONAR
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
   }
 
   @Test
   void loadCarsWithBasicAuthAndResponseDetails() {
-    Response response = createMockApiClientWithBasicAuth().requestCars();
+    try (Response response = createMockApiClientWithBasicAuth().requestCars()) {
 
-    assertThat(response.getStatus()).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withHeader("Trace-Token", matchingUuid()) // NOSONAR
-            .withHeader(HttpHeaders.AUTHORIZATION, matching("Basic Zm9vOmJhcg==")));
+      assertThat(response.getStatus()).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Trace-Token", matchingUuid()) // NOSONAR
+              .withHeader(HttpHeaders.AUTHORIZATION, matching("Basic Zm9vOmJhcg==")));
+    }
   }
 
   @Test
   void addConsumerToken() {
-    Response response = createMockApiClient().requestCars();
+    try (Response response = createMockApiClient().requestCars()) {
 
-    assertThat(response.getStatus()).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withHeader("Consumer-Token", equalTo("test-consumer")) // NOSONAR
-            .withoutHeader(HttpHeaders.AUTHORIZATION));
+      assertThat(response.getStatus()).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Consumer-Token", equalTo("test-consumer")) // NOSONAR
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
   }
 
   @Test
@@ -294,73 +299,77 @@ public class ApiClientTest {
 
   @Test
   void addReceivedTraceTokenToHeadersToPlatformCall() {
-    int status =
+    try (Response response =
         dwClient()
             .path("api")
             .path("cars")
             .request(MediaType.APPLICATION_JSON_TYPE)
             .header("Trace-Token", "test-trace-token-1")
-            .get()
-            .getStatus();
+            .get()) {
+      int status = response.getStatus();
 
-    assertThat(status).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withHeader("Trace-Token", equalTo("test-trace-token-1"))
-            .withoutHeader(HttpHeaders.AUTHORIZATION));
+      assertThat(status).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Trace-Token", equalTo("test-trace-token-1"))
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
   }
 
   @Test
   void addReceivedAuthHeaderToPlatformCall() {
-    int status =
+    try (Response response =
         dwClient()
             .path("api")
             .path("carsAuth")
             .request(MediaType.APPLICATION_JSON_TYPE)
             .header("Authorization", "custom-dummy-token")
             .header("Trace-Token", "test-trace-token-3")
-            .get()
-            .getStatus();
+            .get()) {
+      int status = response.getStatus();
 
-    assertThat(status).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withHeader("Trace-Token", equalTo("test-trace-token-3"))
-            .withHeader(HttpHeaders.AUTHORIZATION, equalTo("custom-dummy-token")));
+      assertThat(status).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withHeader("Trace-Token", equalTo("test-trace-token-3"))
+              .withHeader(HttpHeaders.AUTHORIZATION, equalTo("custom-dummy-token")));
+    }
   }
 
   @Test
   void notAddingReceivedTraceTokenToHeadersOfExternalCall() {
-    int status =
+    try (Response response =
         dwClient()
             .path("api")
             .path("carsExternal")
             .request(MediaType.APPLICATION_JSON_TYPE)
             .header("Trace-Token", "test-trace-token-2")
-            .get()
-            .getStatus();
+            .get()) {
+      int status = response.getStatus();
 
-    assertThat(status).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withoutHeader("Trace-Token"));
+      assertThat(status).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withoutHeader("Trace-Token"));
+    }
   }
 
   @Test
   void notAddingReceivedAuthorizationToHeadersOfExternalCall() {
-    int status =
+    try (Response response =
         dwClient()
             .path("api")
             .path("carsExternal")
             .request(MediaType.APPLICATION_JSON_TYPE)
             .header(HttpHeaders.AUTHORIZATION, "BEARER dummy")
-            .get()
-            .getStatus();
+            .get()) {
+      int status = response.getStatus();
 
-    assertThat(status).isEqualTo(200);
-    WIRE.verify(
-        RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
-            .withoutHeader(HttpHeaders.AUTHORIZATION));
+      assertThat(status).isEqualTo(200);
+      WIRE.verify(
+          RequestPatternBuilder.newRequestPattern(GET, urlEqualTo("/api/cars"))
+              .withoutHeader(HttpHeaders.AUTHORIZATION));
+    }
   }
 
   @Test

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientConfiguredProxyTest.java
@@ -68,10 +68,11 @@ class ClientConfiguredProxyTest {
     PROXY_WIRE.stubFor(get("/").withHeader(HttpHeaders.HOST, equalTo("sda.se")).willReturn(ok()));
 
     // when
-    Response response = getClient("shouldUseProxy").target("http://sda.se").request().get();
+    try (Response response = getClient("shouldUseProxy").target("http://sda.se").request().get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    }
     CONTENT_WIRE.verify(0, RequestPatternBuilder.allRequests());
     PROXY_WIRE.verify(
         1,
@@ -90,11 +91,12 @@ class ClientConfiguredProxyTest {
             .willReturn(aResponse().withStatus(409)));
 
     // when
-    Response response =
-        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get();
+    try (Response response =
+        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+    }
     PROXY_WIRE.verify(0, RequestPatternBuilder.allRequests());
     CONTENT_WIRE.verify(
         1,

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientErrorUtilTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientErrorUtilTest.java
@@ -231,8 +231,10 @@ class ClientErrorUtilTest {
                         APPLICATION_JSON) // https://github.com/dropwizard/dropwizard/issues/231
                     .withBody(OM.writeValueAsBytes(givenError))));
 
-    Response response = webTarget.request(APPLICATION_JSON).get();
-    ApiError errors = ClientErrorUtil.readErrorBody(response);
+    ApiError errors;
+    try (Response response = webTarget.request(APPLICATION_JSON).get()) {
+      errors = ClientErrorUtil.readErrorBody(response);
+    }
     assertThat(errors).isNotNull();
     assertThat(errors.getTitle()).isEqualTo("An error for testing"); // NOSONAR
     assertThat(errors.getInvalidParams())
@@ -255,10 +257,11 @@ class ClientErrorUtilTest {
                     .withBody(
                         OM.writeValueAsBytes(singletonMap("message", "This has been found")))));
 
-    Response response = webTarget.request(APPLICATION_JSON).get();
-    Map<String, Object> errorBody =
-        ClientErrorUtil.readErrorBody(response, new TypeReference<Map<String, Object>>() {});
-    assertThat(errorBody).isNull();
+    try (Response response = webTarget.request(APPLICATION_JSON).get()) {
+      Map<String, Object> errorBody =
+          ClientErrorUtil.readErrorBody(response, new TypeReference<Map<String, Object>>() {});
+      assertThat(errorBody).isNull();
+    }
   }
 
   @Test
@@ -273,10 +276,11 @@ class ClientErrorUtilTest {
                     .withBody(
                         OM.writeValueAsBytes(singletonMap("message", "This has been found")))));
 
-    Response response = webTarget.request(APPLICATION_JSON).get();
-    Map<String, Object> errorBody =
-        ClientErrorUtil.readErrorBody(response, new GenericType<Map<String, Object>>() {});
-    assertThat(errorBody).isNull();
+    try (Response response = webTarget.request(APPLICATION_JSON).get()) {
+      Map<String, Object> errorBody =
+          ClientErrorUtil.readErrorBody(response, new GenericType<Map<String, Object>>() {});
+      assertThat(errorBody).isNull();
+    }
   }
 
   @Test
@@ -292,8 +296,9 @@ class ClientErrorUtilTest {
                         TEXT_PLAIN) // https://github.com/dropwizard/dropwizard/issues/231
                     .withBody("This has been found")));
 
-    Response response = webTarget.request(TEXT_PLAIN).get();
-    String errorBody = ClientErrorUtil.readErrorBody(response, String.class);
-    assertThat(errorBody).isNull();
+    try (Response response = webTarget.request(TEXT_PLAIN).get()) {
+      var errorBody = ClientErrorUtil.readErrorBody(response, String.class);
+      assertThat(errorBody).isNull();
+    }
   }
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/ClientProxyTest.java
@@ -67,10 +67,11 @@ class ClientProxyTest {
     PROXY_WIRE.stubFor(get("/").withHeader(HttpHeaders.HOST, equalTo("sda.se")).willReturn(ok()));
 
     // when
-    Response response = getClient("shouldUseProxy").target("http://sda.se").request().get();
+    try (Response response = getClient("shouldUseProxy").target("http://sda.se").request().get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    }
     CONTENT_WIRE.verify(0, RequestPatternBuilder.allRequests());
     PROXY_WIRE.verify(
         1,
@@ -89,11 +90,12 @@ class ClientProxyTest {
             .willReturn(aResponse().withStatus(409)));
 
     // when
-    Response response =
-        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get();
+    try (Response response =
+        getClient("shouldNotUseProxy").target(CONTENT_WIRE.baseUrl()).request().get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+    }
     PROXY_WIRE.verify(0, RequestPatternBuilder.allRequests());
     CONTENT_WIRE.verify(
         1,

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/error/ClientRequestExceptionMapperTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/error/ClientRequestExceptionMapperTest.java
@@ -26,17 +26,18 @@ class ClientRequestExceptionMapperTest {
   void mapNotFound() {
     ClientRequestException exception = new ClientRequestException(new NotFoundException());
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .contains("404");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .contains("404");
+    }
   }
 
   @Test
@@ -44,34 +45,36 @@ class ClientRequestExceptionMapperTest {
     ClientRequestException exception =
         new ClientRequestException(new InternalServerErrorException());
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .contains("500");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .contains("500");
+    }
   }
 
   @Test
   void mapUnknownClientError() {
     ClientRequestException exception = new ClientRequestException(new ClientErrorException(418));
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .contains("418");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .contains("418");
+    }
   }
 
   @Test
@@ -80,17 +83,18 @@ class ClientRequestExceptionMapperTest {
         new ClientRequestException(
             new ProcessingException(new JsonParseException(mock(JsonParser.class), "No message")));
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .containsIgnoringCase("processing");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .containsIgnoringCase("processing");
+    }
   }
 
   @Test
@@ -100,18 +104,19 @@ class ClientRequestExceptionMapperTest {
             new ProcessingException(
                 new ConnectTimeoutException(ConnectTimeoutException.class.descriptorString())));
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .containsIgnoringCase("Connect")
-        .containsIgnoringCase("timeout");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .containsIgnoringCase("Connect")
+          .containsIgnoringCase("timeout");
+    }
   }
 
   @Test
@@ -119,17 +124,18 @@ class ClientRequestExceptionMapperTest {
     ClientRequestException exception =
         new ClientRequestException(new ProcessingException(new SocketTimeoutException()));
 
-    Response response = clientRequestExceptionMapper.toResponse(exception);
+    try (Response response = clientRequestExceptionMapper.toResponse(exception)) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
-        .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
-    assertThat(response.getEntity()).isInstanceOf(ApiError.class);
-    assertThat((ApiError) response.getEntity())
-        .extracting(ApiError::getTitle)
-        .asString()
-        .isNotBlank()
-        .containsIgnoringCase("read")
-        .containsIgnoringCase("timeout");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.getHeaders().getFirst(CONTENT_TYPE))
+          .isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      assertThat(response.getEntity()).isInstanceOf(ApiError.class);
+      assertThat((ApiError) response.getEntity())
+          .extracting(ApiError::getTitle)
+          .asString()
+          .isNotBlank()
+          .containsIgnoringCase("read")
+          .containsIgnoringCase("timeout");
+    }
   }
 }

--- a/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcRequestFilterTest.java
+++ b/sda-commons-client-jersey/src/test/java/org/sdase/commons/client/jersey/oidc/OidcRequestFilterTest.java
@@ -84,10 +84,11 @@ class OidcRequestFilterTest {
     setupTokenEndpoint(true);
 
     // when
-    Response r = app.getClientTestEndPoint().delegate();
+    try (Response r = app.getClientTestEndPoint().delegate()) {
 
-    // then
-    assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+      // then
+      assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+    }
 
     verify(
         1,
@@ -102,10 +103,11 @@ class OidcRequestFilterTest {
     setupTokenEndpoint(true);
 
     // when
-    Response r = app.getClientTestEndPoint().delegate();
+    try (Response r = app.getClientTestEndPoint().delegate()) {
 
-    // then
-    assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+      // then
+      assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+    }
 
     verify(
         1,
@@ -121,10 +123,11 @@ class OidcRequestFilterTest {
     setupTokenEndpoint(false);
 
     // when
-    Response r = app.getClientTestEndPoint().delegate();
+    try (Response r = app.getClientTestEndPoint().delegate()) {
 
-    // then
-    assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+      // then
+      assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+    }
 
     verify(1, getRequestedFor(urlEqualTo("/api/cars")).withoutHeader(AUTHORIZATION));
     verify(1, postRequestedFor(urlEqualTo("/token")));

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/AuthNoopTracerTest.java
@@ -8,7 +8,6 @@ import static org.sdase.commons.server.opa.testing.AbstractOpa.onAnyRequest;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.OpenTelemetry;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ class AuthNoopTracerTest {
             .request()
             .headers(AUTH.auth().buildAuthHeader())
             .get()) {
-      assertThat(response).extracting(Response::getStatus).isEqualTo(200);
+      assertThat(response.getStatus()).isEqualTo(200);
     }
     OPA.verify(1, "GET", "/resources");
   }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionIT.java
@@ -39,46 +39,49 @@ class AuthClassExtensionIT {
 
   @Test
   void shouldAccessOpenEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/open") // NOSONAR
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open."); // NOSONAR
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open."); // NOSONAR
+    }
   }
 
   @Test
   void shouldAccessOpenEndPointWithInvalidToken() {
     final String invalidTokenWithoutKid =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/open")
             .request(APPLICATION_JSON)
             .header(AUTHORIZATION, "Bearer " + invalidTokenWithoutKid)
-            .get();
+            .get()) {
 
-    // No token checking at this point
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+      // No token checking at this point
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+    }
   }
 
   @Test
   void shouldBeUnauthorizedIfAccessedWithNonJwt() {
-    Response response =
+    Map<String, Object> stringObjectMap;
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .header(AUTHORIZATION, "Bearer .")
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    Map<String, Object> stringObjectMap =
-        response.readEntity(new GenericType<Map<String, Object>>() {});
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      stringObjectMap = response.readEntity(new GenericType<Map<String, Object>>() {});
+    }
 
     assertThat(stringObjectMap)
         .containsOnly(
@@ -90,107 +93,113 @@ class AuthClassExtensionIT {
   void shouldBeUnauthorizedIfAccessedWithTokenFromWrongIdp() {
     final String tokenWithUnknownKid =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImNHV1RlQUJwWnYyN3RfWDFnTW92NEVlRWhEOXRBMWVhcUgzVzFmMXE4Y28ifQ.eyJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0In0.nHN-k_uvKNl8Nh5lXctQkL8KrWKggGiBQ-jaR0xIq_TAWBbhz5zkGXQTiNZwjPFOIcjyuL1xMCqzLPAKiI0Jy0hwOa4xcqukrWr4UwhKC50dnJiFqUgpGM0xLyT1D8JKdSNiVtYL0k-E5XCcpDEqOjHOG3Gw03VoZ0iRNeU2X49Rko8646l5j2g4QbuuOSn1a5G4ICMCAY7C6Vb55dgJtG_WAvkhFdBd_ShQEp_XfWJh6uq0E95_8yfzBx4UuK1Q-TLuWrXKxOlYNCuCH90NYG-3oF9w0gFtdXtYOFzPIEVIkU0Ra6sk_s0IInrEMD_3Q4fgE2PqOzqpuVaD_lHdAA";
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .header(AUTHORIZATION, "Bearer " + tokenWithUnknownKid)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
-        .containsOnly(
-            entry("title", "Could not verify JWT with the requested kid."),
-            entry("invalidParams", emptyList()));
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
+          .containsOnly(
+              entry("title", "Could not verify JWT with the requested kid."),
+              entry("invalidParams", emptyList()));
+    }
   }
 
   @Test
   void shouldAccessOpenEndPointWithToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/open")
             .request(APPLICATION_JSON)
             .headers(AUTH.auth().buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+    }
   }
 
   @Test
   void shouldNotAccessSecureEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
-        .containsOnly(
-            entry("title", "Credentials are required to access this resource."),
-            entry("invalidParams", emptyList()));
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer"); // NOSONAR
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
+          .containsOnly(
+              entry("title", "Credentials are required to access this resource."),
+              entry("invalidParams", emptyList()));
+    }
   }
 
   @Test
   void shouldNotAccessSecureEndPointWithInvalidToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .header(
                 AUTHORIZATION,
                 "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
-        .containsOnly(
-            entry("title", "Could not verify JWT without kid nor x5t."),
-            entry("invalidParams", emptyList()));
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
+          .containsOnly(
+              entry("title", "Could not verify JWT without kid nor x5t."),
+              entry("invalidParams", emptyList()));
+    }
   }
 
   @Test
   void shouldNotAccessSecureEndPointWithExpiredToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .headers(
                 AUTH.auth().addClaim(RegisteredClaims.EXPIRES_AT, new Date(0)).buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
-        .containsOnly(
-            entry("title", "Verifying token failed"), entry("invalidParams", emptyList()));
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
+          .containsOnly(
+              entry("title", "Verifying token failed"), entry("invalidParams", emptyList()));
+    }
   }
 
   @Test
   void shouldAccessSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure")
             .request(APPLICATION_JSON)
             .headers(AUTH.auth().buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(entry("iss", "AuthExtension"), entry("sub", "test"));
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(entry("iss", "AuthExtension"), entry("sub", "test"));
+    }
   }
 
   @Test
   void shouldGetClaimsFromSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure")
             .request(APPLICATION_JSON)
@@ -199,15 +208,16 @@ class AuthClassExtensionIT {
                     .addClaim("test", "testClaim")
                     .addClaims(singletonMap("mapKey", "testClaimFromMap"))
                     .buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(
-            entry("iss", "AuthExtension"),
-            entry("sub", "test"),
-            entry("test", "testClaim"),
-            entry("mapKey", "testClaimFromMap"));
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(
+              entry("iss", "AuthExtension"),
+              entry("sub", "test"),
+              entry("test", "testClaim"),
+              entry("mapKey", "testClaimFromMap"));
+    }
   }
 
   private WebTarget createWebTarget() {

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthClassExtensionProgrammaticIT.java
@@ -31,47 +31,50 @@ class AuthClassExtensionProgrammaticIT {
 
   @Test
   void shouldAccessOpenEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/open")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+    }
   }
 
   @Test
   void shouldNotAccessSecureEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
   }
 
   @Test
   void shouldAccessSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
             .request(APPLICATION_JSON)
             .headers(AUTH.auth().buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(entry("iss", "AuthExtension"), entry("sub", "test"));
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(entry("iss", "AuthExtension"), entry("sub", "test"));
+    }
   }
 
   @Test
   void shouldGetClaimsFromSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
@@ -81,14 +84,15 @@ class AuthClassExtensionProgrammaticIT {
                     .addClaim("test", "testClaim")
                     .addClaims(singletonMap("mapKey", "testClaimFromMap"))
                     .buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(
-            entry("iss", "AuthExtension"),
-            entry("sub", "test"),
-            entry("test", "testClaim"),
-            entry("mapKey", "testClaimFromMap"));
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(
+              entry("iss", "AuthExtension"),
+              entry("sub", "test"),
+              entry("test", "testClaim"),
+              entry("mapKey", "testClaimFromMap"));
+    }
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthDisabledJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthDisabledJUnit5IT.java
@@ -28,27 +28,29 @@ class AuthDisabledJUnit5IT {
 
   @Test
   void shouldAccessOpenEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/open")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+    }
   }
 
   @Test
   void shouldAccessSecureEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
   }
 
   @Test

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthRuleCustomizationJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/AuthRuleCustomizationJUnit5IT.java
@@ -41,47 +41,50 @@ class AuthRuleCustomizationJUnit5IT {
 
   @Test
   void shouldAccessOpenEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("/open")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(String.class)).isEqualTo("We are open.");
+    }
   }
 
   @Test
   void shouldNotAccessSecureEndPointWithoutToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
   }
 
   @Test
   void shouldAccessSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
             .request(APPLICATION_JSON)
             .headers(AUTH.auth().buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(entry("iss", "customIssuer"), entry("sub", "customSubject"));
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(entry("iss", "customIssuer"), entry("sub", "customSubject"));
+    }
   }
 
   @Test
   void shouldDenyAccessWhenTokenExpires() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
@@ -90,15 +93,16 @@ class AuthRuleCustomizationJUnit5IT {
                 AUTH.auth()
                     .addClaim("exp", new GregorianCalendar(1956, Calendar.MARCH, 17).getTime())
                     .buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString("WWW-Authenticate")).contains("Bearer");
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString("WWW-Authenticate")).contains("Bearer");
+    }
   }
 
   @Test
   void shouldGetClaimsFromSecureEndPointWithToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/secure")
@@ -108,14 +112,15 @@ class AuthRuleCustomizationJUnit5IT {
                     .addClaim("test", "testClaim")
                     .addClaims(singletonMap("mapKey", "testClaimFromMap"))
                     .buildAuthHeader())
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
-    assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
-        .contains(
-            entry("iss", "customIssuer"),
-            entry("sub", "customSubject"),
-            entry("test", "testClaim"),
-            entry("mapKey", "testClaimFromMap"));
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+      assertThat(response.readEntity(new GenericType<Map<String, String>>() {}))
+          .contains(
+              entry("iss", "customIssuer"),
+              entry("sub", "customSubject"),
+              entry("test", "testClaim"),
+              entry("mapKey", "testClaimFromMap"));
+    }
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/CustomKeyLoaderConfigIT.java
@@ -56,14 +56,15 @@ class CustomKeyLoaderConfigIT {
   void shouldSendCustomUserAgentInTheJwksRequest() {
     final String token =
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.e30.sJ38ARdiqW5NDXRzkwPGD_XVVBL_q50ytQr3CezUaWCUlDgOwa49G_GuiriVbAAhllyETulropgTvCxbsDdXOHW4YrQWrJ1rn-HLqceoNxSX_Z2HaR5CeNtUmGL2pX-kv_9rYmyjRVwcOMRsQx_a7DPl-Bo5RrKXHka1nnaQ1a55W4PPOSiCCq4oEYH6RerxODh7uvfB9cYruUMH60f-kZeMVVzKuFpwBdI8xCYEZxXcBPtERsOVBTnGpr8S2_2xpaP6vfLsY4M63GwRNsTL9e8Ghm5n7VMuMrJESCHSrCTMMAK90S_iA3VwbVSUMyrJNdeccAc4lBqizUb7JuBygA";
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .header(AUTHORIZATION, "Bearer " + token)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+    }
 
     WIRE.verify(
         getRequestedFor(urlEqualTo("/jwks")).withHeader(USER_AGENT, equalTo("my-user-agent")));

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/auth/testing/KeyLoaderProxyIT.java
@@ -72,15 +72,16 @@ class KeyLoaderProxyIT {
         "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImNHV1RlQUJwWnYyN3RfWDFnTW92NEVlRWhEOXRBMWVhcUgzVzFmMXE4Y28ifQ.eyJwcmVmZXJyZWRfdXNlcm5hbWUiOiJ0ZXN0In0.nHN-k_uvKNl8Nh5lXctQkL8KrWKggGiBQ-jaR0xIq_TAWBbhz5zkGXQTiNZwjPFOIcjyuL1xMCqzLPAKiI0Jy0hwOa4xcqukrWr4UwhKC50dnJiFqUgpGM0xLyT1D8JKdSNiVtYL0k-E5XCcpDEqOjHOG3Gw03VoZ0iRNeU2X49Rko8646l5j2g4QbuuOSn1a5G4ICMCAY7C6Vb55dgJtG_WAvkhFdBd_ShQEp_XfWJh6uq0E95_8yfzBx4UuK1Q-TLuWrXKxOlYNCuCH90NYG-3oF9w0gFtdXtYOFzPIEVIkU0Ra6sk_s0IInrEMD_3Q4fgE2PqOzqpuVaD_lHdAA";
 
     // when
-    Response response =
+    try (Response response =
         createWebTarget()
             .path("/secure") // NOSONAR
             .request(APPLICATION_JSON)
             .header(AUTHORIZATION, "Bearer " + tokenWithUnknownKid)
-            .get();
+            .get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+      // then
+      assertThat(response.getStatus()).isEqualTo(SC_UNAUTHORIZED);
+    }
 
     PROXY_WIRE.verify(
         2,

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/AuthAndOpaIT.java
@@ -62,15 +62,16 @@ class AuthAndOpaIT {
   @Test
   @RetryingTest(5)
   void shouldNotAccessSimpleWithInvalidToken() {
-    Response response =
+    try (Response response =
         getResources(
-            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
-    assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
-    assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
-    assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
-        .containsKeys("title", "invalidParams");
+      assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+      assertThat(response.getHeaderString(WWW_AUTHENTICATE)).contains("Bearer");
+      assertThat(response.getHeaderString(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON);
+      assertThat(response.readEntity(new GenericType<Map<String, Object>>() {}))
+          .containsKeys("title", "invalidParams");
+    }
     OPA_EXTENSION.verify(0, onAnyRequest());
   }
 
@@ -79,10 +80,12 @@ class AuthAndOpaIT {
   void shouldAllowAccessSimple() {
     OPA_EXTENSION.mock(onRequest().withHttpMethod(method).withPath(path).withJwt(jwt).allow());
 
-    Response response = getResources(true);
+    PrincipalInfo principalInfo;
+    try (Response response = getResources(true)) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    }
     assertThat(principalInfo.getJwt()).isEqualTo(jwt);
     assertThat(principalInfo.getConstraints().getConstraint()).isNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isFalse();
@@ -100,10 +103,12 @@ class AuthAndOpaIT {
             .withConstraint(
                 new ConstraintModel().setFullAccess(true).addConstraint("customer_ids", "1")));
 
-    Response response = getResources(true);
+    PrincipalInfo principalInfo;
+    try (Response response = getResources(true)) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    }
     assertThat(principalInfo.getName()).isEqualTo("OpaJwtPrincipal");
     assertThat(principalInfo.getJwt()).isNotNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isTrue();
@@ -118,10 +123,12 @@ class AuthAndOpaIT {
   void shouldAllowAccessWithoutTokenSimple() {
     OPA_EXTENSION.mock(onRequest().withHttpMethod(method).withPath(path).withJwt(null).allow());
 
-    Response response = getResources(false);
+    PrincipalInfo principalInfo;
+    try (Response response = getResources(false)) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    }
     assertThat(principalInfo.getJwt()).isNull();
     assertThat(principalInfo.getConstraints().getConstraint()).isNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isFalse();
@@ -139,10 +146,12 @@ class AuthAndOpaIT {
             .withConstraint(
                 new ConstraintModel().setFullAccess(true).addConstraint("customer_ids", "1")));
 
-    Response response = getResources(false);
+    PrincipalInfo principalInfo;
+    try (Response response = getResources(false)) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    }
     assertThat(principalInfo.getJwt()).isNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isTrue();
     assertThat(principalInfo.getConstraints().getConstraint())

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaClassExtensionProgrammaticIT.java
@@ -36,16 +36,18 @@ public class OpaClassExtensionProgrammaticIT {
     OPA_EXTENSION.mock(onRequest().withHttpMethod("GET").withPath("resources").allow());
 
     // when
-    Response response =
+    PrincipalInfo principalInfo;
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
-            .get(); // NOSONAR
+            .get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    } // NOSONAR
     assertThat(principalInfo.getConstraints().getConstraint()).isNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isFalse();
     assertThat(principalInfo.getJwt()).isNull();

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaConnectionMisconfiguredIT.java
@@ -20,13 +20,14 @@ class OpaConnectionMisconfiguredIT {
 
   @Test
   void shouldDenyAccess() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
-            .get(); // NOSONAR
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN); // NOSONAR
+    }
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledIT.java
@@ -27,14 +27,15 @@ class OpaDisabledIT {
   @Test
   @RetryingTest(5)
   void shouldAllowAccess() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
-            .get(); // NOSONAR
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    } // NOSONAR
   }
 
   @Test

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledJUnit5IT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaDisabledJUnit5IT.java
@@ -32,27 +32,29 @@ class OpaDisabledJUnit5IT {
 
   @RetryingTest(5)
   void shouldAllowAccess() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
-            .get(); // NOSONAR
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+    } // NOSONAR
   }
 
   @RetryingTest(5)
   void shouldNotIncludeHealthCheck() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getAdminPort()) // NOSONAR
             .path("healthcheck")
             .request(MediaType.APPLICATION_JSON_TYPE)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    assertThat(response.readEntity(String.class))
-        .doesNotContain(PolicyExistsHealthCheck.DEFAULT_NAME);
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      assertThat(response.readEntity(String.class))
+          .doesNotContain(PolicyExistsHealthCheck.DEFAULT_NAME);
+    }
   }
 }

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaProgrammaticIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaProgrammaticIT.java
@@ -38,16 +38,18 @@ class OpaProgrammaticIT {
     OPA_EXTENSION.mock(onRequest().withHttpMethod("GET").withPath("resources").allow());
 
     // when
-    Response response =
+    PrincipalInfo principalInfo;
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort()) // NOSONAR
             .path("resources")
             .request()
-            .get(); // NOSONAR
+            .get()) {
 
-    // then
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
-    PrincipalInfo principalInfo = response.readEntity(PrincipalInfo.class);
+      // then
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+      principalInfo = response.readEntity(PrincipalInfo.class);
+    } // NOSONAR
     assertThat(principalInfo.getConstraints().getConstraint()).isNull();
     assertThat(principalInfo.getConstraints().isFullAccess()).isFalse();
     assertThat(principalInfo.getJwt()).isNull();

--- a/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
+++ b/sda-commons-server-auth-testing/src/test/java/org/sdase/commons/server/opa/testing/OpaRequestsIT.java
@@ -133,15 +133,16 @@ class OpaRequestsIT {
   }
 
   private void doGetRequest(MultivaluedMap<String, Object> headers) {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("resources")
             .request()
             .headers(headers)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   private void basicAssertions(Map<String, Object> opaInput) {

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleBodyInputExtensionTest.java
@@ -98,17 +98,18 @@ class OpaBundleBodyInputExtensionTest {
     WIRE.resetRequests();
 
     // when
-    Response response =
+    try (Response response =
         DW_WITH_EXTENSION
             .client()
             .target("http://localhost:" + DW_WITH_EXTENSION.getLocalPort())
             .request()
-            .post(Entity.json(Collections.singletonMap("key", "value")));
+            .post(Entity.json(Collections.singletonMap("key", "value")))) {
 
-    // then
-    assertThat(WIRE.getAllServeEvents()).hasSize(1);
-    assertThat(response.getStatus()).isEqualTo(400);
-    assertThat(response.readEntity(String.class)).contains("Received null input.");
+      // then
+      assertThat(WIRE.getAllServeEvents()).hasSize(1);
+      assertThat(response.getStatus()).isEqualTo(400);
+      assertThat(response.readEntity(String.class)).contains("Received null input.");
+    }
   }
 
   @Test
@@ -118,17 +119,18 @@ class OpaBundleBodyInputExtensionTest {
     WIRE.resetRequests();
 
     // when
-    Response response =
+    try (Response response =
         DW_WITHOUT_EXTENSION
             .client()
             .target("http://localhost:" + DW_WITHOUT_EXTENSION.getLocalPort())
             .request()
-            .post(Entity.json(Collections.singletonMap("key", "value")));
+            .post(Entity.json(Collections.singletonMap("key", "value")))) {
 
-    // then
-    assertThat(WIRE.getAllServeEvents()).hasSize(1);
-    assertThat(response.getStatus()).isEqualTo(200);
-    assertThat(response.readEntity(String.class)).isEqualTo("value");
+      // then
+      assertThat(WIRE.getAllServeEvents()).hasSize(1);
+      assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.readEntity(String.class)).isEqualTo("value");
+    }
   }
 
   /**

--- a/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
+++ b/sda-commons-server-auth/src/test/java/org/sdase/commons/server/opa/OpaBundleClientConfigurationIT.java
@@ -69,9 +69,10 @@ class OpaBundleClientConfigurationIT {
   @Test
   @RetryingTest(5)
   void shouldSendCustomUserAgentInTheOpaRequest() {
-    Response response = createWebTarget().request(APPLICATION_JSON).get();
+    try (Response response = createWebTarget().request(APPLICATION_JSON).get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+    }
 
     WIRE.verify(
         postRequestedFor(urlEqualTo("/v1/data/test"))

--- a/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
+++ b/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleOptionalTokenTest.java
@@ -55,20 +55,22 @@ class ConsumerTokenBundleOptionalTokenTest {
 
   @Test
   void shouldNotRejectRequestWithoutConsumerToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/name")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectOptionsRequest() {
-    Response response =
-        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options();
-    assertThat(response.getStatus()).isEqualTo(200);
+    try (Response response =
+        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
@@ -99,24 +101,26 @@ class ConsumerTokenBundleOptionalTokenTest {
 
   @Test
   void shouldNotRejectRequestWithoutConsumerTokenFixedConfig() {
-    Response response =
+    try (Response response =
         DW_OPTIONAL
             .client()
             .target("http://localhost:" + DW_OPTIONAL.getLocalPort())
             .path("/api/name")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectOptionsRequestFixedConfig() {
-    Response response =
+    try (Response response =
         DW_OPTIONAL
             .client()
             .target("http://localhost:" + DW_OPTIONAL.getLocalPort())
             .request()
-            .options();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .options()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 }

--- a/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleTest.java
+++ b/sda-commons-server-consumer/src/test/java/org/sdase/commons/server/consumer/ConsumerTokenBundleTest.java
@@ -54,44 +54,48 @@ class ConsumerTokenBundleTest {
 
   @Test
   void shouldRejectRequestWithoutConsumerToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/name")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(401);
-    assertThat(response.readEntity(ApiError.class).getTitle())
-        .isEqualTo("Consumer token is required to access this resource.");
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(401);
+      assertThat(response.readEntity(ApiError.class).getTitle())
+          .isEqualTo("Consumer token is required to access this resource.");
+    }
   }
 
   @Test
   void shouldNotRejectRequestWithoutConsumerTokenExcludedSwagger() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/swagger.json")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectRequestWithoutConsumerTokenExcludedOpenApi() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/openapi.json")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectOptionsRequest() {
-    Response response =
-        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options();
-    assertThat(response.getStatus()).isEqualTo(200);
+    try (Response response =
+        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
@@ -122,50 +126,54 @@ class ConsumerTokenBundleTest {
 
   @Test
   void shouldRejectRequestWithoutConsumerTokenFixedConfig() {
-    Response response =
+    try (Response response =
         DW_REQUIRED
             .client()
             .target("http://localhost:" + DW_REQUIRED.getLocalPort())
             .path("/api/name")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(401);
-    assertThat(response.readEntity(ApiError.class).getTitle())
-        .isEqualTo("Consumer token is required to access this resource.");
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(401);
+      assertThat(response.readEntity(ApiError.class).getTitle())
+          .isEqualTo("Consumer token is required to access this resource.");
+    }
   }
 
   @Test
   void shouldNotRejectRequestWithoutConsumerTokenExcludedFixedConfigSwagger() {
-    Response response =
+    try (Response response =
         DW_REQUIRED
             .client()
             .target("http://localhost:" + DW_REQUIRED.getLocalPort())
             .path("/api/swagger.json")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectRequestWithoutConsumerTokenExcludedFixedConfigOpenApi() {
-    Response response =
+    try (Response response =
         DW_REQUIRED
             .client()
             .target("http://localhost:" + DW_REQUIRED.getLocalPort())
             .path("/api/openapi.json")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void shouldNotRejectOptionsRequestFixedConfig() {
-    Response response =
+    try (Response response =
         DW_REQUIRED
             .client()
             .target("http://localhost:" + DW_REQUIRED.getLocalPort())
             .request()
-            .options();
-    assertThat(response.getStatus()).isEqualTo(200);
+            .options()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 }

--- a/sda-commons-server-cors/src/test/java/org/sdase/commons/server/cors/CorsTestIT.java
+++ b/sda-commons-server-cors/src/test/java/org/sdase/commons/server/cors/CorsTestIT.java
@@ -60,271 +60,291 @@ class CorsTestIT {
 
   @Test
   void shouldNotSetHeaderWhenDeny() {
-    Response response =
+    try (Response response =
         DW_DENY
             .client()
             .target(denyEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", "server-a.com")
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldSetHeaderWhenAllow() {
     String origin = "some.com";
-    Response response =
+    try (Response response =
         DW_ALLOW
             .client()
             .target(allowAllEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isEqualTo("Location,exposed");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isEqualTo("Location,exposed");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+    }
   }
 
   @Test
   void shouldSetHeaderWhenOriginAllowed() {
     String origin = "server-a.com";
-    Response response =
+    try (Response response =
         DW_RESTRICTED
             .client()
             .target(restrictedEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isEqualTo("Location,exposed");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isEqualTo("Location,exposed");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+    }
   }
 
   @Test
   void shouldNotSetHeaderWhenOriginNotAllowed() {
     String origin = "server-b.com";
-    Response response =
+    try (Response response =
         DW_RESTRICTED
             .client()
             .target(restrictedEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldNotSetHeaderWhenDenyedPreflight() {
     String origin = "server-a.com";
-    Response response =
+    try (Response response =
         DW_DENY
             .client()
             .target(denyEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER, "POST")
-            .options();
+            .options()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldSetHeaderWhenAllowPreflight() {
     String origin = "some.com";
-    Response response =
+    try (Response response =
         DW_ALLOW
             .client()
             .target(allowAllEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST")
-            .options();
+            .options()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isEqualTo("HEAD,GET,POST,PUT,DELETE,PATCH");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
-    assertThat(
-            response
-                .getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER)
-                .split(","))
-        .containsExactlyInAnyOrder(getAllowedHeaderList("some"));
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isEqualTo("HEAD,GET,POST,PUT,DELETE,PATCH");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+      assertThat(
+              response
+                  .getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER)
+                  .split(","))
+          .containsExactlyInAnyOrder(getAllowedHeaderList("some"));
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldRespondWithStandardAllowHeaderForNonPreflightOptionsRequest() {
-    Response response =
+    try (Response response =
         DW_ALLOW
             .client()
             .target(allowAllEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", "some-origin.com")
-            .options();
-    assertThat(response.getHeaderString(HttpHeaders.ALLOW)).isEqualTo("HEAD,GET,OPTIONS");
+            .options()) {
+      assertThat(response.getHeaderString(HttpHeaders.ALLOW)).isEqualTo("HEAD,GET,OPTIONS");
+    }
   }
 
   @Test
   void shouldSetHeaderWhenOriginAllowedPreflight() {
     String origin = "server-a.com";
-    Response response =
+    try (Response response =
         DW_RESTRICTED
             .client()
             .target(restrictedEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST")
-            .options();
+            .options()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isEqualTo("GET,POST");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
-    assertThat(
-            response
-                .getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER)
-                .split(","))
-        .containsExactlyInAnyOrder(getAllowedHeaderList("some"));
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isEqualTo("GET,POST");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+      assertThat(
+              response
+                  .getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER)
+                  .split(","))
+          .containsExactlyInAnyOrder(getAllowedHeaderList("some"));
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldNotSetHeaderWhenOriginNotAllowedPreflight() {
     String origin = "server-b.com";
-    Response response =
+    try (Response response =
         DW_RESTRICTED
             .client()
             .target(restrictedEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_REQUEST_METHOD_HEADER, "POST")
-            .options();
+            .options()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldNotSetHeaderWhenMethodNotAllowedPreflight() {
     String origin = "server-a.com";
-    Response response =
+    try (Response response =
         DW_RESTRICTED
             .client()
             .target(restrictedEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_REQUEST_METHOD_HEADER, "PUT")
-            .options();
+            .options()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldNotSetHeaderWhenDenyedUnmatchedHostname() {
     String origin = "unknown-server-a.com";
-    Response response =
+    try (Response response =
         DW_PATTERN
             .client()
             .target(patternEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isNullOrEmpty();
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isNullOrEmpty();
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isNullOrEmpty();
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isNullOrEmpty();
+    }
   }
 
   @Test
   void shouldSetHeaderWhenAllowForMatchedSubdomain() {
     String origin = "unknown.server-a.com";
-    Response response =
+    try (Response response =
         DW_PATTERN
             .client()
             .target(patternEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isEqualTo("Location,exposed");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isEqualTo("Location,exposed");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+    }
   }
 
   @Test
   void shouldSetHeaderWhenAllowForMatchedDomain() {
     String origin = "unknownserver-c.com";
-    Response response =
+    try (Response response =
         DW_PATTERN
             .client()
             .target(patternEndpoint)
             .request(MediaType.APPLICATION_JSON)
             .header("Origin", origin)
             .header(CrossOriginFilter.ACCESS_CONTROL_ALLOW_METHODS_HEADER, "POST")
-            .get();
+            .get()) {
 
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
-        .isEqualTo(origin);
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
-        .isEqualTo("Location,exposed");
-    assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
-        .isEqualTo(Boolean.TRUE.toString());
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_ORIGIN_HEADER))
+          .isEqualTo(origin);
+      assertThat(response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_EXPOSE_HEADERS_HEADER))
+          .isEqualTo("Location,exposed");
+      assertThat(
+              response.getHeaderString(CrossOriginFilter.ACCESS_CONTROL_ALLOW_CREDENTIALS_HEADER))
+          .isEqualTo(Boolean.TRUE.toString());
+    }
   }
 
   private String[] getAllowedHeaderList(String... configured) {

--- a/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/LogLevelSystemPropertyTest.java
+++ b/sda-commons-server-dropwizard/src/test/java/org/sdase/commons/server/dropwizard/bundles/LogLevelSystemPropertyTest.java
@@ -26,7 +26,7 @@ class LogLevelSystemPropertyTest {
   @Test
   void shouldProduceDebugOutput(StdOut out) {
 
-    try (Response testResponse = createWebTarget().path("test").request().get()) {
+    try (Response ignored = createWebTarget().path("test").request().get()) {
 
       assertThat(out.capturedLines()).anyMatch(l -> l.contains("[DEBUG]"));
     }

--- a/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
+++ b/sda-commons-server-errorhandling-example/src/test/java/org/sdase/commons/server/errorhandling/ErrorHandlingExampleIT.java
@@ -23,40 +23,48 @@ class ErrorHandlingExampleIT {
 
   @Test
   void shouldGetNotFoundException() {
-    Response response = getClient().path("exception").request(MediaType.APPLICATION_JSON).get();
+    try (Response response =
+        getClient().path("exception").request(MediaType.APPLICATION_JSON).get()) {
 
-    assertThat(response.getStatus()).isEqualTo(404);
-    assertThat(response.readEntity(ApiError.class).getTitle())
-        .isEqualTo("Not Found: HTTP 404 Not Found");
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.readEntity(ApiError.class).getTitle())
+          .isEqualTo("Not Found: HTTP 404 Not Found");
+    }
   }
 
   @Test
   void shouldGetErrorResponse() {
-    Response response = getClient().path("errorResponse").request(MediaType.APPLICATION_JSON).get();
+    try (Response response =
+        getClient().path("errorResponse").request(MediaType.APPLICATION_JSON).get()) {
 
-    assertThat(response.getStatus()).isEqualTo(500);
-    assertThat(response.readEntity(ApiError.class).getTitle())
-        .isEqualTo("ApiError thrown in code to be used in response");
+      assertThat(response.getStatus()).isEqualTo(500);
+      assertThat(response.readEntity(ApiError.class).getTitle())
+          .isEqualTo("ApiError thrown in code to be used in response");
+    }
   }
 
   @Test
   void shouldGetErrorResponseFromApiException() {
-    Response response = getClient().path("apiException").request(MediaType.APPLICATION_JSON).get();
+    try (Response response =
+        getClient().path("apiException").request(MediaType.APPLICATION_JSON).get()) {
 
-    assertThat(response.getStatus()).isEqualTo(422);
-    assertThat(response.readEntity(ApiError.class).getTitle()).isEqualTo("Semantic exception");
+      assertThat(response.getStatus()).isEqualTo(422);
+      assertThat(response.readEntity(ApiError.class).getTitle()).isEqualTo("Semantic exception");
+    }
   }
 
   @Test
   void shouldGetValidationException() {
-    Response response =
+    ApiError apiError;
+    try (Response response =
         getClient()
             .path("validation")
             .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json("{ \"param1\": \"\" }"));
+            .post(Entity.json("{ \"param1\": \"\" }"))) {
 
-    assertThat(response.getStatus()).isEqualTo(422);
-    ApiError apiError = response.readEntity(ApiError.class);
+      assertThat(response.getStatus()).isEqualTo(422);
+      apiError = response.readEntity(ApiError.class);
+    }
     assertThat(apiError.getTitle()).isEqualTo("Request parameters are not valid.");
     assertThat(apiError.getInvalidParams())
         .extracting(ApiInvalidParam::getField, ApiInvalidParam::getErrorCode)
@@ -65,14 +73,16 @@ class ErrorHandlingExampleIT {
 
   @Test
   void shouldGetCustomValidationException() {
-    Response response =
+    ApiError apiError;
+    try (Response response =
         getClient()
             .path("validation")
             .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json("{ \"param1\": \"lowercase\" }"));
+            .post(Entity.json("{ \"param1\": \"lowercase\" }"))) {
 
-    assertThat(response.getStatus()).isEqualTo(422);
-    ApiError apiError = response.readEntity(ApiError.class);
+      assertThat(response.getStatus()).isEqualTo(422);
+      apiError = response.readEntity(ApiError.class);
+    }
     assertThat(apiError.getTitle()).isEqualTo("Request parameters are not valid.");
     assertThat(apiError.getInvalidParams())
         .extracting(ApiInvalidParam::getField, ApiInvalidParam::getErrorCode)

--- a/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleJUnit5IT.java
+++ b/sda-commons-server-hibernate-example/src/test/java/org/sdase/commons/server/hibernate/example/test/HibernateExampleJUnit5IT.java
@@ -63,8 +63,10 @@ class HibernateExampleJUnit5IT {
 
     WebTarget persons = DW.client().target("http://localhost:" + DW.getLocalPort()).path("persons");
 
-    Response postResponse = persons.request(APPLICATION_JSON).post(Entity.json(person));
-    String personLocation = postResponse.getHeaderString("Location");
+    String personLocation;
+    try (Response postResponse = persons.request(APPLICATION_JSON).post(Entity.json(person))) {
+      personLocation = postResponse.getHeaderString("Location");
+    }
     assertThat(personLocation).isNotEmpty();
 
     PersonEntity storedPerson =

--- a/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateIT.java
+++ b/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateIT.java
@@ -59,10 +59,11 @@ class HibernateIT {
     Person entity = new Person();
     entity.setName("John Doe");
     entity.setEmail("j.doe@example.com");
-    Response response = client().path("/api/persons").request().post(Entity.json(entity));
+    try (Response response = client().path("/api/persons").request().post(Entity.json(entity))) {
 
-    assertThat(response.getStatus()).isEqualTo(201);
-    assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+      assertThat(response.getStatus()).isEqualTo(201);
+      assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+    }
   }
 
   @Test

--- a/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateNoPackageScanIT.java
+++ b/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernateNoPackageScanIT.java
@@ -63,10 +63,11 @@ class HibernateNoPackageScanIT {
     Person entity = new Person();
     entity.setName("John Doe");
     entity.setEmail("j.doe@example.com");
-    Response response = client().path("/api/persons").request().post(Entity.json(entity));
+    try (Response response = client().path("/api/persons").request().post(Entity.json(entity))) {
 
-    assertThat(response.getStatus()).isEqualTo(201);
-    assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+      assertThat(response.getStatus()).isEqualTo(201);
+      assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+    }
   }
 
   @Test

--- a/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernatePackageScanIT.java
+++ b/sda-commons-server-hibernate/src/test/java/org/sdase/commons/server/hibernate/HibernatePackageScanIT.java
@@ -59,10 +59,11 @@ class HibernatePackageScanIT {
     Person entity = new Person();
     entity.setName("John Doe");
     entity.setEmail("j.doe@example.com");
-    Response response = client().path("/api/persons").request().post(Entity.json(entity));
+    try (Response response = client().path("/api/persons").request().post(Entity.json(entity))) {
 
-    assertThat(response.getStatus()).isEqualTo(201);
-    assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+      assertThat(response.getStatus()).isEqualTo(201);
+      assertThat(response.getLocation().toString()).matches("http.*/api/persons/\\d+");
+    }
   }
 
   @Test

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/ExceptionMapperTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/ExceptionMapperTest.java
@@ -1,10 +1,10 @@
 package org.sdase.commons.server.jackson;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import jakarta.ws.rs.core.Response;
-import org.assertj.core.api.Assertions;
 import org.eclipse.jetty.io.EofException;
 import org.junit.jupiter.api.Test;
 import org.sdase.commons.server.jackson.errors.EarlyEofExceptionMapper;
@@ -19,12 +19,13 @@ class ExceptionMapperTest {
   @Test
   void shouldReturnApiExceptionResponse() {
     EarlyEofExceptionMapper earlyEofExceptionMapper = new EarlyEofExceptionMapper();
-    Response resp = earlyEofExceptionMapper.toResponse(new EofException("Eof"));
+    try (Response resp = earlyEofExceptionMapper.toResponse(new EofException("Eof"))) {
 
-    Assertions.assertThat(resp.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
-    Assertions.assertThat(resp.getEntity()).isInstanceOf(ApiError.class);
-    Assertions.assertThat(((ApiError) resp.getEntity()).getTitle())
-        .isEqualTo("EOF Exception encountered - client disconnected during stream processing.");
+      assertThat(resp.getStatus()).isEqualTo(Response.Status.BAD_REQUEST.getStatusCode());
+      assertThat(resp.getEntity()).isInstanceOf(ApiError.class);
+      assertThat(((ApiError) resp.getEntity()).getTitle())
+          .isEqualTo("EOF Exception encountered - client disconnected during stream processing.");
+    }
   }
 
   @Test

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationBundleIT.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationBundleIT.java
@@ -13,7 +13,6 @@ import jakarta.ws.rs.core.Form;
 import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.io.*;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -600,15 +599,17 @@ class JacksonConfigurationBundleIT {
 
   @Test
   void shouldGetErrorForMissingQueryParameter() {
-    Response response =
+    ApiError error;
+    try (Response response =
         DropwizardLegacyHelper.client(DW.getObjectMapper())
             .target("http://localhost:" + DW.getLocalPort())
             .path("requiredQuery")
             .request(MediaType.APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    ApiError error = response.readEntity(ApiError.class);
-    assertThat(response.getStatus()).isEqualTo(422);
+      error = response.readEntity(ApiError.class);
+      assertThat(response.getStatus()).isEqualTo(422);
+    }
     assertThat(error.getTitle()).isEqualTo(VALIDATION_ERROR_MESSAGE);
 
     assertThat(error.getInvalidParams())

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationInvalidTypeIT.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/JacksonConfigurationInvalidTypeIT.java
@@ -26,29 +26,32 @@ class JacksonConfigurationInvalidTypeIT {
   void shouldPostResourceWithInheritance() {
     String resource = "{\"type\": \"SubType\"}";
 
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("resourceWithInheritance")
             .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json(resource));
+            .post(Entity.json(resource))) {
 
-    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+      Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
+    }
   }
 
   @Test
   void shouldThrowApiErrorForUnknownSubType() {
     String resource = "{\"type\": \"UnknownSubType\"}";
 
-    Response response =
+    ApiError apiError;
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("resourceWithInheritance")
             .request(MediaType.APPLICATION_JSON)
-            .post(Entity.json(resource));
+            .post(Entity.json(resource))) {
 
-    Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY_422);
-    ApiError apiError = response.readEntity(ApiError.class);
+      Assertions.assertThat(response.getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY_422);
+      apiError = response.readEntity(ApiError.class);
+    }
     Assertions.assertThat(apiError).isNotNull();
     Assertions.assertThat(apiError.getTitle()).isEqualTo("Invalid sub type");
     Assertions.assertThat(apiError.getInvalidParams())

--- a/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/errors/InvalidTypeIdExceptionMapperTest.java
+++ b/sda-commons-server-jackson/src/test/java/org/sdase/commons/server/jackson/errors/InvalidTypeIdExceptionMapperTest.java
@@ -41,10 +41,11 @@ class InvalidTypeIdExceptionMapperTest {
             () -> this.om.readValue(given, ResourceWithInheritance.class));
 
     // when
-    Response response = this.invalidTypeIdExceptionMapper.toResponse(invalidTypeIdException);
+    try (Response response = this.invalidTypeIdExceptionMapper.toResponse(invalidTypeIdException)) {
 
-    // then
-    checkResponse(response, "");
+      // then
+      checkResponse(response, "");
+    }
   }
 
   @Test
@@ -59,10 +60,11 @@ class InvalidTypeIdExceptionMapperTest {
             () -> this.om.readValue(given, ResourceWithNestedNestedInheritance.class));
 
     // when
-    Response response = this.invalidTypeIdExceptionMapper.toResponse(invalidTypeIdException);
+    try (Response response = this.invalidTypeIdExceptionMapper.toResponse(invalidTypeIdException)) {
 
-    // then
-    checkResponse(response, "fieldWithNestedInheritance.fieldWithInheritance");
+      // then
+      checkResponse(response, "fieldWithNestedInheritance.fieldWithInheritance");
+    }
   }
 
   private void checkResponse(Response response, String field) {

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/health/KafkaWithoutHealthCheckIT.java
@@ -54,8 +54,9 @@ class KafkaWithoutHealthCheckIT {
 
   @Test
   void externalHealthCheckShouldContainKafka() {
-    Response response = adminTarget.path("healthcheck").request().get();
-    String healthChecks = response.readEntity(String.class);
-    assertThat(healthChecks).contains(KafkaBundle.EXTERNAL_HEALTHCHECK_NAME);
+    try (Response response = adminTarget.path("healthcheck").request().get()) {
+      var healthChecks = response.readEntity(String.class);
+      assertThat(healthChecks).contains(KafkaBundle.EXTERNAL_HEALTHCHECK_NAME);
+    }
   }
 }

--- a/sda-commons-server-key-mgmt/src/test/java/org/sdase/commons/keymgmt/KeyMgmtBundleTest.java
+++ b/sda-commons-server-key-mgmt/src/test/java/org/sdase/commons/keymgmt/KeyMgmtBundleTest.java
@@ -287,26 +287,28 @@ class KeyMgmtBundleTest {
 
   @Test
   void shouldValidateAsParameter() {
-    Response response =
+    try (Response response =
         client
             .path("api")
             .path("validateParameter")
             .queryParam("param", "MALE")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT_204);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.NO_CONTENT_204);
+    }
   }
 
   @Test
   void shouldValidateAsParameterFail() {
-    Response responseNotValid =
+    try (Response responseNotValid =
         client
             .path("api")
             .path("validateParameter")
             .queryParam("param", "NOVALID")
             .request(APPLICATION_JSON)
-            .get();
-    assertThat(responseNotValid.getStatus()).isEqualTo(422);
+            .get()) {
+      assertThat(responseNotValid.getStatus()).isEqualTo(422);
+    }
   }
 
   public static class KeyMgmtBundleTestApp extends Application<KeyMgmtBundleTestConfig> {

--- a/sda-commons-server-opentelemetry-example/src/test/java/org/sdase/server/opentelemetry/example/OpenTelemetryTracingAppIT.java
+++ b/sda-commons-server-opentelemetry-example/src/test/java/org/sdase/server/opentelemetry/example/OpenTelemetryTracingAppIT.java
@@ -69,8 +69,9 @@ class OpenTelemetryTracingAppIT {
 
   @Test
   void shouldDoException() {
-    Response response = webTarget("/exception").request().get();
-    assertThat(response.getStatus()).isEqualTo(200);
+    try (Response response = webTarget("/exception").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
 
     await()
         .untilAsserted(
@@ -100,8 +101,9 @@ class OpenTelemetryTracingAppIT {
 
   @Test
   void shouldDoRecursive() {
-    Response response = webTarget("/recursive").request().get();
-    assertThat(response.getStatus()).isEqualTo(200);
+    try (Response response = webTarget("/recursive").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
 
     await().untilAsserted(() -> assertThat(OTEL.getSpans()).isNotEmpty().hasSizeGreaterThan(2));
   }

--- a/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/AutoConfigurationTest.java
+++ b/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/AutoConfigurationTest.java
@@ -43,11 +43,12 @@ class AutoConfigurationTest {
   void shouldUseEnvironmentVariablesForConfiguration(StdOut out) {
     assertThat(System.getenv("OTEL_TRACES_EXPORTER")).isEqualTo("logging");
 
-    Response r = createClient().path("base/respond/test").request().get();
+    try (Response r = createClient().path("base/respond/test").request().get()) {
 
-    r.readEntity(String.class);
+      r.readEntity(String.class);
 
-    assertThat(r.getStatus()).isEqualTo(SC_OK);
+      assertThat(r.getStatus()).isEqualTo(SC_OK);
+    }
 
     // assert the logging exporter is used
     await()

--- a/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/servlet/TracingAsyncListenerIT.java
+++ b/sda-commons-server-opentelemetry/src/test/java/org/sdase/commons/server/opentelemetry/servlet/TracingAsyncListenerIT.java
@@ -36,9 +36,10 @@ class TracingAsyncListenerIT {
 
   @RetryingTest(maxAttempts = 3, name = "[{index}] check PLP-932 on error")
   void shouldTraceAsyncServlets() {
-    Response response = createAdminClient().path("/async/trace").request().get();
+    try (Response response = createAdminClient().path("/async/trace").request().get()) {
 
-    assertThat(response.getStatus()).isEqualTo(SC_OK);
+      assertThat(response.getStatus()).isEqualTo(SC_OK);
+    }
 
     // setting the pollDelay and maximum timeout, because it is an async call
     await()
@@ -75,8 +76,9 @@ class TracingAsyncListenerIT {
 
   @Test
   void shouldCatchErrors() {
-    Response response = createAdminClient().path("/async/error").request().get();
-    assertThat(response.getStatus()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
+    try (Response response = createAdminClient().path("/async/error").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
+    }
 
     await()
         .untilAsserted(
@@ -107,8 +109,9 @@ class TracingAsyncListenerIT {
 
   @Test
   void shouldCatchTimeout() {
-    Response response = createAdminClient().path("/async/timeout").request().get();
-    assertThat(response.getStatus()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
+    try (Response response = createAdminClient().path("/async/timeout").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(SC_INTERNAL_SERVER_ERROR);
+    }
 
     await()
         .untilAsserted(

--- a/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
+++ b/sda-commons-server-prometheus-example/src/test/java/org/sdase/commons/server/prometheus/example/PrometheusMetricsIT.java
@@ -69,13 +69,14 @@ class PrometheusMetricsIT {
   }
 
   private String readMetrics() {
-    Response response =
+    try (Response response =
         DW.client()
             .target(String.format("http://localhost:%d", DW.getAdminPort()) + "/metrics/prometheus")
             .request()
-            .get();
-    String metrics = response.readEntity(String.class);
-    LOG.info("Prometheus metrics:\n{}", metrics);
-    return metrics;
+            .get()) {
+      var metrics = response.readEntity(String.class);
+      LOG.info("Prometheus metrics:\n{}", metrics);
+      return metrics;
+    }
   }
 }

--- a/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
+++ b/sda-commons-server-prometheus/src/test/java/org/sdase/commons/server/prometheus/PrometheusBundleTest.java
@@ -171,17 +171,18 @@ class PrometheusBundleTest {
 
   @Test
   void shouldNotHttpCacheHealthCheck() {
-    Response response =
+    try (Response response =
         DW.client()
             .target(
                 String.format("http://localhost:%d", DW.getAdminPort()) + "/healthcheck/prometheus")
             .request()
-            .get();
-    assertThat(response.getHeaders()).containsKey("Cache-Control");
-    assertThat(response.getHeaders().getFirst("Cache-Control").toString())
-        .contains("must-revalidate")
-        .contains("no-cache")
-        .contains("no-store");
+            .get()) {
+      assertThat(response.getHeaders()).containsKey("Cache-Control");
+      assertThat(response.getHeaders().getFirst("Cache-Control").toString())
+          .contains("must-revalidate")
+          .contains("no-cache")
+          .contains("no-store");
+    }
   }
 
   @Test
@@ -288,25 +289,27 @@ class PrometheusBundleTest {
   }
 
   private String readMetrics() {
-    Response response =
+    try (Response response =
         DW.client()
             .target(String.format("http://localhost:%d", DW.getAdminPort()) + "/metrics/prometheus")
             .request()
-            .get();
-    String metrics = response.readEntity(String.class);
-    LOGGER.info("Prometheus metrics: {}", metrics);
-    return metrics;
+            .get()) {
+      var metrics = response.readEntity(String.class);
+      LOGGER.info("Prometheus metrics: {}", metrics);
+      return metrics;
+    }
   }
 
   private String readHealthChecks() {
-    Response response =
+    try (Response response =
         DW.client()
             .target(
                 String.format("http://localhost:%d", DW.getAdminPort()) + "/healthcheck/prometheus")
             .request()
-            .get();
-    String healthChecks = response.readEntity(String.class);
-    LOGGER.info("Prometheus health checks: {}", healthChecks);
-    return healthChecks;
+            .get()) {
+      var healthChecks = response.readEntity(String.class);
+      LOGGER.info("Prometheus health checks: {}", healthChecks);
+      return healthChecks;
+    }
   }
 }

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithExternalHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithExternalHealthCheckIT.java
@@ -50,10 +50,11 @@ class S3WithExternalHealthCheckIT {
 
   @Test
   void shouldReturnHealthCheckOk() {
-    Response response = adminTarget.path("healthcheck").request().get();
-    assertThat(response.getStatus()).isEqualTo(HTTP_OK);
-    assertThat(response.readEntity(String.class))
-        .contains("\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"")
-        .doesNotContain("\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"");
+    try (Response response = adminTarget.path("healthcheck").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(HTTP_OK);
+      assertThat(response.readEntity(String.class))
+          .contains("\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"")
+          .doesNotContain("\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"");
+    }
   }
 }

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithHealthCheckIT.java
@@ -50,10 +50,11 @@ class S3WithHealthCheckIT {
 
   @Test
   void shouldReturnHealthCheckOk() {
-    Response response = adminTarget.path("healthcheck").request().get();
-    assertThat(response.getStatus()).isEqualTo(HTTP_OK);
-    assertThat(response.readEntity(String.class))
-        .contains("\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"")
-        .doesNotContain("\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"");
+    try (Response response = adminTarget.path("healthcheck").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(HTTP_OK);
+      assertThat(response.readEntity(String.class))
+          .contains("\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"")
+          .doesNotContain("\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"");
+    }
   }
 }

--- a/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithoutHealthCheckIT.java
+++ b/sda-commons-server-s3/src/test/java/org/sdase/commons/server/s3/health/S3WithoutHealthCheckIT.java
@@ -48,11 +48,12 @@ class S3WithoutHealthCheckIT {
 
   @Test
   void shouldReturnHealthCheckOk() {
-    Response response = adminTarget.path("healthcheck").request().get();
-    assertThat(response.getStatus()).isEqualTo(HTTP_OK);
-    assertThat(response.readEntity(String.class))
-        .doesNotContain(
-            "\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"",
-            "\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"");
+    try (Response response = adminTarget.path("healthcheck").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(HTTP_OK);
+      assertThat(response.readEntity(String.class))
+          .doesNotContain(
+              "\"" + S3Bundle.S3_HEALTH_CHECK_NAME + "\"",
+              "\"" + S3Bundle.S3_EXTERNAL_HEALTH_CHECK_NAME + "\"");
+    }
   }
 }

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/AbstractSecurityTest.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/AbstractSecurityTest.java
@@ -89,57 +89,57 @@ abstract class AbstractSecurityTest<C extends Configuration> {
   @Test
   void doNotUseServerHeaderInApp() {
     assertThat(getAppConnector().isUseServerHeader()).isFalse();
-    Response response =
-        getAppClient()
-            .path("path")
-            .path("does")
-            .path("not")
-            .path("exist")
-            .request()
-            .get(); // NOSONAR
-    assertThat(response.getStatus()).isEqualTo(404);
-    assertThat(response.getHeaderString("Server")).isBlank();
+    try (Response response =
+        getAppClient().path("path").path("does").path("not").path("exist").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.getHeaderString("Server")).isBlank(); // NOSONAR
+    }
   }
 
   @Test
   void doNotUseServerHeaderInAdmin() {
     assertThat(getAdminConnector().isUseServerHeader()).isFalse();
-    Response response =
-        getAdminClient().path("path").path("does").path("not").path("exist").request().get();
-    assertThat(response.getStatus()).isEqualTo(404);
-    assertThat(response.getHeaderString("Server")).isBlank();
+    try (Response response =
+        getAdminClient().path("path").path("does").path("not").path("exist").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.getHeaderString("Server")).isBlank();
+    }
   }
 
   @Test
   void doNotUseDateHeaderInApp() {
     assertThat(getAppConnector().isUseDateHeader()).isFalse();
-    Response response =
-        getAppClient().path("path").path("does").path("not").path("exist").request().get();
-    assertThat(response.getStatus()).isEqualTo(404);
-    assertThat(response.getHeaderString("Date")).isBlank();
+    try (Response response =
+        getAppClient().path("path").path("does").path("not").path("exist").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.getHeaderString("Date")).isBlank();
+    }
   }
 
   @Test
   void doNotUseDateHeaderInAdmin() {
     assertThat(getAdminConnector().isUseDateHeader()).isFalse();
-    Response response =
-        getAppClient().path("path").path("does").path("not").path("exist").request().get();
-    assertThat(response.getStatus()).isEqualTo(404);
-    assertThat(response.getHeaderString("Date")).isBlank();
+    try (Response response =
+        getAppClient().path("path").path("does").path("not").path("exist").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      assertThat(response.getHeaderString("Date")).isBlank();
+    }
   }
 
   @Test
   void doNotShowDefaultErrorPageInApp() {
-    Response response =
+    String content;
+    try (Response response =
         getAppClient()
             .path("path")
             .path("does")
             .path("not")
             .path("exist")
             .request(MediaType.APPLICATION_JSON)
-            .get();
-    assertThat(response.getStatus()).isEqualTo(404);
-    String content = response.readEntity(String.class);
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      content = response.readEntity(String.class);
+    }
     // should not render the default error object of jetty which writes a json with a property code
     // that contains only
     // the http status
@@ -155,7 +155,7 @@ abstract class AbstractSecurityTest<C extends Configuration> {
     while (valueMoreThanOneKib.length() < 1024) {
       valueMoreThanOneKib.append(chars);
     }
-    Response response =
+    try (Response response =
         getAppClient()
             .request(MediaType.APPLICATION_JSON)
             .header("X-Header-One", valueMoreThanOneKib.toString())
@@ -166,9 +166,10 @@ abstract class AbstractSecurityTest<C extends Configuration> {
             .header("X-Header-Six", valueMoreThanOneKib.toString())
             .header("X-Header-Seven", valueMoreThanOneKib.toString())
             .header("X-Header-Eight", valueMoreThanOneKib.toString())
-            .get();
-    assertThat(response.getStatus()).isEqualTo(431); // Request Header Fields Too Large
-    response.close();
+            .get()) {
+      assertThat(response.getStatus()).isEqualTo(431); // Request Header Fields Too Large
+      response.close();
+    }
   }
 
   @Test
@@ -183,7 +184,8 @@ abstract class AbstractSecurityTest<C extends Configuration> {
     while (valueMoreThanOneKib.length() < 1024) {
       valueMoreThanOneKib.append(chars);
     }
-    Response response =
+    String responseBodyRaw;
+    try (Response response =
         getAppClient()
             .request(MediaType.APPLICATION_JSON)
             .header("X-Header-One", valueMoreThanOneKib.toString())
@@ -194,8 +196,9 @@ abstract class AbstractSecurityTest<C extends Configuration> {
             .header("X-Header-Six", valueMoreThanOneKib.toString())
             .header("X-Header-Seven", valueMoreThanOneKib.toString())
             .header("X-Header-Eight", valueMoreThanOneKib.toString())
-            .get();
-    String responseBodyRaw = response.readEntity(String.class);
+            .get()) {
+      responseBodyRaw = response.readEntity(String.class);
+    }
     assertThat(responseBodyRaw).doesNotMatch(".*<[^>]+>.*"); // no HTML
   }
 

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/SecureBundleITest.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/SecureBundleITest.java
@@ -62,22 +62,24 @@ class SecureBundleITest extends AbstractSecurityTest<Configuration> {
 
   @Test
   void useCustomErrorHandlersForRuntimeException() {
-    Response response = getAppClient().path("throw").request().get();
-    assertThat(response.getStatus()).isEqualTo(500);
-    String content = response.readEntity(String.class);
+    String content;
+    try (Response response = getAppClient().path("throw").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(500);
+      content = response.readEntity(String.class);
+    }
     assertThat(content).doesNotMatch(".*\"code\"\\s*:\\s*500.*");
   }
 
   @Test
   void useCustomErrorPageHandlerForErrorPages() {
-    Response response = getAppClient().path("404").request().get();
-    assertThat(response.getStatus()).isEqualTo(404);
-    String content = response.readEntity(String.class);
-    assertThat(content)
-        .doesNotMatch(".*\"code\"\\s*:\\s*500.*") // no default exception mapper
-        .doesNotContain("<html") // no html page
-        .doesNotContain("<h1>") // no html page
-        .doesNotContain("<h2>") // no html page
-    ;
+    try (Response response = getAppClient().path("404").request().get()) {
+      assertThat(response.getStatus()).isEqualTo(404);
+      var content = response.readEntity(String.class);
+      assertThat(content)
+          .doesNotMatch(".*\"code\"\\s*:\\s*500.*") // no default exception mapper
+          .doesNotContain("<html") // no html page
+          .doesNotContain("<h1>") // no html page
+          .doesNotContain("<h2>"); // no html page
+    }
   }
 }

--- a/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/TraceTokenBundleTest.java
+++ b/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/TraceTokenBundleTest.java
@@ -32,14 +32,15 @@ class TraceTokenBundleTest {
 
   @Test
   void shouldRespondWithGivenTraceToken() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/token")
             .request(APPLICATION_JSON)
             .header("Trace-Token", "test-trace-token")
-            .get();
-    assertThat(response.getHeaderString("Trace-Token")).isEqualTo("test-trace-token");
+            .get()) {
+      assertThat(response.getHeaderString("Trace-Token")).isEqualTo("test-trace-token");
+    }
   }
 
   @Test
@@ -55,25 +56,29 @@ class TraceTokenBundleTest {
 
   @Test
   void shouldAddTokenToResponse() {
-    Response response =
+    String header;
+    String property;
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/token")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    String header = response.getHeaderString("Trace-Token");
-    String property = response.readEntity(String.class);
+      header = response.getHeaderString("Trace-Token");
+      property = response.readEntity(String.class);
+    }
 
     assertThat(header).isEqualTo(property);
   }
 
   @Test
   void shouldDoNothingOnOptions() {
-    Response response =
-        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options();
-    String header = response.getHeaderString("Trace-Token");
-    assertThat(header).isBlank();
-    assertThat(response.getStatus()).isEqualTo(200);
+    try (Response response =
+        DW.client().target("http://localhost:" + DW.getLocalPort()).request().options()) {
+      String header = response.getHeaderString("Trace-Token");
+      assertThat(header).isBlank();
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 }

--- a/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/WeldBundleApplicationTest.java
+++ b/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/WeldBundleApplicationTest.java
@@ -38,10 +38,11 @@ class WeldBundleApplicationTest {
 
   @Test
   void testServlet() {
-    Response response =
-        APP.client().target(LOCALHOST + APP.getLocalPort() + "/foo").request().get();
-    assertThat(response).isNotNull();
-    assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    try (Response response =
+        APP.client().target(LOCALHOST + APP.getLocalPort() + "/foo").request().get()) {
+      assertThat(response).isNotNull();
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
   }
 
   @Test

--- a/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/WeldBundleProgrammaticConfigTest.java
+++ b/sda-commons-server-weld-testing/src/test/java/org/sdase/commons/server/weld/testing/WeldBundleProgrammaticConfigTest.java
@@ -37,10 +37,11 @@ class WeldBundleProgrammaticConfigTest {
 
   @Test
   void testServlet() {
-    Response response =
-        APP.client().target(LOCALHOST + APP.getLocalPort() + "/foo").request().get();
-    assertThat(response).isNotNull();
-    assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    try (Response response =
+        APP.client().target(LOCALHOST + APP.getLocalPort() + "/foo").request().get()) {
+      assertThat(response).isNotNull();
+      assertThat(response.getStatus()).isEqualTo(Response.Status.OK.getStatusCode());
+    }
   }
 
   @Test

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/PlatformRequirementsIT.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/PlatformRequirementsIT.java
@@ -38,15 +38,17 @@ class PlatformRequirementsIT {
   @ParameterizedTest
   @ValueSource(strings = {"openapi.json", "openapi.yaml"})
   void shouldHavePublicAppEndpoint(String path) {
-    Response r = createTarget().path(path).request().get();
-    assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+    try (Response r = createTarget().path(path).request().get()) {
+      assertThat(r.getStatus()).isEqualTo(OK.getStatusCode());
+    }
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"ping", "metrics/prometheus", "healthcheck/internal"})
   void shouldHaveAdminEndpoints(String path) {
-    Response response = createAdminTarget().path(path).request().buildGet().invoke();
-    assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
+    try (Response response = createAdminTarget().path(path).request().buildGet().invoke()) {
+      assertThat(response.getStatus()).isEqualTo(OK.getStatusCode());
+    }
   }
 
   private WebTarget createTarget() {

--- a/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
+++ b/sda-commons-starter-example/src/test/java/org/sdase/commons/starter/example/SdaPlatformExampleApplicationIT.java
@@ -62,21 +62,24 @@ class SdaPlatformExampleApplicationIT {
 
   @Test
   void accessSwaggerWithoutAuthentication() {
-    Response response = baseUrlWebTarget().path("openapi.json").request(APPLICATION_JSON).get();
+    try (Response response =
+        baseUrlWebTarget().path("openapi.json").request(APPLICATION_JSON).get()) {
 
-    assertThat(response).extracting(Response::getStatus).isEqualTo(200);
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void rejectApiRequestWithoutAuthentication() {
-    Response response =
+    try (Response response =
         baseUrlWebTarget()
             .path("people")
             .request(APPLICATION_JSON) // NOSONAR
             .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(403);
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
   }
 
   @Test
@@ -89,42 +92,45 @@ class SdaPlatformExampleApplicationIT {
             .withJwtFromHeaderValue(authHeader)
             .allow());
 
-    Response response =
+    try (Response response =
         baseUrlWebTarget()
             .path("people")
             .request(APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, authHeader)
             .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(200);
+      assertThat(response.getStatus()).isEqualTo(200);
+    }
   }
 
   @Test
   void respond401DueToInvalidJWT() {
-    Response response =
+    try (Response response =
         baseUrlWebTarget()
             .path("people")
             .request(APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, "Bearer: invalidToken")
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(401);
+      assertThat(response.getStatus()).isEqualTo(401);
+    }
   }
 
   @Test
   void respond404ForUnknownPerson() {
     OPA.mock(onAnyRequest().allow());
-    Response response =
+    try (Response response =
         baseUrlWebTarget()
             .path("people")
             .path("jamie-doe")
             .request(APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, AUTH.auth().buildHeaderValue())
             .header(ConsumerTracing.TOKEN_HEADER, TEST_CONSUMER_TOKEN)
-            .get();
+            .get()) {
 
-    assertThat(response).extracting(Response::getStatus).isEqualTo(404);
+      assertThat(response.getStatus()).isEqualTo(404);
+    }
   }
 
   @Test

--- a/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
+++ b/sda-commons-starter/src/test/java/org/sdase/commons/starter/FilterPriorityTest.java
@@ -30,45 +30,48 @@ class FilterPriorityTest {
 
   @Test
   void corsFromSwaggerHasHigherPriority() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("/api/openapi.yaml")
             .request("application/yaml")
             .header("Origin", "example.com")
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(OK_200);
-    assertThat(response.getMetadata().getFirst("Access-Control-Allow-Origin"))
-        .isEqualTo("example.com");
+      assertThat(response.getStatus()).isEqualTo(OK_200);
+      assertThat(response.getMetadata().getFirst("Access-Control-Allow-Origin"))
+          .isEqualTo("example.com");
+    }
   }
 
   @Test
   void traceTokenFilterHasHighestPriority() {
     // Make sure that trace token filter is even executed when authentication fails
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("api")
             .path("ping")
             .request(APPLICATION_JSON)
             .header("Trace-Token", "MyTraceToken")
-            .get();
+            .get()) {
 
-    assertThat(response.getMetadata().getFirst("Trace-Token")).isEqualTo("MyTraceToken");
+      assertThat(response.getMetadata().getFirst("Trace-Token")).isEqualTo("MyTraceToken");
+    }
   }
 
   @Test
   void errorsInConsumerTokenFilterTrackedByPrometheus() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("api")
             .path("ping")
             .request(APPLICATION_JSON)
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(403);
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
 
     String metrics =
         DW.client()
@@ -83,16 +86,17 @@ class FilterPriorityTest {
 
   @Test
   void errorsInAuthenticationFilterAreTrackedByPrometheus() {
-    Response response =
+    try (Response response =
         DW.client()
             .target("http://localhost:" + DW.getLocalPort())
             .path("api")
             .path("ping")
             .request(APPLICATION_JSON)
             .header("Consumer-Token", "MyConsumer")
-            .get();
+            .get()) {
 
-    assertThat(response.getStatus()).isEqualTo(403);
+      assertThat(response.getStatus()).isEqualTo(403);
+    }
 
     String metrics =
         DW.client()


### PR DESCRIPTION
tests may hang if they start too many connections with the same Jersey client