### PR TITLE
ci(cve-check): add concurrency group for cve checks

### DIFF
--- a/.github/workflows/cve-check-r8.yml
+++ b/.github/workflows/cve-check-r8.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: "23 4 * * *"
 
+concurrency:
+  group: cve-check-dropwizard
+  cancel-in-progress: false
+
 jobs:
   trivy-vulnerability-check:
     timeout-minutes: 30

--- a/.github/workflows/cve-check.yml
+++ b/.github/workflows/cve-check.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: "23 4 * * *"
 
+concurrency:
+  group: cve-check-dropwizard
+  cancel-in-progress: false
+
 jobs:
   trivy-vulnerability-check:
     timeout-minutes: 30


### PR DESCRIPTION
Background is, that the workflow can send multiple messages, should the output of trivy be too much. If the services run in parallel it can happen, that messages are send after a check they are not allign to.
