### PR TITLE
fix(deps): bump mongoDbDriverVersion from 4.11.2 to 5.1.1

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -24,7 +24,7 @@ ext {
   openTelemetryVersion = '1.36.0'
   openTelemetryAlpha2Version = '2.5.0-alpha'
   // should be aligned with transitive dependency of Spring Data MongoDB
-  mongoDbDriverVersion = '4.11.2'
+  mongoDbDriverVersion = '5.1.1'
   tuprologVersion = '0.20.9' // don't upgrade separately! use version from database-rider
   bouncyCastleVersion = '1.78.1'
   victoolsVersion = '4.35.0'


### PR DESCRIPTION
BREAKING CHANGE:

Version 7 of `sda-dropwizard-commons` integrates MongoDB Java Driver 5.1.1. This upgrade introduces
some breaking changes, primarily due to the removal of deprecated methods. While many changes might
not directly impact your services, it's essential to review and test your application to ensure a
smooth transition.

For a comprehensive list of changes and detailed migration steps, please refer to
the [official MongoDB Java Driver 5.0 documentation](https://www.mongodb.com/community/forums/t/mongodb-java-driver-5-0-is-released/268913).

Updates `org.mongodb:mongodb-driver-core` from 4.11.2 to 5.1.1

Updates `org.mongodb:mongodb-driver-sync` from 4.11.2 to 5.1.1

Updates `org.mongodb:mongodb-driver-legacy` from 4.11.2 to 5.1.1