### PR TITLE
fix(deps): bump spring-data-mongodb from 4.1.7 to 4.1.8

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -129,7 +129,7 @@ dependencies {
     api "it.unibo.tuprolog:parser-theory-jvm:$tuprologVersion"
 
     // sda-commons-server-mongo-testing, sda-commons-server-spring-data-mongo
-    api 'org.springframework.data:spring-data-mongodb:4.1.7' // Keep that version for now, since 4.2.0 introduces a bug
+    api 'org.springframework.data:spring-data-mongodb:4.1.8' // Keep that version for now, since 4.2.0 introduces a bug
     api "de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.1"
     api "io.opentelemetry.instrumentation:opentelemetry-mongo-3.1:${openTelemetryVersion}-alpha"
     api "org.mongodb:mongodb-driver-core:${mongoDbDriverVersion}"


### PR DESCRIPTION
Dependabot ignores spring-data-mongodb because https://github.com/SDA-SE/sda-dropwizard-commons/pull/2356 was closed. I have not succeeded to unignore it again.

"fixing" [CVE-2024-22233](https://www.cvedetails.com/cve/CVE-2024-22233/). We're not affected but update anyway to get rid of [security findings](https://github.com/SDA-SE/sda-dropwizard-commons/actions/workflows/cve-check.yml).

* [Release Notes](https://github.com/spring-projects/spring-data-mongodb/releases/tag/4.1.8)
