### PR TITLE
Revert of mongodb driver update because of incompatibility with AWS DocumentDB 4

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -26,7 +26,7 @@ ext {
   openTelemetryVersion = '1.41.0'
   openTelemetryAlpha2Version = '2.15.0-alpha'
   // should be aligned with transitive dependency of Spring Data MongoDB
-  mongoDbDriverVersion = '5.5.0'
+  mongoDbDriverVersion = '5.4.0'
   tuprologVersion = '0.20.9' // don't upgrade separately! use version from database-rider
   bouncyCastleVersion = '1.80'
   victoolsVersion = '4.38.0'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -26,7 +26,7 @@ ext {
   openTelemetryVersion = '1.41.0'
   openTelemetryAlpha2Version = '2.15.0-alpha'
   // should be aligned with transitive dependency of Spring Data MongoDB
-  mongoDbDriverVersion = '5.4.0'
+  mongoDbDriverVersion = '5.4.0' // 5.5.0 incompatible with AWS DocumentDB 4
   tuprologVersion = '0.20.9' // don't upgrade separately! use version from database-rider
   bouncyCastleVersion = '1.80'
   victoolsVersion = '4.38.0'


### PR DESCRIPTION
In tests with the latest commons version, wee errors:

> com.mongodb.MongoIncompatibleDriverException: Server at ****:27017 reports wire version 7, but this version of the driver requires at least 8 (MongoDB 4.2)

We may Drop support for AWS DocumentDB 4 later.