### PR TITLE
fix(server-mongo-testing): remove deprecated methods from MongoDb int…

### DIFF
--- a/docs/migration-guides/MIGRATION_GUIDE_v5_to_v6.md
+++ b/docs/migration-guides/MIGRATION_GUIDE_v5_to_v6.md
@@ -112,6 +112,10 @@ removed. The database connection must be configured with [`connectionString`](ht
 Removed custom proxy configuration for MongoDB executable download.
 OS proxy settings should be configured instead.
 
+Removed getters from the `MongoDb` interface which affects the `MongoDbClassExtension`.
+You can retrieve information about the database, username or password from the 
+`ConnectionString` that is provided by `MongoDbClassExtension#getMongoConnectionString()`.
+
 #### FixtureHelpers
 
 The class `io.drowizard.helpers.fixtures.FixtureHelpers` is not available in Dropwizard v4. So

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtension.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtension.java
@@ -6,8 +6,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 
 /**
  * JUnit 5 Extension for running a MongoDB instance alongside the (integration) tests. Can be
- * configured with custom user credentials and database name. Use {@link #getHosts()} to retrieve
- * the host to connect to.
+ * configured with custom user credentials and database name. Use {@link #getConnectionString()} *
+ * to retrieve the connection string.
  *
  * <p>Example usage:
  *

--- a/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDb.java
+++ b/sda-commons-server-mongo-testing/src/main/java/org/sdase/commons/server/mongo/testing/UseExistingMongoDb.java
@@ -1,88 +1,38 @@
 package org.sdase.commons.server.mongo.testing;
 
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
-
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
-import org.bson.BsonDocument;
-import org.bson.BsonString;
+import com.mongodb.ConnectionString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class UseExistingMongoDb {
+public class UseExistingMongoDb implements MongoDb {
 
   private static final Logger LOG = LoggerFactory.getLogger(UseExistingMongoDb.class);
 
-  private final String hosts;
-  private final String database;
-  private final String username;
-  private final String password;
-  private final String options;
-  private final MongoClientURI mongoClientUri;
-
-  private String connectionString;
+  private final ConnectionString mongoConnectionString;
 
   public UseExistingMongoDb(String mongoDbConnectionString) {
-    this.connectionString = mongoDbConnectionString;
-    mongoClientUri = new MongoClientURI(mongoDbConnectionString);
-    hosts = String.join(",", mongoClientUri.getHosts());
-    database = mongoClientUri.getDatabase();
-    options = optionsFromMongoUrl(mongoDbConnectionString);
-    username = mongoClientUri.getUsername();
-    password = asStringOrNull(mongoClientUri.getPassword());
-  }
-
-  public String getHosts() {
-    return hosts;
-  }
-
-  public String getDatabase() {
-    return database;
-  }
-
-  public String getOptions() {
-    return options;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public String getPassword() {
-    return password;
+    this.mongoConnectionString = new ConnectionString(mongoDbConnectionString);
   }
 
   public String getConnectionString() {
-    return connectionString;
+    return mongoConnectionString.getConnectionString();
   }
 
-  public MongoClient createClient() {
-    return new MongoClient(mongoClientUri);
-  }
-
-  /**
-   * @return the version of the MongoDB instance which is associated with this MongoDbClassExtension
-   */
-  public String getServerVersion() {
-    try (MongoClient client = createClient()) {
-      return client
-          .getDatabase(getDatabase())
-          .runCommand(new BsonDocument("buildinfo", new BsonString("")))
-          .get("version")
-          .toString();
-    }
+  public ConnectionString getMongoConnectionString() {
+    return mongoConnectionString;
   }
 
   protected void logConnection() {
     if (LOG.isInfoEnabled()) {
-      String withPasswordText = isNotBlank(password) ? "using a password" : "without password";
+      String withPasswordText =
+          mongoConnectionString.getPassword() != null ? "using a password" : "without password";
       LOG.info(
           "Testing as '{}' {} in MongoDB '{}' at '{}' with options '{}'",
-          username,
+          mongoConnectionString.getUsername(),
           withPasswordText,
-          getDatabase(),
-          getHosts(),
-          getOptions());
+          mongoConnectionString.getDatabase(),
+          mongoConnectionString.getHosts(),
+          optionsFromMongoUrl(getConnectionString()));
       // secondary log, getServerVersion() already requires a connection
       LOG.info("MongoDB server used for test has version {}", getServerVersion());
     }
@@ -95,9 +45,5 @@ public class UseExistingMongoDb {
     } else {
       return "";
     }
-  }
-
-  private String asStringOrNull(char[] chars) {
-    return chars == null ? null : new String(chars);
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtensionBuilderTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/MongoDbClassExtensionBuilderTest.java
@@ -1,21 +1,20 @@
 package org.sdase.commons.server.mongo.testing;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class MongoDbClassExtensionBuilderTest {
 
+  @RegisterExtension
+  static final MongoDbClassExtension MONGO = MongoDbClassExtension.builder().build();
+
   @Test
   void shouldUseDefaultValues() {
-    assertThatCode(
-            () -> {
-              final MongoDbClassExtension extension = MongoDbClassExtension.builder().build();
-              assertThat(extension.getUsername()).isNotNull();
-              assertThat(extension.getPassword()).isNotNull();
-              assertThat(extension.getDatabase()).isNotNull();
-            })
-        .doesNotThrowAnyException();
+    assertThat(MONGO.getMongoConnectionString()).isNotNull();
+    assertThat(MONGO.getMongoConnectionString().getUsername()).isNotNull();
+    assertThat(MONGO.getMongoConnectionString().getPassword()).isNotNull();
+    assertThat(MONGO.getMongoConnectionString().getDatabase()).isNotNull();
   }
 }

--- a/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbClassExtensionTest.java
+++ b/sda-commons-server-mongo-testing/src/test/java/org/sdase/commons/server/mongo/testing/StartLocalMongoDbClassExtensionTest.java
@@ -38,9 +38,10 @@ class StartLocalMongoDbClassExtensionTest {
 
   @Test
   void shouldStartMongoDbWithSpecifiedSettings() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(MONGO_DB_EXTENSION.getHosts()),
+            ServerAddressHelper.createServerAddress(hosts.get(0)),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -53,9 +54,10 @@ class StartLocalMongoDbClassExtensionTest {
 
   @Test
   void shouldRejectAccessForBadCredentials() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(MONGO_DB_EXTENSION.getHosts()),
+            ServerAddressHelper.createServerAddress(hosts.get(0)),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, (DATABASE_PASSWORD + "_bad").toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -68,9 +70,10 @@ class StartLocalMongoDbClassExtensionTest {
   @Test
   // Flapdoodle can not require auth and create a user
   void shouldAllowAccessWithoutCredentials() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(MONGO_DB_EXTENSION.getHosts()),
+            ServerAddressHelper.createServerAddress(hosts.get(0)),
             MongoClientOptions.builder().build())) {
       long documentCount = mongoClient.getDatabase("my_db").getCollection("test").countDocuments();
       assertThat(documentCount).isZero();
@@ -103,9 +106,10 @@ class StartLocalMongoDbClassExtensionTest {
 
   @Test
   void shouldClearCollections() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(MONGO_DB_EXTENSION.getHosts()),
+            ServerAddressHelper.createServerAddress(hosts.get(0)),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -124,9 +128,10 @@ class StartLocalMongoDbClassExtensionTest {
 
   @Test
   void shouldClearDatabase() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
     try (MongoClient mongoClient =
         new MongoClient(
-            ServerAddressHelper.createServerAddress(MONGO_DB_EXTENSION.getHosts()),
+            ServerAddressHelper.createServerAddress(hosts.get(0)),
             MongoCredential.createCredential(
                 DATABASE_USERNAME, DATABASE_NAME, DATABASE_PASSWORD.toCharArray()),
             MongoClientOptions.builder().build())) {
@@ -185,9 +190,11 @@ class StartLocalMongoDbClassExtensionTest {
 
   @Test
   void shouldReturnConnectionString() {
+    var hosts = MONGO_DB_EXTENSION.getMongoConnectionString().getHosts();
+    var database = MONGO_DB_EXTENSION.getMongoConnectionString().getDatabase();
     assertThat(MONGO_DB_EXTENSION.getConnectionString())
         .isNotEmpty()
-        .contains(MONGO_DB_EXTENSION.getHosts())
-        .contains(MONGO_DB_EXTENSION.getDatabase());
+        .contains(hosts.get(0))
+        .contains(database);
   }
 }

--- a/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/SpringDataMongoBundleLocalDateConvertersIT.java
+++ b/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/SpringDataMongoBundleLocalDateConvertersIT.java
@@ -114,7 +114,11 @@ abstract class SpringDataMongoBundleLocalDateConvertersIT {
 
     try (MongoClient client = getMongo().createClient()) {
       Document foundPerson =
-          client.getDatabase(getMongo().getDatabase()).getCollection("people").find().first();
+          client
+              .getDatabase(getMongo().getMongoConnectionString().getDatabase())
+              .getCollection("people")
+              .find()
+              .first();
 
       assertThat(foundPerson).isNotNull();
       assertThat(foundPerson.get("birthday")).isInstanceOf(String.class).isEqualTo("1979-02-08");

--- a/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/compatibility/MorphiaCompatibilityITest.java
+++ b/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/compatibility/MorphiaCompatibilityITest.java
@@ -243,7 +243,7 @@ abstract class MorphiaCompatibilityITest {
     try (var mongoClient = getMongo().createClient()) {
       var actual =
           mongoClient
-              .getDatabase(getMongo().getDatabase())
+              .getDatabase(getMongo().getMongoConnectionString().getDatabase())
               .getCollection("MyEntity")
               .find(new BsonDocument("_id", new BsonString("ID_1234")))
               .first();

--- a/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/inheritance/InheritanceMappingITest.java
+++ b/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/inheritance/InheritanceMappingITest.java
@@ -96,7 +96,11 @@ abstract class InheritanceMappingITest {
 
     try (var mongoClient = getMongo().createClient()) {
       Document privateZoo =
-          mongoClient.getDatabase(getMongo().getDatabase()).getCollection("zoo").find().first();
+          mongoClient
+              .getDatabase(getMongo().getMongoConnectionString().getDatabase())
+              .getCollection("zoo")
+              .find()
+              .first();
 
       assertThat(privateZoo)
           .isNotNull()
@@ -148,7 +152,10 @@ abstract class InheritanceMappingITest {
                     Map.of("_class", "cat", "name", "Miez"))));
 
     try (var mongoClient = getMongo().createClient()) {
-      mongoClient.getDatabase(getMongo().getDatabase()).getCollection("zoo").insertOne(given);
+      mongoClient
+          .getDatabase(getMongo().getMongoConnectionString().getDatabase())
+          .getCollection("zoo")
+          .insertOne(given);
 
       List<PrivateZoo> all = mongoOperations.findAll(PrivateZoo.class);
       assertThat(all).hasSize(1);

--- a/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/metadata/AbstractMetadataContextStorageIntegrationTest.java
+++ b/sda-commons-server-spring-data-mongo/src/test/java/org/sdase/commons/server/spring/data/mongo/metadata/AbstractMetadataContextStorageIntegrationTest.java
@@ -286,6 +286,8 @@ abstract class AbstractMetadataContextStorageIntegrationTest {
   }
 
   private MongoCollection<Document> businessEntityCollection(MongoClient client) {
-    return client.getDatabase(getMongo().getDatabase()).getCollection("businessEntity");
+    return client
+        .getDatabase(getMongo().getMongoConnectionString().getDatabase())
+        .getCollection("businessEntity");
   }
 }


### PR DESCRIPTION
…erface

BREAKING CHANGE: remove deprecated methods from MongoDb interface

Removed getters from the `MongoDb` interface which affects the `MongoDbClassExtension`. You can retrieve information about the database, username or password from the `ConnectionString` that is provided by `MongoDbClassExtension#getMongoConnectionString()`.