### PR TITLE
fix(deps): bump org.springframework.data:spring-data-mongodb from 4.1…

### DIFF
--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -120,7 +120,7 @@ dependencies {
     api "it.unibo.tuprolog:parser-theory-jvm:$tuprologVersion"
 
     // sda-commons-server-mongo-testing, sda-commons-server-spring-data-mongo
-    api 'org.springframework.data:spring-data-mongodb:4.1.12' // Keep that version for now, since 4.2.0 introduces a bug
+    api 'org.springframework.data:spring-data-mongodb:4.5.4'
     api "de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.11.1"
     api "io.opentelemetry.instrumentation:opentelemetry-mongo-3.1:${openTelemetryAlpha2Version}"
     // check if commons-compress management is still needed after flapdoodle upgrade

--- a/sda-commons-server-spring-data-mongo/build.gradle
+++ b/sda-commons-server-spring-data-mongo/build.gradle
@@ -1,5 +1,6 @@
-configurations {
-  all*.exclude group: 'org.springframework', module: 'spring-jcl' // clashes with jcl-over-slf4j
+configurations.all {
+  exclude group: 'org.springframework', module: 'spring-jcl' // clashes with jcl-over-slf4j
+  exclude group: 'io.micrometer', module: 'micrometer-observation'
 }
 
 dependencies {


### PR DESCRIPTION
….12 to 4.5.4

Hello SDA SE,

Mend whitesource scan detected a vulnerability of high severity in the spring libraries (spring-core-6.0.20.jar), therefore we need to bump the spring data mongo dependency.