### PR TITLE
Fix failure that occurs in distroless image with read only file system

### DIFF
--- a/.github/workflows/kafka-regression-test.yml
+++ b/.github/workflows/kafka-regression-test.yml
@@ -1,0 +1,20 @@
+# This workflow tests a regression that came with a Kafka client update in apps running distroless
+# images with read only file system.
+# See sda-commons-server-kafka/src/test/DockerTest for details
+name: Read only file system
+
+on:
+  pull_request:
+
+jobs:
+  test-in-docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - name: build image
+        run: docker build -t kafka-ro:test .
+      - name: Run writable # should always pass
+        run: docker run kafka-ro:test
+      - name: Run readonly # should fail with wrong kafka-client version
+        run: docker run --read-only kafka-ro:test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:21-jammy AS build
+
+# This docker file is used to test a specific regression from kafka-client:3.8.0 in a distroless
+# container with readonly file system.
+# See sda-commons-server-kafka/src/test/DockerTest for details.
+
+COPY ./ /project
+
+WORKDIR /project
+
+RUN ls -al
+RUN echo ''
+RUN echo 'task download(type: Copy) {'            >> ./sda-commons-server-kafka/build.gradle
+RUN echo '  from configurations.runtimeClasspath' >> ./sda-commons-server-kafka/build.gradle
+RUN echo '  into "build/lib"'                     >> ./sda-commons-server-kafka/build.gradle
+RUN echo '}'                                      >> ./sda-commons-server-kafka/build.gradle
+
+RUN ./gradlew :sda-commons-server-kafka:compileTestJava :sda-commons-server-kafka:download
+
+RUN mkdir "/build-result"
+RUN mkdir "/build-result/cp"
+RUN cp /project/sda-commons-server-kafka/build/classes/java/test/DockerTest.class /build-result/DockerTest.class
+RUN cp /project/sda-commons-server-kafka/build/lib/*.jar /build-result/cp
+
+FROM gcr.io/distroless/java21-debian12:nonroot
+
+WORKDIR /home
+COPY --from=build --chown=65532:65532 /build-result ./nonroot
+WORKDIR /home/nonroot
+USER 65532:65532
+
+ENTRYPOINT ["/usr/bin/java"]
+CMD ["-cp", "/home/nonroot/cp/*:.", "DockerTest"]

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -15,7 +15,7 @@ ext {
   jacksonVersion = '2.17.2'
   jsonUnitVersion = '3.2.2'
   scalaVersion = '2.13.14' // align transitive dependency from various modules, keep up to date
-  kafkaVersion = '3.8.0'
+  kafkaVersion = '3.7.1'
   kafkaJunitVersion = '3.2.5' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5
   dbRiderVersion = '1.44.0'
   kotlinVersion = '2.0.0'

--- a/sda-commons-server-kafka/src/test/java/DockerTest.java
+++ b/sda-commons-server-kafka/src/test/java/DockerTest.java
@@ -1,0 +1,42 @@
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test is build for a regression introduced with an update to kafka-clients:3.8.0.
+ *
+ * <p>The Kafka client library introduced some kind of autodiscovery for compression configuration
+ * which results in an attempt to write to the filesystem. For security reasons services built with
+ * SDA Dropwizard Commons should use distroless images and a read only filesystem.
+ *
+ * <p>The error does not happen in regular builds. It only appears when a service bundled as docker
+ * image is started with a readonly file system, e.g. in Kubernetes or with {@code docker run
+ * --read-only …}. This test is used to create a {@linkplain #main(String[]) main class} for a
+ * docker image (see {@code /Dockerfile} in repo root) that is executed with a read only filesystem
+ * in {@code /.github/workflows/kafka-regression-test.yml} to simulate a real world scenario.
+ *
+ * @see <a href="https://github.com/SDA-SE/sda-dropwizard-commons/pull/3575">more details in the
+ *     pull request</a>
+ */
+public class DockerTest {
+  public static void main(String[] args) {
+    System.out.println("Hello World!");
+    createProducerConfig();
+  }
+
+  @Test
+  void shouldCreateProducerConfig() {
+    assertThatNoException().isThrownBy(DockerTest::createProducerConfig);
+  }
+
+  private static void createProducerConfig() {
+    var validConfig =
+        Map.<String, Object>of(
+            "key.serializer",
+            "org.apache.kafka.common.serialization.StringSerializer",
+            "value.serializer",
+            "org.apache.kafka.common.serialization.StringSerializer");
+    new org.apache.kafka.clients.producer.ProducerConfig(validConfig);
+  }
+}


### PR DESCRIPTION
The Bug has been introduced in DW Commons [7.0.49](https://github.com/SDA-SE/sda-dropwizard-commons/releases/tag/7.0.49). It is not covered in the lib but shows up in services that use Kafka and run in distroless images with a read only file system.

**Behavior**

The services crashes on startup when the Kafka producer is created with an exception:

```
java.lang.ExceptionInInitializerError: Cannot unpack libzstd-jni-1.5.6-3: Read-only file system
	at java.base/java.io.UnixFileSystem.createFileExclusively(Native Method)
	at java.base/java.io.File.createTempFile(File.java:2170)
	at com.github.luben.zstd.util.Native.load(Native.java:130)
	at com.github.luben.zstd.util.Native.load(Native.java:86)
	at com.github.luben.zstd.Zstd.<clinit>(Zstd.java:12)
	at org.apache.kafka.common.compress.ZstdCompression.<clinit>(ZstdCompression.java:41)
	at org.apache.kafka.clients.producer.ProducerConfig.<clinit>(ProducerConfig.java:384)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:295)
	at org.apache.kafka.clients.producer.KafkaProducer.<init>(KafkaProducer.java:322)
	at org.sdase.commons.server.kafka.KafkaBundle.createProducer(KafkaBundle.java:330)
	at org.sdase.commons.server.kafka.KafkaBundle.createProducer(KafkaBundle.java:376)
	at org.sdase.commons.server.kafka.KafkaBundle.registerProducer(KafkaBundle.java:220)
	at com.sdase.business.transaction.ods.service.BusinessTransactionOdsApplication.initOutgoingProducer(BusinessTransactionOdsApplication.java:217)
	at com.sdase.business.transaction.ods.service.BusinessTransactionOdsApplication.run(BusinessTransactionOdsApplication.java:111)
	at com.sdase.business.transaction.ods.service.BusinessTransactionOdsApplication.run(BusinessTransactionOdsApplication.java:37)
	at io.dropwizard.core.cli.EnvironmentCommand.run(EnvironmentCommand.java:66)
	at io.dropwizard.core.cli.ConfiguredCommand.run(ConfiguredCommand.java:98)
	at io.dropwizard.core.cli.Cli.run(Cli.java:78)
	at io.dropwizard.core.Application.run(Application.java:94)
	at …
```

**Additional information**

Kafka introduced some automated [detection for message compression](https://github.com/apache/kafka/pull/15516).

To validate the configuration for ZstdCompression a library is instrumented statically. This library has some magic to make the underlying native library available.

Assumption: Because the native library does not exist in the distroless images, the Java library tries to [put it in the readonly filesystem](https://github.com/luben/zstd-jni/blob/76acf0fe88613c68ae1a8f4f0d8b2280f22a5f63/src/main/java/com/github/luben/zstd/util/Native.java#L95) and fails. We usually do not use such compression and therefore, the library classes have not been loaded in the past, so that we were not affected. It seems like we would have faced the same issue, when compression with zstd is used in services.