### PR TITLE
chore: disable Dependabot for release/2.x.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,36 +44,4 @@ updates:
     prefix: "chore"
     prefix-development: "chore"
     include: scope
-# maintaining v2
-- package-ecosystem: gradle
-  target-branch: "release/2.x.x"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  labels:
-    - "dependencies"
-    - "release-2.x.x"
-  ignore:
-    - dependency-name: "org.eclipse.jetty:jetty-bom"
-      # ignore all Dependabot updates for version 10, 11, 12
-      # Major version should be in-sync with the version used by Dropwizard
-      update-types: [ "version-update:semver-major" ]
-    - dependency-name: "org.flywaydb:flyway-core"
-      # version 10+ needs Java 17
-      update-types: [ "version-update:semver-major" ]
-  commit-message:
-    prefix: "fix"
-    prefix-development: "chore"
-    include: scope
-- package-ecosystem: github-actions
-  target-branch: "release/2.x.x"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  labels:
-    - "dependencies"
-    - "release-2.x.x"
-  commit-message:
-    prefix: "chore"
-    prefix-development: "chore"
-    include: scope
+


### PR DESCRIPTION
README states:
> Version 2.x.x only receives critical security updates until October 2023. We will only provide security updates for the libraries that are still compatible with Java 8.
>
> Please make sure to upgrade to version 5 as soon as possible.

Furthermore, the first beta of version 6 is approaching. Time to slowly fade out 2.x.x.
This will close several PRs and save a couple of resources.