### PR TITLE
fix: add uuid to IssuerClient oidc-client name for unique metric

### DIFF
--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/OidcClient.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/OidcClient.java
@@ -40,6 +40,26 @@ public class OidcClient {
     this.cache = Caffeine.newBuilder().expireAfter(new AfterCreateExpiry()).build();
   }
 
+  public OidcClient(ClientFactory clientFactory, OidcConfiguration config, String clientName) {
+    this.config = config;
+
+    if (config.isDisabled()) {
+      LOGGER.warn("OIDC was disabled.");
+      this.cache = null;
+      this.issuerClient = null;
+      return;
+    }
+
+    this.issuerClient = new IssuerClient(clientFactory, config, clientName);
+
+    if (config.getCache().isDisabled()) {
+      this.cache = null;
+      return;
+    }
+
+    this.cache = Caffeine.newBuilder().expireAfter(new AfterCreateExpiry()).build();
+  }
+
   /**
    * Retrieves a new access token from the token endpoint using the given {@link OidcConfiguration}.
    *

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/filter/OidcRequestFilter.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/filter/OidcRequestFilter.java
@@ -36,6 +36,19 @@ public class OidcRequestFilter implements ClientRequestFilter {
     }
   }
 
+  public OidcRequestFilter(
+      ClientFactory clientFactory,
+      OidcConfiguration oidc,
+      boolean authenticationPassthrough,
+      String clientName) {
+    if (authenticationPassthrough) {
+      authHeaderClientFilter = new AuthHeaderClientFilter();
+    }
+    if (!oidc.isDisabled()) {
+      this.oidcClient = new OidcClient(clientFactory, oidc, clientName);
+    }
+  }
+
   @Override
   public void filter(ClientRequestContext requestContext) {
     // Passing on existing tokens has precedence over creating new ones

--- a/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/rest/IssuerClient.java
+++ b/sda-commons-client-jersey/src/main/java/org/sdase/commons/client/jersey/oidc/rest/IssuerClient.java
@@ -25,6 +25,19 @@ public class IssuerClient {
   private final Client client;
   private final OpenIdDiscoveryApi discoveryApi;
 
+  public IssuerClient(ClientFactory clientFactory, OidcConfiguration config, String clientName) {
+    this.config = config;
+
+    this.client =
+        clientFactory.externalClient(config.getHttpClient()).buildGenericClient(clientName);
+
+    this.discoveryApi =
+        createProxy(
+            OpenIdDiscoveryApi.class,
+            WebResourceFactory.newResource(
+                OpenIdDiscoveryApi.class, client.target(config.getIssuerUrl())));
+  }
+
   public IssuerClient(ClientFactory clientFactory, OidcConfiguration config) {
     this.config = config;
 


### PR DESCRIPTION
We need to call "new OidcRequestFilter(jerseyClientBundle.getClientFactory(), oidcConfiguration, false);" multiple times in our service as there can be multiple Oidc. 

The code currently returns the following error: 
A metric named org.apache.hc.client5.http.io.HttpClientConnectionManager.oidc-client.available-connections already exists
java.lang.IllegalArgumentException: A metric named org.apache.hc.client5.http.io.HttpClientConnectionManager.oidc-client.available-connections already exists

We need a unique name for the oidc-client so that the error no longer occurs.