### PR TITLE
SCM-1392: adapted RetryProcessingErrorMLS to support a max. number of…

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/retryprocessingerror/RetryCounter.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/retryprocessingerror/RetryCounter.java
@@ -1,0 +1,65 @@
+package org.sdase.commons.server.kafka.consumer.strategies.retryprocessingerror;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * Helper class counting the number of executions for a given record.
+ *
+ * <p>Internally it increases a counter for the current offset of the record as long as the offset
+ * remains the same. If the offset changes, the counter is reset to 0.
+ */
+public class RetryCounter {
+  private final Map<Integer, OffsetCounter> offsetCountersByPartition =
+      Collections.synchronizedMap(new HashMap<>());
+
+  private final long maxRetryCount;
+
+  public RetryCounter(long maxRetryCount) {
+    this.maxRetryCount = maxRetryCount;
+  }
+
+  public void incErrorCount(ConsumerRecord<?, ?> consumerRecord) {
+    getOffsetCounterInternal(consumerRecord).inc();
+  }
+
+  public boolean isMaxRetryCountReached(ConsumerRecord<?, ?> consumerRecord) {
+    long counter = getOffsetCounter(consumerRecord);
+    return counter > maxRetryCount;
+  }
+
+  public long getOffsetCounter(ConsumerRecord<?, ?> consumerRecord) {
+    return getOffsetCounterInternal(consumerRecord).count;
+  }
+
+  public long getMaxRetryCount() {
+    return maxRetryCount;
+  }
+
+  private OffsetCounter getOffsetCounterInternal(ConsumerRecord<?, ?> consumerRecord) {
+    OffsetCounter counter =
+        offsetCountersByPartition.computeIfAbsent(
+            consumerRecord.partition(), k -> new OffsetCounter(0));
+    if (counter.offset != consumerRecord.offset()) {
+      counter.offset = consumerRecord.offset();
+      counter.count = 0;
+    }
+    return counter;
+  }
+
+  private static class OffsetCounter {
+    private long offset = 0;
+    private long count = 0;
+
+    public OffsetCounter(long offset) {
+      this.offset = offset;
+      this.count = 0;
+    }
+
+    public long inc() {
+      return ++count;
+    }
+  }
+}

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/retryprocessingerror/RetryProcessingErrorMLS.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/retryprocessingerror/RetryProcessingErrorMLS.java
@@ -3,6 +3,7 @@ package org.sdase.commons.server.kafka.consumer.strategies.retryprocessingerror;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -27,12 +28,27 @@ public class RetryProcessingErrorMLS<K, V> extends MessageListenerStrategy<K, V>
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryProcessingErrorMLS.class);
   private final MessageHandler<K, V> handler;
-  private final ErrorHandler<K, V> errorHandler;
+  private final ErrorHandler<K, V> intermediateErrorHandler;
+  private final ErrorHandler<K, V> finalErrorHandler;
+  private final long maxRetryCount;
   private String consumerName;
+  private Map<TopicPartition, OffsetCounter> offsetCounters =
+      Collections.synchronizedMap(new HashMap<>());
 
-  public RetryProcessingErrorMLS(MessageHandler<K, V> handler, ErrorHandler<K, V> errorHandler) {
+  public RetryProcessingErrorMLS(
+      MessageHandler<K, V> handler, ErrorHandler<K, V> intermediateErrorHandler) {
+    this(handler, intermediateErrorHandler, Long.MAX_VALUE, null);
+  }
+
+  public RetryProcessingErrorMLS(
+      MessageHandler<K, V> handler,
+      ErrorHandler<K, V> intermediateErrorHandler,
+      long maxRetryCount,
+      ErrorHandler<K, V> finalErrorHandler) {
     this.handler = handler;
-    this.errorHandler = errorHandler;
+    this.intermediateErrorHandler = intermediateErrorHandler;
+    this.maxRetryCount = maxRetryCount;
+    this.finalErrorHandler = finalErrorHandler;
   }
 
   @Override
@@ -57,9 +73,7 @@ public class RetryProcessingErrorMLS<K, V> extends MessageListenerStrategy<K, V>
         try {
           Instant timerStart = Instant.now();
           handler.handle(consumerRecord);
-          // mark last successful processed record for commit
-          lastCommitOffset = new OffsetAndMetadata(consumerRecord.offset() + 1);
-          addOffsetToCommitOnClose(consumerRecord);
+          lastCommitOffset = markConsumerRecordProcessed(consumerRecord);
 
           Instant timerEnd = Instant.now();
           if (LOGGER.isTraceEnabled()) {
@@ -71,20 +85,25 @@ public class RetryProcessingErrorMLS<K, V> extends MessageListenerStrategy<K, V>
           }
 
         } catch (RuntimeException e) {
-          LOGGER.error(
-              "Error while handling record {} in message handler {}",
-              consumerRecord.key(),
-              handler.getClass(),
-              e);
-          boolean shouldContinue = errorHandler.handleError(consumerRecord, e, consumer);
-          if (!shouldContinue) {
-            throw new StopListenerException(e);
-          } else {
-            LOGGER.warn(
-                "Error while handling record {} in message handler {}, will be retried",
+          long retryCount = getOffsetCounter(partition, consumerRecord.offset()).inc();
+          if (retryCount > maxRetryCount) {
+            LOGGER.error(
+                "Error while handling record {} in message handler {}, no more retries",
                 consumerRecord.key(),
                 handler.getClass(),
                 e);
+
+            callErrorHandler(finalErrorHandler, consumerRecord, e, consumer);
+            lastCommitOffset = markConsumerRecordProcessed(consumerRecord);
+          } else {
+            LOGGER.warn(
+                "Error while handling record {} in message handler {}, will be retried (%s / %s)..."
+                    .formatted(retryCount, maxRetryCount),
+                consumerRecord.key(),
+                handler.getClass(),
+                e);
+
+            callErrorHandler(intermediateErrorHandler, consumerRecord, e, consumer);
 
             // seek to the current offset of the failing record for retry
             consumer.seek(partition, consumerRecord.offset());
@@ -103,6 +122,48 @@ public class RetryProcessingErrorMLS<K, V> extends MessageListenerStrategy<K, V>
     if (Boolean.TRUE.equals(Boolean.valueOf(config.getOrDefault("enable.auto.commit", "true")))) {
       throw new ConfigurationException(
           "The strategy should commit explicitly by partition but property 'enable.auto.commit' in consumer config is set to 'true'");
+    }
+  }
+
+  private void callErrorHandler(
+      ErrorHandler<K, V> errorHandler,
+      ConsumerRecord<K, V> consumerRecord,
+      RuntimeException e,
+      KafkaConsumer<K, V> consumer) {
+    if (errorHandler != null) {
+      boolean shouldContinue = errorHandler.handleError(consumerRecord, e, consumer);
+      if (!shouldContinue) {
+        throw new StopListenerException(e);
+      }
+    }
+  }
+
+  private OffsetAndMetadata markConsumerRecordProcessed(ConsumerRecord<K, V> consumerRecord) {
+    addOffsetToCommitOnClose(consumerRecord);
+    return new OffsetAndMetadata(consumerRecord.offset() + 1);
+  }
+
+  private OffsetCounter getOffsetCounter(TopicPartition partition, long offset) {
+    OffsetCounter counter = offsetCounters.computeIfAbsent(partition, k -> new OffsetCounter(0));
+    if (counter.offset != offset) {
+      counter.offset = offset;
+      counter.count = 0;
+    }
+
+    return counter;
+  }
+
+  public static class OffsetCounter {
+    private long offset = 0;
+    private long count = 0;
+
+    public OffsetCounter(long offset) {
+      this.offset = offset;
+      this.count = 0;
+    }
+
+    public long inc() {
+      return ++count;
     }
   }
 }

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyIT.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyIT.java
@@ -1,0 +1,210 @@
+package org.sdase.commons.server.kafka.consumer;
+
+import static io.dropwizard.testing.ConfigOverride.config;
+import static io.dropwizard.testing.ResourceHelpers.resourceFilePath;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.*;
+
+import com.salesforce.kafka.test.junit5.SharedKafkaTestResource;
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import java.util.*;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.sdase.commons.server.kafka.KafkaBundle;
+import org.sdase.commons.server.kafka.KafkaBundleConsts;
+import org.sdase.commons.server.kafka.builder.MessageListenerRegistration;
+import org.sdase.commons.server.kafka.builder.ProducerRegistration;
+import org.sdase.commons.server.kafka.config.ConsumerConfig;
+import org.sdase.commons.server.kafka.consumer.strategies.retryprocessingerror.RetryProcessingErrorMLS;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestApplication;
+import org.sdase.commons.server.kafka.dropwizard.KafkaTestConfiguration;
+
+class RetryProcessingErrorStrategyIT {
+  private static final String TOPIC_NAME = "some-topic";
+
+  private static final int MAX_RETRIES = 2;
+
+  @RegisterExtension
+  @Order(0)
+  public static final SharedKafkaTestResource KAFKA =
+      new SharedKafkaTestResource()
+          .withBrokers(1)
+          .withBrokerProperty("offsets.topic.num.partitions", "3")
+          // we don't need to wait that a consumer group rebalances since we always start with a
+          // fresh kafka instance
+          .withBrokerProperty("group.initial.rebalance.delay.ms", "0");
+
+  @RegisterExtension
+  @Order(1)
+  static final DropwizardAppExtension<KafkaTestConfiguration> DROPWIZARD_APP_EXTENSION =
+      new DropwizardAppExtension<>(
+          KafkaTestApplication.class,
+          resourceFilePath("test-config-default.yml"),
+          config("kafka.brokers", KAFKA::getKafkaConnectString));
+
+  private static KafkaProducer<String, String> stringStringProducer;
+
+  private static MessageHandler<String, String> messageHandler = mock(MessageHandler.class);
+
+  private static ErrorHandler<String, String> errorHandler = mock(ErrorHandler.class);
+  private static ErrorHandler<String, String> finalErrorHandler = mock(ErrorHandler.class);
+
+  @BeforeAll
+  static void beforeAll() {
+    KAFKA.getKafkaTestUtils().createTopic(TOPIC_NAME, 3, Short.parseShort("1"));
+
+    KafkaTestApplication testApplication = DROPWIZARD_APP_EXTENSION.getApplication();
+    KafkaBundle<KafkaTestConfiguration> kafkaBundle = testApplication.kafkaBundle();
+    kafkaBundle.createMessageListener(
+        MessageListenerRegistration.builder()
+            .withDefaultListenerConfig()
+            .forTopic(TOPIC_NAME)
+            .withConsumerConfig(
+                ConsumerConfig.builder()
+                    .addConfig("max.poll.records", "1")
+                    .addConfig("auto.commit.interval.ms", "1")
+                    .addConfig("enable.auto.commit", "false")
+                    .build())
+            .withValueDeserializer(new StringDeserializer())
+            .withListenerStrategy(
+                new RetryProcessingErrorMLS<>(
+                    messageHandler, errorHandler, MAX_RETRIES, finalErrorHandler))
+            .build());
+
+    kafkaBundle.registerProducer(
+        ProducerRegistration.builder()
+            .forTopic(TOPIC_NAME)
+            .withDefaultProducer()
+            .withKeySerializer(new StringSerializer())
+            .withValueSerializer(new StringSerializer())
+            .build());
+
+    stringStringProducer =
+        KAFKA.getKafkaTestUtils().getKafkaProducer(StringSerializer.class, StringSerializer.class);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    stringStringProducer.close();
+  }
+
+  @BeforeEach
+  void setup() {
+    reset(messageHandler, errorHandler, finalErrorHandler);
+    when(errorHandler.handleError(any(), any(), any())).thenReturn(true);
+    when(finalErrorHandler.handleError(any(), any(), any())).thenReturn(true);
+  }
+
+  @Test
+  void shouldStopRetryingAfterMaxRetries() {
+    configureFailCountPerMessage(Integer.MAX_VALUE);
+    sendMessages(1);
+
+    await()
+        .atMost(KafkaBundleConsts.N_MAX_WAIT_MS, MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              assertHandlerCalledWithMessage(1, MAX_RETRIES);
+              verify(errorHandler, times(MAX_RETRIES)).handleError(any(), any(), any());
+              verify(finalErrorHandler, times(1)).handleError(any(), any(), any());
+            });
+  }
+
+  @Test
+  void shouldStopRetryingAfterMaxRetriesWhenUsingMultiplePartitions() {
+    int noOfMessages = 50;
+    configureFailCountPerMessage(Integer.MAX_VALUE);
+    sendMessages(noOfMessages);
+
+    await()
+        .atMost(30, SECONDS)
+        .untilAsserted(
+            () -> {
+              assertHandlerCalledWithMessage(noOfMessages, MAX_RETRIES);
+              verify(errorHandler, times(MAX_RETRIES * noOfMessages))
+                  .handleError(any(), any(), any());
+              verify(finalErrorHandler, times(noOfMessages)).handleError(any(), any(), any());
+            });
+  }
+
+  @Test
+  void shouldStopRetryingWhenMessagesIsSuccessfulAndUsingMultiplePartitions() {
+    int failCount = 1;
+    int noOfMessages = 20;
+
+    configureFailCountPerMessage(failCount);
+    sendMessages(noOfMessages);
+
+    await()
+        .atMost(KafkaBundleConsts.N_MAX_WAIT_MS, MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              assertHandlerCalledWithMessage(noOfMessages, failCount);
+              verify(errorHandler, times(noOfMessages * failCount))
+                  .handleError(any(), any(), any());
+              verifyNoInteractions(finalErrorHandler);
+            });
+  }
+
+  /**
+   * Configure the messageHandler mock to fail each message a given number of times before
+   * succeeding
+   */
+  private void configureFailCountPerMessage(int failCount) {
+    Map<String, Integer> errorCount = new HashMap<>();
+    doAnswer(
+            invocation -> {
+              ConsumerRecord<String, String> consumerRecord = invocation.getArgument(0);
+              String key = consumerRecord.value();
+              Integer myErrors = errorCount.get(key);
+              if (myErrors == null) {
+                myErrors = 0;
+                errorCount.put(key, myErrors);
+              }
+              if (myErrors < failCount) {
+                errorCount.put(key, myErrors + 1);
+                throw new RuntimeException("Simulated processing error");
+              }
+              return null;
+            })
+        .when(messageHandler)
+        .handle(any(ConsumerRecord.class));
+  }
+
+  private void assertHandlerCalledWithMessage(int noOfMessages, int failCount) {
+    ArgumentCaptor<ConsumerRecord<String, String>> captor =
+        ArgumentCaptor.forClass(ConsumerRecord.class);
+    Mockito.verify(messageHandler, atLeast(1)).handle(captor.capture());
+
+    List<ConsumerRecord<String, String>> capturedRecords = captor.getAllValues();
+    List<String> capturedMessages = capturedRecords.stream().map(ConsumerRecord::value).toList();
+
+    List<String> expectedMessages = new ArrayList<>();
+    for (int i = 0; i < noOfMessages; i++) {
+      for (int j = 0;
+          j < failCount + 1;
+          j++) { // +1 because the message will be executed as least once
+        expectedMessages.add("test message " + i);
+      }
+    }
+
+    assertThat(capturedMessages).containsExactlyInAnyOrderElementsOf(expectedMessages);
+  }
+
+  private void sendMessages(int noOfMessages) {
+    for (int i = 0; i < noOfMessages; i++) {
+      String key = UUID.randomUUID().toString();
+      stringStringProducer.send(new ProducerRecord<>(TOPIC_NAME, key, "test message " + i));
+    }
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyTest.java
@@ -1,0 +1,133 @@
+package org.sdase.commons.server.kafka.consumer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.*;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.sdase.commons.server.kafka.consumer.strategies.retryprocessingerror.RetryProcessingErrorMLS;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RetryProcessingErrorStrategyTest {
+  private static final long MAX_RETRIES = 2;
+
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition("topic", 0);
+
+  @Mock private MessageHandler<String, String> messageHandler;
+  @Mock private ErrorHandler<String, String> intermediateErrorHandler;
+  @Mock private ErrorHandler<String, String> finalErrorHandler;
+  @Mock private KafkaConsumer<String, String> consumer;
+
+  private RetryProcessingErrorMLS<String, String> strategy;
+
+  @BeforeEach
+  void init() {
+    when(intermediateErrorHandler.handleError(any(), any(), any())).thenReturn(true);
+    when(finalErrorHandler.handleError(any(), any(), any())).thenReturn(true);
+    strategy =
+        new RetryProcessingErrorMLS<>(
+            messageHandler, intermediateErrorHandler, MAX_RETRIES, finalErrorHandler);
+  }
+
+  @Test
+  void shouldCallMessageHandler() {
+    ConsumerRecords<String, String> records = createConsumerRecords(2);
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(1));
+    verifyNoMoreInteractions(messageHandler);
+    verifyNoInteractions(intermediateErrorHandler, finalErrorHandler);
+  }
+
+  @Test
+  void shouldCallMessageHandlerMultipleTimesOnError() {
+    ConsumerRecords<String, String> records = createConsumerRecords(2);
+    RuntimeException exception = new RuntimeException("Test");
+
+    // we fail in first call
+    doThrow(exception).when(messageHandler).handle(any());
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(intermediateErrorHandler)
+        .handleError(records.records(TOPIC_PARTITION).get(0), exception, consumer);
+    verifyNoMoreInteractions(messageHandler, intermediateErrorHandler);
+    verifyNoInteractions(finalErrorHandler);
+
+    // second call is fine
+    doNothing().when(messageHandler).handle(any());
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler, times(2)).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(1));
+    verifyNoMoreInteractions(messageHandler, intermediateErrorHandler);
+    verifyNoInteractions(finalErrorHandler);
+  }
+
+  @Test
+  void shouldStopCallingAfterMaxRetries() {
+    ConsumerRecords<String, String> records = createConsumerRecords(2);
+    RuntimeException exception = new RuntimeException("Test");
+
+    // we fail in first call
+    doThrow(exception).when(messageHandler).handle(any());
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(intermediateErrorHandler)
+        .handleError(records.records(TOPIC_PARTITION).get(0), exception, consumer);
+    verifyNoMoreInteractions(messageHandler, intermediateErrorHandler);
+    verifyNoInteractions(finalErrorHandler);
+
+    // we fail in second call
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler, times(2)).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(intermediateErrorHandler, times(2))
+        .handleError(records.records(TOPIC_PARTITION).get(0), exception, consumer);
+    verifyNoMoreInteractions(messageHandler, intermediateErrorHandler);
+    verifyNoInteractions(finalErrorHandler);
+
+    // and we fail in third (last) call
+    strategy.processRecords(records, consumer);
+
+    verify(messageHandler, times(3)).handle(records.records(TOPIC_PARTITION).get(0));
+    verify(intermediateErrorHandler, times(2))
+        .handleError(records.records(TOPIC_PARTITION).get(0), exception, consumer);
+    verify(finalErrorHandler)
+        .handleError(records.records(TOPIC_PARTITION).get(0), exception, consumer);
+
+    // as the first record has been thrown away, the second now can also be processed (due to mock,
+    // preparation it will also fail)
+    verify(messageHandler).handle(records.records(TOPIC_PARTITION).get(1));
+    verify(intermediateErrorHandler)
+        .handleError(records.records(TOPIC_PARTITION).get(1), exception, consumer);
+
+    verifyNoMoreInteractions(messageHandler, intermediateErrorHandler);
+    verifyNoMoreInteractions(finalErrorHandler);
+  }
+
+  static ConsumerRecords<String, String> createConsumerRecords(int noMessages) {
+    Map<TopicPartition, List<ConsumerRecord<String, String>>> payload = new HashMap<>();
+
+    String topic = TOPIC_PARTITION.topic();
+    List<ConsumerRecord<String, String>> messages = new ArrayList<>();
+    for (int i = 0; i < noMessages; i++) {
+      messages.add(new ConsumerRecord<>(topic, 0, i, topic, "message-" + i));
+    }
+    payload.put(TOPIC_PARTITION, messages);
+    return new ConsumerRecords<>(payload);
+  }
+}

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/RetryProcessingErrorStrategyTest.java
@@ -125,7 +125,8 @@ class RetryProcessingErrorStrategyTest {
     String topic = TOPIC_PARTITION.topic();
     List<ConsumerRecord<String, String>> messages = new ArrayList<>();
     for (int i = 0; i < noMessages; i++) {
-      messages.add(new ConsumerRecord<>(topic, 0, i, topic, "message-" + i));
+      messages.add(
+          new ConsumerRecord<>(topic, TOPIC_PARTITION.partition(), i, topic, "message-" + i));
     }
     payload.put(TOPIC_PARTITION, messages);
     return new ConsumerRecords<>(payload);


### PR DESCRIPTION
This PR add the ability to do a defined amount of retries before giving up to `RetryProcessingErrorMLS`.

The idea is:
- Count the number of processing a specific offset for a given partition
- If that number matches the max number of retries, mark increase the offset and do some error handling
- For the error handling there are now 2 errorhandlers:
  - intermediateErrorHandler is called after each failed processing
  - finalErrorHandler is called when no more retries are left