### PR TITLE
fix(deps): bump transitive commons-compress to 1.26.0 to fix CVEs 2024-25710 and 2024-26308

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -132,6 +132,9 @@ dependencies {
     // sda-commons-server-mongo-testing, sda-commons-server-spring-data-mongo
     api 'org.springframework.data:spring-data-mongodb:4.1.8' // Keep that version for now, since 4.2.0 introduces a bug
     api "de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.1"
+    // check if commons-compress management is still needed after flapdoodle upgrade
+    // flapdoodle 4.11.1 pulls commons-compress 1.25.0 with CVEs 2024-25710 and 2024-26308
+    api "org.apache.commons:commons-compress:1.26.0"
     api "io.opentelemetry.instrumentation:opentelemetry-mongo-3.1:${openTelemetryVersion}-alpha"
     api "org.mongodb:mongodb-driver-core:${mongoDbDriverVersion}"
     api "org.mongodb:mongodb-driver-sync:${mongoDbDriverVersion}"


### PR DESCRIPTION
CVE-2024-1597 is already fixed by #3189 