### PR TITLE
test(shared-certificates): use our own domain for testing

### DIFF
--- a/sda-commons-shared-certificates/src/test/java/org/sdase/commons/shared/certificates/ca/CaCertificatesBundleHttpsIT.java
+++ b/sda-commons-shared-certificates/src/test/java/org/sdase/commons/shared/certificates/ca/CaCertificatesBundleHttpsIT.java
@@ -30,7 +30,7 @@ import org.sdase.commons.shared.certificates.ca.ssl.SslUtil;
 class CaCertificatesBundleHttpsIT {
   private static final String DEFAULT_SSL_PROTOCOL = "TLSv1.2";
 
-  private static final String securedHost = "https://stackoverflow.com";
+  private static final String securedHost = "https://sda.se";
 
   @Test
   void shouldFailWithCustomTrustStore() throws Exception {


### PR DESCRIPTION
It seems like Stackoverflow (sometimes?) blocks requests from GH runners.