### PR TITLE
chore: use windows-2019 in "Java CI" workflow

### DIFF
--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         java_version: ['17', '21']
-        os: ['ubuntu-latest', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-2019']
 
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
according to the following source it should improve the performance: https://github.com/actions/runner-images/issues/7320