### PR TITLE
fix(deps): change httpclient5-fluent to existing version 5.3.1

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -77,7 +77,7 @@ dependencies {
       because "CVE-2023-24998 in 1.4"
     }
     api 'org.apache.httpcomponents.client5:httpclient5:5.3.1'
-    api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3.1.1'
+    api 'org.apache.httpcomponents.client5:httpclient5-fluent:5.3.1'
     api "io.github.classgraph:classgraph:4.8.174", {
       because "conflict between io.swagger.core.v3:swagger-jaxrs2 and io.swagger.core.v3:swagger-integration upgrade"
     }


### PR DESCRIPTION
As described in #3583, version 5.3.1.1 does not exist in [Maven Central](https://central.sonatype.com/artifact/org.apache.httpcomponents.client5/httpclient5-fluent/5.3.1/overview).

Fixes #3583