### PR TITLE
fix(security): write obscured errors as JSON

### DIFF
--- a/sda-commons-server-security/src/main/java/org/sdase/commons/server/security/handler/ObscuringErrorHandler.java
+++ b/sda-commons-server-security/src/main/java/org/sdase/commons/server/security/handler/ObscuringErrorHandler.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.MediaType;
 import java.nio.ByteBuffer;
-import org.apache.commons.lang3.SerializationUtils;
+import java.nio.charset.StandardCharsets;
 import org.eclipse.jetty.ee10.servlet.ErrorHandler;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.server.Request;
@@ -40,7 +40,7 @@ public class ObscuringErrorHandler extends ErrorHandler {
     int status = response.getStatus();
     String bodyContent = errorBody(status);
 
-    ByteBuffer byteBuffer = ByteBuffer.wrap(SerializationUtils.serialize(bodyContent));
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bodyContent.getBytes(StandardCharsets.UTF_8));
     response.setStatus(status);
     response.write(true, byteBuffer, callback);
     return true;

--- a/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/SecureBundleITest.java
+++ b/sda-commons-server-security/src/test/java/org/sdase/commons/server/security/SecureBundleITest.java
@@ -2,11 +2,13 @@ package org.sdase.commons.server.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.dropwizard.core.Configuration;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit5.DropwizardAppExtension;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sdase.commons.server.security.test.SecurityTestApp;
@@ -71,15 +73,20 @@ class SecureBundleITest extends AbstractSecurityTest<Configuration> {
   }
 
   @Test
-  void useCustomErrorPageHandlerForErrorPages() {
+  void useCustomErrorPageHandlerForErrorPages() throws Exception {
     try (Response response = getAppClient().path("404").request().get()) {
       assertThat(response.getStatus()).isEqualTo(404);
-      var content = response.readEntity(String.class);
+      assertThat(response.getMediaType()).isEqualTo(MediaType.APPLICATION_JSON_TYPE);
+      byte[] contentRaw = response.readEntity(byte[].class);
+      var content = new String(contentRaw, StandardCharsets.UTF_8);
       assertThat(content)
           .doesNotMatch(".*\"code\"\\s*:\\s*500.*") // no default exception mapper
           .doesNotContain("<html") // no html page
           .doesNotContain("<h1>") // no html page
           .doesNotContain("<h2>"); // no html page
+
+      var json = new ObjectMapper().readTree(content);
+      assertThat(json.path("title").asText()).isEqualTo("HTTP Error 404 occurred.");
     }
   }
 }


### PR DESCRIPTION
## Summary
- write obscured error responses as UTF-8 JSON bytes instead of Java-serialized String bytes
- keep the security error payload as a proper  JSON document
- strengthen the integration test to assert JSON content type and parseable JSON body

## Why
The Jetty 12 migration fixed the old  payload bug, but accidentally wrote Java serialization bytes to the response body. That made the response invalid for  clients.

## Testing
- 
