### PR TITLE
fix(kafka): treat continued handling errors like successful consumed message

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/autocommit/AutocommitMLS.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/autocommit/AutocommitMLS.java
@@ -60,7 +60,9 @@ public class AutocommitMLS<K, V> extends MessageListenerStrategy<K, V> {
               handler.getClass(),
               e);
           boolean shouldContinue = errorHandler.handleError(consumerRecord, e, consumer);
-          if (!shouldContinue) {
+          if (shouldContinue) {
+            addOffsetToCommitOnClose(consumerRecord);
+          } else {
             throw new StopListenerException(e);
           }
         }


### PR DESCRIPTION
Note: This fix only affects cases, when a subsequent message in the same poll causes the consumer to stop consuming. It may also cover scenarios when the application is shut down while the messages of this poll are handled.