### PR TITLE
docs: show how trace-token can be used with tasks

### DIFF
--- a/docs/server-trace.md
+++ b/docs/server-trace.md
@@ -46,3 +46,23 @@ public class MyApplication extends Application<MyConfiguration> {
    }
 }
 ```
+
+### Custom initialization
+
+In some cases, Dropwizard can't be configured to start correlation for a specific initialization
+point.
+For example, a dedicated correlation for each entity may be useful when batch processes act on
+multiple entities in the database.
+Also, [Dropwizard Tasks](https://www.dropwizard.io/en/release-3.0.x/manual/core.html#tasks) can't be
+configured on library level like regular HTTP endpoints although correlation may be desired here as
+well.
+
+To cover such individual cases, the library allows to wrap an operation in a `TraceTokenContext`.
+This will result in a `Trace-Token` in the log MDC, forwarding the trace token with clients build
+with [client-jersey](./client-jersey.md) and forwarding the parent trace token with producers of
+[server-kafka](./server-kafka.md).
+
+??? example "Trace Context for Dropwizard Tasks"
+    ```java
+    --8<-- "./sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/test/TraceTokenAwareExampleTask.java"
+    ```

--- a/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/TraceTokenBundleTest.java
+++ b/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/TraceTokenBundleTest.java
@@ -4,11 +4,16 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.dropwizard.core.Configuration;
+import io.dropwizard.testing.ConfigOverride;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.Response;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.StdIo;
+import org.junitpioneer.jupiter.StdOut;
 import org.sdase.commons.server.trace.test.TraceTokenTestApp;
 
 class TraceTokenBundleTest {
@@ -16,7 +21,10 @@ class TraceTokenBundleTest {
   @RegisterExtension
   public static final DropwizardAppExtension<Configuration> DW =
       new DropwizardAppExtension<>(
-          TraceTokenTestApp.class, ResourceHelpers.resourceFilePath("test-config.yaml"));
+          TraceTokenTestApp.class,
+          ResourceHelpers.resourceFilePath("test-config.yaml"),
+          ConfigOverride.config(
+              "logging.appenders[0].logFormat", "%logger{0} %message %mdc{Trace-Token:-}"));
 
   @Test
   void shouldReadTraceToken() {
@@ -79,6 +87,34 @@ class TraceTokenBundleTest {
       String header = response.getHeaderString("Trace-Token");
       assertThat(header).isBlank();
       assertThat(response.getStatus()).isEqualTo(200);
+    }
+  }
+
+  @Test
+  @StdIo
+  @SuppressWarnings("JUnitMalformedDeclaration")
+  void shouldHaveTraceTokenRequestedInTask(StdOut out) {
+    String expectedLogPattern =
+        "^TraceTokenAwareExampleTask Log with a TraceToken in the MDC. (.+)$";
+    try (Response response =
+        DW.client()
+            .target("http://localhost:" + DW.getAdminPort())
+            .path("tasks")
+            .path("example-task")
+            .request()
+            .post(Entity.text("Test"))) {
+
+      assertThat(response.getStatus()).isEqualTo(200);
+
+      var traceToken =
+          Arrays.stream(out.capturedLines())
+              .filter(l -> l.matches(expectedLogPattern))
+              .map(l -> l.replaceAll(expectedLogPattern, "$1"))
+              .findFirst()
+              .orElse(null);
+
+      assertThat(response.readEntity(String.class).trim())
+          .isEqualTo("Trace-Token: %s".formatted(traceToken));
     }
   }
 }

--- a/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/test/TraceTokenAwareExampleTask.java
+++ b/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/test/TraceTokenAwareExampleTask.java
@@ -1,0 +1,29 @@
+package org.sdase.commons.server.trace.test;
+
+import io.dropwizard.servlets.tasks.Task;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+import org.sdase.commons.shared.tracing.TraceTokenContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TraceTokenAwareExampleTask extends Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TraceTokenAwareExampleTask.class);
+
+  public TraceTokenAwareExampleTask() {
+    super("example-task");
+  }
+
+  @Override
+  public void execute(Map<String, List<String>> parameters, PrintWriter output) {
+    try (var traceTokenContext = TraceTokenContext.getOrCreateTraceTokenContext()) {
+      LOG.info("Log with a TraceToken in the MDC.");
+      // Note: Response headers will NOT contain the Trace-Token.
+      output.println("Trace-Token: %s".formatted(traceTokenContext.get()));
+
+      // Implement the task here. Logs will contain the 'Trace-Token' from the MDC.
+    }
+  }
+}

--- a/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/test/TraceTokenTestApp.java
+++ b/sda-commons-server-trace/src/test/java/org/sdase/commons/server/trace/test/TraceTokenTestApp.java
@@ -28,6 +28,7 @@ public class TraceTokenTestApp extends Application<Configuration> {
   @Override
   public void run(Configuration configuration, Environment environment) {
     environment.jersey().register(this);
+    environment.admin().addTask(new TraceTokenAwareExampleTask());
   }
 
   @OPTIONS

--- a/sda-commons-server-trace/src/test/resources/test-config.yaml
+++ b/sda-commons-server-trace/src/test/resources/test-config.yaml
@@ -6,3 +6,6 @@ server:
   - type: http
     port: 0
   rootPath: "/api/*"
+logging:
+  appenders:
+    - type: console


### PR DESCRIPTION
Unfortunately, #359 can't be solved in the library. This PR documents how the desired Trace-Token functionality can be achieved for Dropwizard Tasks in each task itself.