### PR TITLE
Enable the configuration of a default key mapping.

### DIFF
--- a/docs/server-key-mgmt.md
+++ b/docs/server-key-mgmt.md
@@ -30,6 +30,12 @@ This means, that the original value is just passed instead of being mapped. Ther
 
 This fail strategy can be configured as part of the builder. There is another fail strategy implemented (`FAIL_WITH_EXCEPTION`),
 that throws an `IllegalArgumentException` when no mapping can be found with no log message.
+Furthermore, there are three other fail strategies (`PLACEHOLDER_BIDIRECTIONAL`, `PLACEHOLDER_API_TO_IMPL`, `PLACEHOLDER_IMPL_TO_API`)
+which insert a placeholder value ("UNKNOWN_KEY_VALUE") if there's no available mapping.
+`PLACEHOLDER_BIDIRECTIONAL` performs this substitution in both directions. `PLACEHOLDER_API_TO_IMPL`
+only in the direction from api to implementation, and `PLACEHOLDER_IMPL_TO_API` only in the
+direction from implementation to api. (If no substitution is performed, the mapper continues to
+throw an `IllegalArgumentException` for unmappable values.)
 
 ## Usage
 ```

--- a/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/KeyMgmtBundle.java
+++ b/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/KeyMgmtBundle.java
@@ -69,15 +69,23 @@ public class KeyMgmtBundle<T extends Configuration> implements ConfiguredBundle<
           "KeyMapper can be build in run(C, Environment), not in initialize(Bootstrap)");
     }
     if (failStrategy == FailStrategy.FAIL_WITH_EXCEPTION) {
-      return getMapOrFailKeyMapper(keyDefinitionName);
+      return getMapOrFailKeyMapper(keyDefinitionName, false, false);
+    } else if (failStrategy == FailStrategy.PLACEHOLDER_BIDIRECTIONAL) {
+      return getMapOrFailKeyMapper(keyDefinitionName, true, true);
+    } else if (failStrategy == FailStrategy.PLACEHOLDER_API_TO_IMPL) {
+      return getMapOrFailKeyMapper(keyDefinitionName, true, false);
+    } else if (failStrategy == FailStrategy.PLACEHOLDER_IMPL_TO_API) {
+      return getMapOrFailKeyMapper(keyDefinitionName, false, true);
     } else {
       return getMapOrPassthroughKeyMapper(keyDefinitionName);
     }
   }
 
-  private MapOrFailKeyMapper getMapOrFailKeyMapper(String keyDefinitionName) {
-    if (mappings.containsKey(keyDefinitionName)) {
-      return new MapOrFailKeyMapper(mappings.get(keyDefinitionName));
+  private MapOrFailKeyMapper getMapOrFailKeyMapper(
+      String keyDefinitionName, boolean useApiPlaceholder, boolean useImplPlaceholder) {
+    if (keyDefinitionName != null && mappings.containsKey(keyDefinitionName)) {
+      return new MapOrFailKeyMapper(
+          mappings.get(keyDefinitionName), useApiPlaceholder, useImplPlaceholder);
     } else {
       throw new IllegalArgumentException(
           String.format("No mapping found for key '%s'", keyDefinitionName));
@@ -120,7 +128,10 @@ public class KeyMgmtBundle<T extends Configuration> implements ConfiguredBundle<
   // --------------
   public enum FailStrategy {
     PASSTHROUGH,
-    FAIL_WITH_EXCEPTION
+    FAIL_WITH_EXCEPTION,
+    PLACEHOLDER_BIDIRECTIONAL,
+    PLACEHOLDER_IMPL_TO_API,
+    PLACEHOLDER_API_TO_IMPL
   }
 
   public interface InitialBuilder {

--- a/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/manager/MapOrFailKeyMapper.java
+++ b/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/manager/MapOrFailKeyMapper.java
@@ -2,14 +2,40 @@ package org.sdase.commons.keymgmt.manager;
 
 import java.util.Locale;
 import java.util.Objects;
+import java.util.Optional;
 import org.sdase.commons.keymgmt.model.KeyMappingModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MapOrFailKeyMapper implements KeyMapper {
 
+  private static final Logger LOG = LoggerFactory.getLogger(MapOrFailKeyMapper.class);
+
+  private static final String PLACEHOLDER = "UNKNOWN_KEY_VALUE";
+
   private final KeyMappingModel mappingModel;
 
-  public MapOrFailKeyMapper(KeyMappingModel mappingModel) {
+  private final boolean useApiToImplPlaceholder;
+
+  private final boolean useImplToApiPlaceholder;
+
+  /**
+   * Creates a new {@link MapOrFailKeyMapper}, optionally using placeholders for missing mappings.
+   *
+   * @param mappingModel the mapping model to use
+   * @param useApiToImplPlaceholder if true, a placeholder is used for missing mappings from API to
+   *     implementation
+   * @param useImplToApiPlaceholder if true, a placeholder is used for missing mappings from
+   *     implementation to API
+   * @return a new {@link MapOrFailKeyMapper}
+   */
+  public MapOrFailKeyMapper(
+      KeyMappingModel mappingModel,
+      boolean useApiToImplPlaceholder,
+      boolean useImplToApiPlaceholder) {
     this.mappingModel = mappingModel;
+    this.useApiToImplPlaceholder = useApiToImplPlaceholder;
+    this.useImplToApiPlaceholder = useImplToApiPlaceholder;
   }
 
   @Override
@@ -17,6 +43,19 @@ public class MapOrFailKeyMapper implements KeyMapper {
     return mappingModel
         .getMapping()
         .mapToImpl(value)
+        .or(
+            () -> {
+              if (useApiToImplPlaceholder) {
+                LOG.warn(
+                    "No mapping to implementation found for key '{}' and value '{}'. Substituting"
+                        + " \"UNKNOWN_KEY_VALUE\"",
+                    mappingModel.getName(),
+                    value);
+                return Optional.of(PLACEHOLDER);
+              } else {
+                return Optional.empty();
+              }
+            })
         .orElseThrow(
             () ->
                 new IllegalArgumentException(
@@ -30,6 +69,19 @@ public class MapOrFailKeyMapper implements KeyMapper {
     return mappingModel
         .getMapping()
         .mapToApi(value)
+        .or(
+            () -> {
+              if (useImplToApiPlaceholder) {
+                LOG.warn(
+                    "No mapping to api found for key '{}' and value '{}'. Substituting"
+                        + " \"UNKNOWN_KEY_VALUE\"",
+                    mappingModel.getName(),
+                    value);
+                return Optional.of(PLACEHOLDER);
+              } else {
+                return Optional.empty();
+              }
+            })
         .map(s -> s.toUpperCase(Locale.ROOT))
         .orElseThrow(
             () ->

--- a/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/manager/MapOrPassthroughKeyMapper.java
+++ b/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/manager/MapOrPassthroughKeyMapper.java
@@ -24,7 +24,8 @@ public class MapOrPassthroughKeyMapper implements KeyMapper {
         .orElseGet(
             () -> {
               LOG.warn(
-                  "No mapping to implementation found for key '{}' and value '{}'. Passing the value",
+                  "No mapping to implementation found for key '{}' and value '{}'. Passing the"
+                      + " value",
                   mappingModel.getName(),
                   value);
               return value;

--- a/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/model/ValueMappingModel.java
+++ b/sda-commons-server-key-mgmt/src/main/java/org/sdase/commons/keymgmt/model/ValueMappingModel.java
@@ -36,6 +36,9 @@ public class ValueMappingModel {
   }
 
   public Optional<String> mapToImpl(String apiValue) {
+    if (apiValue == null) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(
         apiToImpl.getOrDefault(
             apiValue.toUpperCase(Locale.ROOT),
@@ -43,6 +46,9 @@ public class ValueMappingModel {
   }
 
   public Optional<String> mapToApi(String implValue) {
+    if (implValue == null) {
+      return Optional.empty();
+    }
     return Optional.ofNullable(
         implToApi.getOrDefault(implValue, implToApiBidirectional.get(implValue)));
   }

--- a/sda-commons-server-key-mgmt/src/test/java/org/sdase/commons/keymgmt/KeyMgmtBundleWithPlaceholderTest.java
+++ b/sda-commons-server-key-mgmt/src/test/java/org/sdase/commons/keymgmt/KeyMgmtBundleWithPlaceholderTest.java
@@ -1,0 +1,160 @@
+package org.sdase.commons.keymgmt;
+
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.core.Application;
+import io.dropwizard.core.setup.Bootstrap;
+import io.dropwizard.core.setup.Environment;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sdase.commons.keymgmt.manager.KeyMapper;
+
+class KeyMgmtBundleWithPlaceholderTest {
+
+  @RegisterExtension
+  @Order(0)
+  static final DropwizardAppExtension<KeyMgmtBundleTestConfig> bidirectionalDW =
+      new DropwizardAppExtension<>(
+          BidirectionalTestApp.class,
+          resourceFilePath("test-config.yml"),
+          ConfigOverride.config("keyMgmt.apiKeysDefinitionPath", resourceFilePath("keys")),
+          ConfigOverride.config("keyMgmt.mappingDefinitionPath", resourceFilePath("mappings")));
+
+  @RegisterExtension
+  @Order(1)
+  static final DropwizardAppExtension<KeyMgmtBundleTestConfig> apiToImplDW =
+      new DropwizardAppExtension<>(
+          ApiToImplTestApp.class,
+          resourceFilePath("test-config.yml"),
+          ConfigOverride.config("keyMgmt.apiKeysDefinitionPath", resourceFilePath("keys")),
+          ConfigOverride.config("keyMgmt.mappingDefinitionPath", resourceFilePath("mappings")));
+
+  @RegisterExtension
+  @Order(2)
+  static final DropwizardAppExtension<KeyMgmtBundleTestConfig> implToApiDW =
+      new DropwizardAppExtension<>(
+          ImplToApiTestApp.class,
+          resourceFilePath("test-config.yml"),
+          ConfigOverride.config("keyMgmt.apiKeysDefinitionPath", resourceFilePath("keys")),
+          ConfigOverride.config("keyMgmt.mappingDefinitionPath", resourceFilePath("mappings")));
+
+  private static KeyMgmtBundle<KeyMgmtBundleTestConfig> bidirectionalKeyMgmtBundle;
+
+  private static KeyMgmtBundle<KeyMgmtBundleTestConfig> apiToImplKeyMgmtBundle;
+
+  private static KeyMgmtBundle<KeyMgmtBundleTestConfig> implToApiKeyMgmtBundle;
+
+  @BeforeAll
+  static void init() {
+    bidirectionalKeyMgmtBundle =
+        ((BidirectionalTestApp) bidirectionalDW.getApplication()).getKeyMgmtBundle();
+    assertThat(bidirectionalKeyMgmtBundle).isNotNull();
+    apiToImplKeyMgmtBundle = ((ApiToImplTestApp) apiToImplDW.getApplication()).getKeyMgmtBundle();
+    assertThat(apiToImplKeyMgmtBundle).isNotNull();
+    implToApiKeyMgmtBundle = ((ImplToApiTestApp) implToApiDW.getApplication()).getKeyMgmtBundle();
+    assertThat(implToApiKeyMgmtBundle).isNotNull();
+  }
+
+  @Test
+  void shouldMapBiDirectionalMappings() {
+    KeyMapper keyMapper = bidirectionalKeyMgmtBundle.createKeyMapper("BIDIRECTIONAL_ONLY");
+    // success case
+    assertThat(keyMapper.toImpl("A")).isEqualTo("B");
+    assertThat(keyMapper.toApi("B")).isEqualTo("A");
+    // fail case
+    assertThat(keyMapper.toImpl("B")).isEqualTo("UNKNOWN_KEY_VALUE");
+    assertThat(keyMapper.toApi("A")).isEqualTo("UNKNOWN_KEY_VALUE");
+  }
+
+  @Test
+  void shouldMapApiToImplMappings() {
+    KeyMapper keyMapper = apiToImplKeyMgmtBundle.createKeyMapper("BIDIRECTIONAL_ONLY");
+    // success case
+    assertThat(keyMapper.toImpl("A")).isEqualTo("B");
+    // fail case
+    assertThat(keyMapper.toImpl("B")).isEqualTo("UNKNOWN_KEY_VALUE");
+  }
+
+  @Test
+  void shouldMapImplToApiMappings() {
+    KeyMapper keyMapper = implToApiKeyMgmtBundle.createKeyMapper("BIDIRECTIONAL_ONLY");
+    // success case
+    assertThat(keyMapper.toApi("B")).isEqualTo("A");
+    // fail case
+    assertThat(keyMapper.toApi("A")).isEqualTo("UNKNOWN_KEY_VALUE");
+  }
+
+  public static class BidirectionalTestApp extends Application<KeyMgmtBundleTestConfig> {
+
+    private final KeyMgmtBundle<KeyMgmtBundleTestConfig> keyMgmt =
+        KeyMgmtBundle.builder()
+            .withKeyMgmtConfigProvider(KeyMgmtBundleTestConfig::getKeyMgmt)
+            .withFailStrategy(KeyMgmtBundle.FailStrategy.PLACEHOLDER_BIDIRECTIONAL)
+            .build();
+
+    @Override
+    public void initialize(Bootstrap<KeyMgmtBundleTestConfig> bootstrap) {
+      bootstrap.addBundle(keyMgmt);
+    }
+
+    @Override
+    public void run(KeyMgmtBundleTestConfig configuration, Environment environment) {
+      // nothing here
+    }
+
+    public KeyMgmtBundle<KeyMgmtBundleTestConfig> getKeyMgmtBundle() {
+      return keyMgmt;
+    }
+  }
+
+  public static class ApiToImplTestApp extends Application<KeyMgmtBundleTestConfig> {
+
+    private final KeyMgmtBundle<KeyMgmtBundleTestConfig> keyMgmt =
+        KeyMgmtBundle.builder()
+            .withKeyMgmtConfigProvider(KeyMgmtBundleTestConfig::getKeyMgmt)
+            .withFailStrategy(KeyMgmtBundle.FailStrategy.PLACEHOLDER_API_TO_IMPL)
+            .build();
+
+    @Override
+    public void initialize(Bootstrap<KeyMgmtBundleTestConfig> bootstrap) {
+      bootstrap.addBundle(keyMgmt);
+    }
+
+    @Override
+    public void run(KeyMgmtBundleTestConfig configuration, Environment environment) {
+      // nothing here
+    }
+
+    public KeyMgmtBundle<KeyMgmtBundleTestConfig> getKeyMgmtBundle() {
+      return keyMgmt;
+    }
+  }
+
+  public static class ImplToApiTestApp extends Application<KeyMgmtBundleTestConfig> {
+
+    private final KeyMgmtBundle<KeyMgmtBundleTestConfig> keyMgmt =
+        KeyMgmtBundle.builder()
+            .withKeyMgmtConfigProvider(KeyMgmtBundleTestConfig::getKeyMgmt)
+            .withFailStrategy(KeyMgmtBundle.FailStrategy.PLACEHOLDER_IMPL_TO_API)
+            .build();
+
+    @Override
+    public void initialize(Bootstrap<KeyMgmtBundleTestConfig> bootstrap) {
+      bootstrap.addBundle(keyMgmt);
+    }
+
+    @Override
+    public void run(KeyMgmtBundleTestConfig configuration, Environment environment) {
+      // nothing here
+    }
+
+    public KeyMgmtBundle<KeyMgmtBundleTestConfig> getKeyMgmtBundle() {
+      return keyMgmt;
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a fail strategy to the key management system that uses predefined default values when specific key mappings are missing. The changes ought to be backward compatible.