### PR TITLE
ci: update info.version in openapi.yaml with semver-release

### DIFF
--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiFileHelper.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/server/openapi/OpenApiFileHelper.java
@@ -26,6 +26,21 @@ public class OpenApiFileHelper {
     LinkedHashMap<String, Object> yamlMap =
         YamlUtil.load(yaml, new TypeReference<LinkedHashMap<String, Object>>() {});
     yamlMap.remove("servers");
+    yamlMap.get("info");
+    return YamlUtil.writeValueAsString(yamlMap);
+  }
+
+  /**
+   * Remove version from the info field from a textual OpenApi in the {@code yaml} format
+   * so that it is ignored during comparison .
+   *
+   * @param yaml the content of the {@code openapi.yaml} file
+   * @return the cleaned up {@code yaml}
+   */
+  public static String removeInfoVersionFromOpenApiYaml(String yaml) {
+    LinkedHashMap<String, Object> yamlMap =
+        YamlUtil.load(yaml, new TypeReference<LinkedHashMap<String, Object>>() {});
+    ((LinkedHashMap<String, Object>) yamlMap.get("info")).remove("version");
     return YamlUtil.writeValueAsString(yamlMap);
   }
 }

--- a/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/GoldenFileAssertions.java
+++ b/sda-commons-server-testing/src/main/java/org/sdase/commons/server/testing/GoldenFileAssertions.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
+import org.sdase.commons.server.openapi.OpenApiFileHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,12 +158,13 @@ public class GoldenFileAssertions extends AbstractAssert<GoldenFileAssertions, P
     try {
       // assert if exists
       Assertions.assertThat(actual).as(ASSERTION_TEXT, fileName, fileName, fileName).exists();
+      String actualAsString = new String(Files.readAllBytes(actual));
 
       // assert YAML / JSON
       ObjectMapper objectMapper = Jackson.newObjectMapper(new YAMLFactory());
-      Assertions.assertThat(objectMapper.readTree(actual.toFile()))
+      Assertions.assertThat(objectMapper.readTree(OpenApiFileHelper.removeInfoVersionFromOpenApiYaml(actualAsString)))
           .as(ASSERTION_TEXT, fileName, fileName, fileName)
-          .isEqualTo(objectMapper.readTree(expected));
+          .isEqualTo(objectMapper.readTree(OpenApiFileHelper.removeInfoVersionFromOpenApiYaml(expected)));
     } finally {
       // eventually update the file content
       if (ciUtil.isRunningInCiPipeline()) {


### PR DESCRIPTION
Add new utility method so that the api version is ignored when comparing the files