### PR TITLE
Final dependency updates and CVE mitigation for Release 8.x.x

### DIFF
--- a/.github/workflows/ignore-policy.rego
+++ b/.github/workflows/ignore-policy.rego
@@ -12,6 +12,14 @@ ignore_cves := {
   "CVE-2026-2332",
   # Spring Context is just in the background because we use Spring Data MongoDB.
   "CVE-2024-38820",
+  # Jetty bound to Jetty 11 on this branch, no upgrade available
+  # consumers may upgrade to 11.0.31 with commercial support
+  # consumers of this library are likely not affected because we propagate bearer token
+  # authentication and not HTTP Digest.
+  "CVE-2026-10050",
+  # Jetty bound to Jetty 11 on this branch, no upgrade available
+  # consumers may upgrade to 11.0.29 with commercial support
+  "CVE-2026-6790",
 }
 
 ignore {

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -23,8 +23,8 @@ ext {
   kafkaVersion = '3.9.2'
   kafkaJunitVersion = '3.2.5' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5
   dbRiderVersion = '1.44.0'
-  kotlinVersion = '2.3.20'
-  kotlinxCoroutinesVersion = '1.10.2'
+  kotlinVersion = '2.4.10'
+  kotlinxCoroutinesVersion = '1.11.0'
   resilience4jVersion = '2.4.0'
   openTelemetryVersion = '1.62.0'
   openTelemetryAlpha2Version = '2.21.0-alpha'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     api "io.swagger.core.v3:swagger-models-jakarta:${swaggerCoreV3Version}"
 
     // sda-commons-server-auth
-    api "com.auth0:java-jwt:4.5.1"
+    api "com.auth0:java-jwt:4.6.0"
     api "org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion"
     api "org.bouncycastle:bcprov-jdk18on:$bouncyCastleVersion"
 

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -143,7 +143,7 @@ dependencies {
     api "io.swagger.core.v3:swagger-jaxrs2-jakarta:$swaggerCoreV3Version"
     api "io.swagger.core.v3:swagger-jaxrs2-servlet-initializer-v2-jakarta:$swaggerCoreV3Version"
     api "io.swagger.core.v3:swagger-annotations-jakarta:$swaggerCoreV3Version"
-    api "io.swagger.parser.v3:swagger-parser-v3:2.1.39"
+    api "io.swagger.parser.v3:swagger-parser-v3:2.1.45"
 
     api "io.micrometer:micrometer-core:$micrometerVersion"
     api "io.micrometer:micrometer-registry-prometheus-simpleclient:$micrometerVersion", {

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
     exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
   }
-  api enforcedPlatform("software.amazon.awssdk:bom:2.42.33")
+  api enforcedPlatform("software.amazon.awssdk:bom:2.49.3")
   api enforcedPlatform("jakarta.platform:jakarta.jakartaee-bom:11.0.0")
   api enforcedPlatform("io.opentelemetry:opentelemetry-bom:$openTelemetryVersion")
   api enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:${openTelemetryVersion}-alpha")

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     api "org.apache.httpcomponents.core5:httpcore5-h2:${apacheHttpCore5Version}"
     api "org.apache.httpcomponents.client5:httpclient5:${apacheHttpClient5Version}"
     api "org.apache.httpcomponents.client5:httpclient5-fluent:${apacheHttpClient5Version}"
-    api "io.github.classgraph:classgraph:4.8.184"
+    api "io.github.classgraph:classgraph:4.8.185"
 
     api "org.jboss.logging:jboss-logging:3.6.3.Final", {
       because "conflict between org.hibernate.validator:hibernate-validator and org.jboss.weld.se:weld-se-core"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -227,7 +227,7 @@ dependencies {
 
     //spring-data-mongodb can't be updated without breaking changes.
     //Instead we can add the spring-core dependency to fix spring related CVEs.
-    api 'org.springframework:spring-core:6.2.17'
+    api 'org.springframework:spring-core:6.2.19'
 
     api 'com.github.jknack:handlebars:4.5.3' //CVE-2026-55760 (check if still needed by next wiremock update)
   }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -18,7 +18,7 @@ ext {
   weldVersion = '5.1.2.Final'
   jacksonVersion = '2.22.1'
   jackson3Version = '3.2.1'
-  jsonUnitVersion = '5.1.1'
+  jsonUnitVersion = '5.1.2'
   scalaVersion = '2.13.18' // align transitive dependency from various modules, keep up to date
   kafkaVersion = '3.9.2'
   kafkaJunitVersion = '3.2.5' // Matching version: https://github.com/salesforce/kafka-junit/tree/master/kafka-junit5

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -14,7 +14,7 @@ ext {
   dropwizardVersion = '4.0.17'
   prometheusVersion = '0.16.0'
   micrometerVersion = '1.16.4'
-  swaggerCoreV3Version = '2.2.43'
+  swaggerCoreV3Version = '2.2.52'
   weldVersion = '5.1.2.Final'
   jacksonVersion = '2.22.1'
   jackson3Version = '3.2.1'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -31,7 +31,7 @@ ext {
   // should be aligned with transitive dependency of Spring Data MongoDB
   mongoDbDriverVersion = '5.6.5'
   tuprologVersion = '0.20.9' // don't upgrade separately! use version from database-rider
-  bouncyCastleVersion = '1.84'
+  bouncyCastleVersion = '1.85'
   victoolsVersion = '4.38.0'
   flywayVersion = '12.3.0'
 }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     api "org.objenesis:objenesis:3.5"
 
     // sda-commons-server-hibernate
-    api "org.postgresql:postgresql:42.7.11"
+    api "org.postgresql:postgresql:42.7.12"
     api "org.flywaydb:flyway-core:${flywayVersion}"
     api "org.flywaydb:flyway-database-postgresql:${flywayVersion}"
     // conflict between Flyway and tuprolog via DB Rider

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -17,7 +17,7 @@ ext {
   swaggerCoreV3Version = '2.2.43'
   weldVersion = '5.1.2.Final'
   jacksonVersion = '2.22.1'
-  jackson3Version = '3.1.4'
+  jackson3Version = '3.2.1'
   jsonUnitVersion = '5.1.1'
   scalaVersion = '2.13.18' // align transitive dependency from various modules, keep up to date
   kafkaVersion = '3.9.2'

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -33,7 +33,7 @@ ext {
   tuprologVersion = '0.20.9' // don't upgrade separately! use version from database-rider
   bouncyCastleVersion = '1.85'
   victoolsVersion = '4.38.0'
-  flywayVersion = '12.3.0'
+  flywayVersion = '12.11.0'
 }
 
 dependencies {

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -86,6 +86,8 @@ dependencies {
     api "org.jboss.logging:jboss-logging:3.6.3.Final", {
       because "conflict between org.hibernate.validator:hibernate-validator and org.jboss.weld.se:weld-se-core"
     }
+    api "at.yawk.lz4:lz4-java:1.11.1"
+
     api "org.yaml:snakeyaml:2.3", {
       because "conflict between com.github.database-rider:rider-core and com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
       because "vulnerability CVE-2022-1471 in 1.33 and below"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -229,6 +229,6 @@ dependencies {
     //Instead we can add the spring-core dependency to fix spring related CVEs.
     api 'org.springframework:spring-core:6.2.17'
 
-    api 'com.github.jknack:handlebars:4.5.2' //CVE-2026-55760 (check if still needed by next wiremock update)
+    api 'com.github.jknack:handlebars:4.5.3' //CVE-2026-55760 (check if still needed by next wiremock update)
   }
 }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     }
     api "at.yawk.lz4:lz4-java:1.11.1"
 
-    api "org.yaml:snakeyaml:2.3", {
+    api "org.yaml:snakeyaml:2.6", {
       because "conflict between com.github.database-rider:rider-core and com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
       because "vulnerability CVE-2022-1471 in 1.33 and below"
     }

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     api 'org.jboss.weld:weld-junit5:4.0.5.Final'
 
     // sda-commons-shared-*
-    api 'commons-io:commons-io:2.21.0'
+    api 'commons-io:commons-io:2.22.0'
 
     // sda-commons-server-opentelemetry
     api "io.opentelemetry.javaagent.instrumentation:opentelemetry-javaagent-apache-httpclient-5.0:${openTelemetryAlpha2Version}"

--- a/sda-commons-dependencies/build.gradle
+++ b/sda-commons-dependencies/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     api "org.objenesis:objenesis:3.5"
 
     // sda-commons-server-hibernate
-    api "org.postgresql:postgresql:42.7.12"
+    api "org.postgresql:postgresql:42.7.13"
     api "org.flywaydb:flyway-core:${flywayVersion}"
     api "org.flywaydb:flyway-database-postgresql:${flywayVersion}"
     // conflict between Flyway and tuprolog via DB Rider


### PR DESCRIPTION
After merge:
- [ ] Update release notes to clarify this is the last release for SDA Dropwizard Commons Version 8.
- [ ] Make branch release/8.x.x readonly