### PR TITLE
chore: ignore CVE-2023-6378

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -12,7 +12,10 @@ ignore_cves := {
   # Flapdoodle is only used in test.
   "CVE-2023-42503",
   # Netty is used by Zookeeper which is only used in test.
-  "CVE-2023-4586"
+  "CVE-2023-4586",
+  # Logback is not affected since Dropwizard does not ship logback-receiver
+  # see https://github.com/dropwizard/dropwizard/issues/7969
+  "CVE-2023-6378"
 }
 
 ignore {


### PR DESCRIPTION
We might also get a new release of Dropwizard that will bump the Logback version: https://github.com/dropwizard/dropwizard/issues/7969
Anyway, this is a false positive.