### PR TITLE
feat(client-jersey-wiremock-testing): deprecate custom JUnit 5 Wiremock extensions and show migration in test changes

### DIFF
--- a/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtension.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtension.java
@@ -11,7 +11,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockClassRule} */
+/**
+ * Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockClassRule}
+ *
+ * @deprecated This extension will be removed in the next major release. Existing tests using this
+ *     extension should be migrated to {@link
+ *     com.github.tomakehurst.wiremock.junit5.WireMockExtension} which comes with Wiremock. The next
+ *     major of Dropwizard commons will also upgrade Wiremock from 2.x.x to 3.x.x.
+ */
+@Deprecated(since = "5", forRemoval = true)
 public class WireMockClassExtension extends WireMockServer
     implements BeforeAllCallback, AfterAllCallback {
 

--- a/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtension.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/main/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockExtension.java
@@ -15,7 +15,15 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockRule} */
+/**
+ * Junit 5 replacement for {@link com.github.tomakehurst.wiremock.junit.WireMockRule}
+ *
+ * @deprecated This extension will be removed in the next major release. Existing tests using this
+ *     extension should be migrated to {@link
+ *     com.github.tomakehurst.wiremock.junit5.WireMockExtension} which comes with Wiremock. The next
+ *     major of Dropwizard commons will also upgrade Wiremock from 2.x.x to 3.x.x.
+ */
+@Deprecated(since = "5", forRemoval = true)
 public class WireMockExtension extends WireMockServer
     implements BeforeEachCallback, AfterEachCallback {
 

--- a/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/DeprecatedWireMockClassExtensionTest.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/DeprecatedWireMockClassExtensionTest.java
@@ -1,51 +1,32 @@
 package org.sdase.commons.client.jersey.wiremock.testing;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.findUnmatchedRequests;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
-import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
-import java.util.Set;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-/**
- * @deprecated This test is still here to show migration from {@link
- *     org.sdase.commons.client.jersey.wiremock.testing.WireMockExtension} in its commit history.
- */
 @Deprecated(forRemoval = true)
-class WireMockExtensionTest {
+class DeprecatedWireMockClassExtensionTest {
 
-  @RegisterExtension
-  @SuppressWarnings("JUnitMalformedDeclaration") // intended to be a class extension
-  WireMockExtension wire = new WireMockExtension();
+  @RegisterExtension public static WireMockClassExtension wire = new WireMockClassExtension();
 
-  static Set<String> wireBaseUrls = new HashSet<>();
-
-  @BeforeEach // Wiremock is reset for each test
-  void before() {
-    wireBaseUrls.add(wire.baseUrl());
-    stubFor(
+  @BeforeAll
+  public static void beforeAll() {
+    wire.stubFor(
         get("/api/cars") // NOSONAR
             .withHeader("Accept", notMatching("gzip"))
             .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
-  }
-
-  @AfterAll
-  static void afterAll() {
-    assertThat(wireBaseUrls).hasSize(2);
   }
 
   @Test
@@ -53,7 +34,6 @@ class WireMockExtensionTest {
     URLConnection connection = new URL(wire.baseUrl() + "/api/cars").openConnection();
     try (InputStream inputStream = connection.getInputStream()) {
       assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("[]");
-      assertThat(findUnmatchedRequests()).isEmpty();
     }
   }
 
@@ -62,6 +42,27 @@ class WireMockExtensionTest {
     HttpURLConnection connection =
         (HttpURLConnection) new URL(wire.baseUrl() + "/foo").openConnection();
     assertThat(connection.getResponseCode()).isEqualTo(404);
-    assertThat(findUnmatchedRequests()).isNotEmpty();
+  }
+
+  @Nested
+  class ConstructorTests {
+    @Test
+    void shouldSetupMockForPortAndHttpsPort() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090, 8091);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+      assertThat(wireMockClassExtension.getOptions().httpsSettings().port()).isEqualTo(8091);
+    }
+
+    @Test
+    void shouldSetupMockForPort() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090);
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
+    }
+
+    @Test
+    void shouldSetupMockForNoParameters() {
+      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension();
+      assertThat(wireMockClassExtension.getOptions().portNumber()).isBetween(0, 9999);
+    }
   }
 }

--- a/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtensionTest.java
+++ b/sda-commons-client-jersey-wiremock-testing/src/test/java/org/sdase/commons/client/jersey/wiremock/testing/WireMockClassExtensionTest.java
@@ -3,65 +3,49 @@ package org.sdase.commons.client.jersey.wiremock.testing;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.notMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
+/**
+ * @deprecated This test is still here to show migration from {@link
+ *     org.sdase.commons.client.jersey.wiremock.testing.WireMockClassExtension} in its commit
+ *     history.
+ */
+@Deprecated(forRemoval = true)
+@WireMockTest
 class WireMockClassExtensionTest {
 
-  @RegisterExtension public static WireMockClassExtension wire = new WireMockClassExtension();
-
-  @BeforeAll
-  public static void beforeAll() {
-    wire.stubFor(
+  @BeforeEach
+  public void addStubs() {
+    stubFor(
         get("/api/cars") // NOSONAR
             .withHeader("Accept", notMatching("gzip"))
             .willReturn(ok().withHeader("Content-type", "application/json").withBody("[]")));
   }
 
   @Test
-  void shouldGetMockedResponse() throws Exception {
-    URLConnection connection = new URL(wire.baseUrl() + "/api/cars").openConnection();
+  void shouldGetMockedResponse(WireMockRuntimeInfo wire) throws Exception {
+    URLConnection connection = new URL(wire.getHttpBaseUrl() + "/api/cars").openConnection();
     try (InputStream inputStream = connection.getInputStream()) {
       assertThat(IOUtils.toString(inputStream, StandardCharsets.UTF_8)).isEqualTo("[]");
     }
   }
 
   @Test
-  void shouldGet404() throws Exception {
+  void shouldGet404(WireMockRuntimeInfo wire) throws Exception {
     HttpURLConnection connection =
-        (HttpURLConnection) new URL(wire.baseUrl() + "/foo").openConnection();
+        (HttpURLConnection) new URL(wire.getHttpBaseUrl() + "/foo").openConnection();
     assertThat(connection.getResponseCode()).isEqualTo(404);
-  }
-
-  @Nested
-  class ConstructorTests {
-    @Test
-    void shouldSetupMockForPortAndHttpsPort() {
-      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090, 8091);
-      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
-      assertThat(wireMockClassExtension.getOptions().httpsSettings().port()).isEqualTo(8091);
-    }
-
-    @Test
-    void shouldSetupMockForPort() {
-      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension(8090);
-      assertThat(wireMockClassExtension.getOptions().portNumber()).isEqualTo(8090);
-    }
-
-    @Test
-    void shouldSetupMockForNoParameters() {
-      WireMockClassExtension wireMockClassExtension = new WireMockClassExtension();
-      assertThat(wireMockClassExtension.getOptions().portNumber()).isBetween(0, 9999);
-    }
   }
 }


### PR DESCRIPTION
In the meantime an official JUnit5 extension is provided by Wiremock. The extensions will be removed in the next major version of SDA Dropwizard Commons.