### PR TITLE
feat: add beforePoll hook to MessageListenerStrategy

### DIFF
--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/MessageListener.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/MessageListener.java
@@ -79,6 +79,9 @@ public class MessageListener<K, V> implements Runnable {
         // wait for the next poll interval
         waitForNextPoll();
 
+        // allow to run optional pre-poll logic
+        strategy.beforePoll(consumer);
+
         ConsumerRecords<K, V> records =
             consumer.poll(Duration.ofMillis(configuredPollIntervalMillis));
 

--- a/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/MessageListenerStrategy.java
+++ b/sda-commons-server-kafka/src/main/java/org/sdase/commons/server/kafka/consumer/strategies/MessageListenerStrategy.java
@@ -79,6 +79,20 @@ public abstract class MessageListenerStrategy<K, V> {
   public abstract void processRecords(ConsumerRecords<K, V> records, KafkaConsumer<K, V> consumer);
 
   /**
+   * A hook that is called once per poll cycle, right before the consumer polls for new records.
+   *
+   * <p>This enables strategies to perform periodic tasks, such as reacting to external signals,
+   * independently of the received records. The base implementation is empty to ensure backward
+   * compatibility.
+   *
+   * @param consumer The consumer instance, which can be manipulated (e.g., with {@code seek()})
+   *     before polling.
+   */
+  public void beforePoll(@SuppressWarnings("unused") KafkaConsumer<K, V> consumer) {
+    // Base implementation does nothing.
+  }
+
+  /**
    * Creates a context for the current {@link Thread} to handle a message with appropriate
    * information in {@link ThreadLocal}s.
    *

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerHookTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerHookTest.java
@@ -37,14 +37,16 @@ class MessageListenerHookTest {
     strategyMock = mock(MessageListenerStrategy.class);
     executorService = Executors.newSingleThreadExecutor();
 
-    when(consumerMock.partitionsFor(anyString())).thenReturn(Collections.singletonList(mock(PartitionInfo.class)));
+    when(consumerMock.partitionsFor(anyString()))
+        .thenReturn(Collections.singletonList(mock(PartitionInfo.class)));
     when(consumerMock.poll(any(Duration.class))).thenReturn(ConsumerRecords.empty());
 
-    messageListener = new MessageListener<>(
-        Collections.singletonList(TOPIC_NAME),
-        consumerMock,
-        ListenerConfig.getDefault(),
-        strategyMock);
+    messageListener =
+        new MessageListener<>(
+            Collections.singletonList(TOPIC_NAME),
+            consumerMock,
+            ListenerConfig.getDefault(),
+            strategyMock);
 
     verify(consumerMock).subscribe(anyCollection());
   }
@@ -77,10 +79,11 @@ class MessageListenerHookTest {
 
       await()
           .atMost(Duration.ofSeconds(5))
-          .untilAsserted(() -> {
-            inOrder.verify(strategyMock).beforePoll(consumerMock);
-            inOrder.verify(consumerMock).poll(any(Duration.class));
-          });
+          .untilAsserted(
+              () -> {
+                inOrder.verify(strategyMock).beforePoll(consumerMock);
+                inOrder.verify(consumerMock).poll(any(Duration.class));
+              });
 
     } finally {
       messageListener.stopConsumer();
@@ -89,18 +92,22 @@ class MessageListenerHookTest {
 
   @Test
   void shouldExecuteActionsWithinHook() {
-    doAnswer(invocation -> {
-      KafkaConsumer<String, String> consumer = invocation.getArgument(0);
-      consumer.seek(new TopicPartition(TOPIC_NAME, 0), 123L);
-      return null;
-    }).when(strategyMock).beforePoll(consumerMock);
+    doAnswer(
+            invocation -> {
+              KafkaConsumer<String, String> consumer = invocation.getArgument(0);
+              consumer.seek(new TopicPartition(TOPIC_NAME, 0), 123L);
+              return null;
+            })
+        .when(strategyMock)
+        .beforePoll(consumerMock);
 
     try {
       executorService.submit(messageListener);
 
       await()
           .atMost(Duration.ofSeconds(5))
-          .untilAsserted(() -> verify(consumerMock, atLeastOnce()).seek(any(TopicPartition.class), anyLong()));
+          .untilAsserted(
+              () -> verify(consumerMock, atLeastOnce()).seek(any(TopicPartition.class), anyLong()));
 
       InOrder inOrder = inOrder(strategyMock, consumerMock);
       inOrder.verify(strategyMock).beforePoll(consumerMock);

--- a/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerHookTest.java
+++ b/sda-commons-server-kafka/src/test/java/org/sdase/commons/server/kafka/consumer/MessageListenerHookTest.java
@@ -1,0 +1,114 @@
+package org.sdase.commons.server.kafka.consumer;
+
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.sdase.commons.server.kafka.config.ListenerConfig;
+import org.sdase.commons.server.kafka.consumer.strategies.MessageListenerStrategy;
+
+@SuppressWarnings("unchecked")
+class MessageListenerHookTest {
+
+  static final String TOPIC_NAME = "test-hook-topic";
+
+  KafkaConsumer<String, String> consumerMock;
+  MessageListenerStrategy<String, String> strategyMock;
+  MessageListener<String, String> messageListener;
+  ExecutorService executorService;
+
+  @BeforeEach
+  void setUp() {
+    consumerMock = mock(KafkaConsumer.class);
+    strategyMock = mock(MessageListenerStrategy.class);
+    executorService = Executors.newSingleThreadExecutor();
+
+    when(consumerMock.partitionsFor(anyString())).thenReturn(Collections.singletonList(mock(PartitionInfo.class)));
+    when(consumerMock.poll(any(Duration.class))).thenReturn(ConsumerRecords.empty());
+
+    messageListener = new MessageListener<>(
+        Collections.singletonList(TOPIC_NAME),
+        consumerMock,
+        ListenerConfig.getDefault(),
+        strategyMock);
+
+    verify(consumerMock).subscribe(anyCollection());
+  }
+
+  @AfterEach
+  void tearDown() {
+    messageListener.stopConsumer();
+    executorService.shutdown();
+  }
+
+  @Test
+  void shouldCallBeforePollHookInEachCycle() {
+    try {
+      executorService.submit(messageListener);
+
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> verify(strategyMock, atLeast(5)).beforePoll(consumerMock));
+
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+
+  @Test
+  void shouldCallBeforePollHookBeforePolling() {
+    try {
+      InOrder inOrder = inOrder(strategyMock, consumerMock);
+      executorService.submit(messageListener);
+
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> {
+            inOrder.verify(strategyMock).beforePoll(consumerMock);
+            inOrder.verify(consumerMock).poll(any(Duration.class));
+          });
+
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+
+  @Test
+  void shouldExecuteActionsWithinHook() {
+    doAnswer(invocation -> {
+      KafkaConsumer<String, String> consumer = invocation.getArgument(0);
+      consumer.seek(new TopicPartition(TOPIC_NAME, 0), 123L);
+      return null;
+    }).when(strategyMock).beforePoll(consumerMock);
+
+    try {
+      executorService.submit(messageListener);
+
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> verify(consumerMock, atLeastOnce()).seek(any(TopicPartition.class), anyLong()));
+
+      InOrder inOrder = inOrder(strategyMock, consumerMock);
+      inOrder.verify(strategyMock).beforePoll(consumerMock);
+      inOrder.verify(consumerMock).seek(new TopicPartition(TOPIC_NAME, 0), 123L);
+      inOrder.verify(consumerMock).poll(any(Duration.class));
+
+    } finally {
+      messageListener.stopConsumer();
+    }
+  }
+}


### PR DESCRIPTION
**What is the problem?**
Commit ee80de4 changed the MessageListener to only invoke `strategy.processRecords()` when `records.count() > 0`.
This prevents advanced strategies from performing periodic tasks on every poll cycle, such as reacting to external control signals (e.g., `pause()` or `seek()`) or managing internal state.

**How does this PR solve the problem?**
This PR introduces a new `beforePoll(KafkaConsumer<K, V> consumer)` hook to the `MessageListenerStrategy`. It is invoked in every `MessageListener` loop, right before `consumer.poll()`. The base implementation is empty, making this change fully backward-compatible.

This provides a clean, dedicated API for such pre-poll actions, removing the need for strategies to implement complex or inefficient workarounds.