### PR TITLE
CDI: Undo deprecation of `WeldAppExtension` and `WeldTestSupport`

### DIFF
--- a/sda-commons-server-weld-example/build.gradle
+++ b/sda-commons-server-weld-example/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   api project(':sda-commons-server-dropwizard')
   api project(':sda-commons-server-weld')
 
-  testImplementation project(':sda-commons-server-weld-testing')
+  testImplementation project(':sda-commons-server-testing')
+  testImplementation 'org.jboss.weld:weld-junit5:2.0.2.Final'
 }
 

--- a/sda-commons-server-weld-example/build.gradle
+++ b/sda-commons-server-weld-example/build.gradle
@@ -14,7 +14,6 @@ dependencies {
   api project(':sda-commons-server-dropwizard')
   api project(':sda-commons-server-weld')
 
-  testImplementation project(':sda-commons-server-testing')
-  testImplementation 'org.jboss.weld:weld-junit5:2.0.2.Final'
+  testImplementation project(':sda-commons-server-weld-testing')
 }
 

--- a/sda-commons-server-weld-example/src/main/java/org/sdase/commons/server/weld/WeldExampleApplication.java
+++ b/sda-commons-server-weld-example/src/main/java/org/sdase/commons/server/weld/WeldExampleApplication.java
@@ -6,12 +6,19 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
 import org.sdase.commons.server.weld.beans.UsageBean;
 
+@Path("someString")
+@Produces(MediaType.APPLICATION_JSON)
 @ApplicationScoped
 public class WeldExampleApplication extends Application<Configuration> {
 
   @Inject private UsageBean usageBean;
+  @Inject private String someString;
 
   public static void main(String[] args) throws Exception {
     // activate weld for this application.
@@ -37,14 +44,22 @@ public class WeldExampleApplication extends Application<Configuration> {
     // INFO  [xxxx-xx-xx xx:xx:xx,xxx] org.sdase.commons.server.weld.beans.SimpleBean: injected
     // string 'some string'
     usageBean.useSimpleBean();
+
+    // beans that serve requests must be registered
+    environment.jersey().register(this);
+  }
+
+  @GET
+  public String getSomeString() {
+    return someString;
   }
 
   /**
-   * Method oly for testing. It provides the bean to the test, where it can be verified
+   * Method only for testing. It provides the bean to the test, where it can be verified
    *
    * @return the usage bean
    */
-  public UsageBean getUsageBean() {
+  UsageBean getUsageBean() {
     return usageBean;
   }
 }

--- a/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
+++ b/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
@@ -1,11 +1,13 @@
 package org.sdase.commons.server.weld;
 
 import static io.dropwizard.testing.ConfigOverride.randomPorts;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.Configuration;
-import org.assertj.core.api.Assertions;
+import javax.ws.rs.core.MediaType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sdase.commons.server.weld.beans.UsageBean;
 import org.sdase.commons.server.weld.testing.WeldAppExtension;
 
 class WeldExampleApplicationITest {
@@ -17,6 +19,16 @@ class WeldExampleApplicationITest {
   @Test
   void shouldBeInjectedCorrectly() {
     WeldExampleApplication app = APP.getApplication();
-    Assertions.assertThat(app.getUsageBean()).isNotNull();
+    assertThat(app.getUsageBean()).isNotNull().isInstanceOf(UsageBean.class);
+  }
+
+  @Test
+  void shouldGetFromRest() {
+    String result =
+        APP.client()
+            .target(String.format("http://localhost:%d/someString", APP.getLocalPort()))
+            .request(MediaType.APPLICATION_JSON_TYPE)
+            .get(String.class);
+    assertThat(result).isEqualTo("some string");
   }
 }

--- a/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
+++ b/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
@@ -3,36 +3,19 @@ package org.sdase.commons.server.weld;
 import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
-import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.MediaType;
-import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
-import org.jboss.weld.junit5.auto.AddExtensions;
-import org.jboss.weld.junit5.auto.AddPackages;
-import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sdase.commons.server.weld.beans.UsageBean;
+import org.sdase.commons.server.weld.testing.WeldAppExtension;
 
-@EnableAutoWeld
-@AddPackages(WeldExampleApplication.class)
-@AddExtensions(CdiComponentProvider.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WeldExampleApplicationITest {
 
   @RegisterExtension
   static DropwizardAppExtension<Configuration> APP =
-      new DropwizardAppExtension<>(
-          new DropwizardTestSupport<>(WeldExampleApplication.class, null, randomPorts()) {
-            @Override
-            public Application<Configuration> newApplication() {
-              return CDI.current().select(WeldExampleApplication.class).get();
-            }
-          });
+      new WeldAppExtension<>(WeldExampleApplication.class, null, randomPorts());
 
   @Test
   void shouldBeInjectedCorrectly() {

--- a/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
+++ b/sda-commons-server-weld-example/src/test/java/org/sdase/commons/server/weld/WeldExampleApplicationITest.java
@@ -3,18 +3,36 @@ package org.sdase.commons.server.weld;
 import static io.dropwizard.testing.ConfigOverride.randomPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.dropwizard.Application;
 import io.dropwizard.Configuration;
+import io.dropwizard.testing.DropwizardTestSupport;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import javax.enterprise.inject.spi.CDI;
 import javax.ws.rs.core.MediaType;
+import org.glassfish.jersey.ext.cdi1x.internal.CdiComponentProvider;
+import org.jboss.weld.junit5.auto.AddExtensions;
+import org.jboss.weld.junit5.auto.AddPackages;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sdase.commons.server.weld.beans.UsageBean;
-import org.sdase.commons.server.weld.testing.WeldAppExtension;
 
+@EnableAutoWeld
+@AddPackages(WeldExampleApplication.class)
+@AddExtensions(CdiComponentProvider.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WeldExampleApplicationITest {
 
   @RegisterExtension
-  static final WeldAppExtension<Configuration> APP =
-      new WeldAppExtension<>(WeldExampleApplication.class, null, randomPorts());
+  static DropwizardAppExtension<Configuration> APP =
+      new DropwizardAppExtension<>(
+          new DropwizardTestSupport<>(WeldExampleApplication.class, null, randomPorts()) {
+            @Override
+            public Application<Configuration> newApplication() {
+              return CDI.current().select(WeldExampleApplication.class).get();
+            }
+          });
 
   @Test
   void shouldBeInjectedCorrectly() {

--- a/sda-commons-server-weld-testing/src/main/java/org/sdase/commons/server/weld/testing/WeldAppExtension.java
+++ b/sda-commons-server-weld-testing/src/main/java/org/sdase/commons/server/weld/testing/WeldAppExtension.java
@@ -16,12 +16,7 @@ import javax.annotation.Nullable;
  *   static final WeldAppExtension&lt;AppConfiguration%gt APP =
  *       new WeldAppExtension&lt;&gt;(WeldExampleApplication.class, resourceFilePath("test-config.yaml"));
  * </pre>
- *
- * @deprecated This extension is going to be removed in the next major release. Please switch to the
- *     official <a href="https://github.com/weld/weld-testing">Weld Testing Extension</a>, which is
- *     also provided in this module.
  */
-@Deprecated(forRemoval = true)
 public class WeldAppExtension<C extends Configuration> extends DropwizardAppExtension<C> {
 
   public WeldAppExtension(

--- a/sda-commons-server-weld-testing/src/main/java/org/sdase/commons/server/weld/testing/WeldTestSupport.java
+++ b/sda-commons-server-weld-testing/src/main/java/org/sdase/commons/server/weld/testing/WeldTestSupport.java
@@ -18,12 +18,7 @@ import org.sdase.commons.server.weld.internal.WeldSupport;
  *   static final DropwizardAppExtension&lt;AppConfiguration&gt; EXTENSION = new DropwizardAppExtension&lt;&gt;(
  *       new WeldTestSupport&lt;&gt;(Application.class, ResourceHelpers.resourceFilePath("config.yml")));
  * </pre>
- *
- * @deprecated Since we are switching to the official <a
- *     href="https://github.com/weld/weld-testing">Weld JUnit extension</a>, this class is not
- *     needed any longer and will be removed with the next major release.
  */
-@Deprecated(forRemoval = true)
 public class WeldTestSupport<C extends Configuration> extends DropwizardTestSupport<C> {
 
   private WeldContainer container;


### PR DESCRIPTION
To reduce maintenance effort, we deprecated the [WeldAppExtension](https://github.com/SDA-SE/sda-dropwizard-commons/releases/tag/5.16.0) for removal. 
So far we did not show an alternative way for testing applications using Weld. This PR is meant to close this gap.

To have better coverage, the test of the example module is extended to verify a REST response ~~and then [migrated](https://github.com/SDA-SE/sda-dropwizard-commons/commit/77a38f37dcda0a3f5e28af650299f40259895440)~~. We decided to undo the deprecation and have test support for Weld in the future. The official extension requires too much overhead for a working integration test of a full Dropwizard application.


**Disclaimer**

We suggest to use pure Java with this library instead of an additional layer of magic like CDI. You may want to consider [Spring Boot for SDA compliant services](https://github.com/SDA-SE/sda-spring-boot-commons) that use dependency injection.