### PR TITLE
Avoid duplicate embed parameters and inherit field filter configuration

### DIFF
--- a/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
+++ b/sda-commons-server-openapi/src/main/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifier.java
@@ -7,24 +7,24 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.integration.api.OpenApiReader;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.ArraySchema;
-import io.swagger.v3.oas.models.media.ComposedSchema;
-import io.swagger.v3.oas.models.media.MediaType;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.media.*;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.QueryParameter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Adds the embeddable resources as query parameter, so they can be selected in the swagger ui. */
 @OpenAPIDefinition
 @SuppressWarnings({"java:S3740", "rawtypes"})
 // ignore "Raw types should not be used" introduced by swagger-core
 public class EmbedParameterModifier implements ReaderListener {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EmbedParameterModifier.class);
+
   private static final String EMBEDDED_PROPERTY = "_embedded";
+  private static final String EMBED_PARAMETER_NAME = "embed";
+  private static final String QUERY_PARAMETER_LOCATION = "query";
 
   @Override
   public void beforeScan(OpenApiReader reader, OpenAPI openAPI) {
@@ -80,8 +80,7 @@ public class EmbedParameterModifier implements ReaderListener {
               if (embedQueryParameter == null) {
                 return;
               }
-
-              operation.addParametersItem(embedQueryParameter);
+              addEmbedParameter(operation, embedQueryParameter);
             });
   }
 
@@ -91,6 +90,57 @@ public class EmbedParameterModifier implements ReaderListener {
     }
 
     return null;
+  }
+
+  private void addEmbedParameter(Operation operation, Parameter generatedParameter) {
+    Parameter existingEmbedParameter = null;
+
+    if (operation.getParameters() != null) {
+      for (Parameter parameter : operation.getParameters()) {
+        if (parameter == null || !isEmbedQueryParameter(parameter)) {
+          continue;
+        }
+
+        if (existingEmbedParameter != null) {
+          throw new IllegalStateException(
+              "The operation contains multiple 'embed' query parameters already.");
+        }
+
+        existingEmbedParameter = parameter;
+      }
+    }
+
+    if (existingEmbedParameter == null) {
+      operation.addParametersItem(generatedParameter);
+      return;
+    }
+
+    if (!isCompatibleEmbedParameter(existingEmbedParameter)) {
+      throw new IllegalStateException(
+          "The query parameter 'embed' conflicts with the generated embed parameter. "
+              + "It must be an array of strings or use a different name.");
+    }
+
+    LOGGER.info(
+        "A compatible 'embed' query parameter already exists for operation '{}'. "
+            + "Adding another one was skipped.",
+        operation.getOperationId());
+  }
+
+  private boolean isEmbedQueryParameter(Parameter parameter) {
+    return EMBED_PARAMETER_NAME.equals(parameter.getName())
+        && QUERY_PARAMETER_LOCATION.equals(parameter.getIn());
+  }
+
+  private boolean isCompatibleEmbedParameter(Parameter parameter) {
+    Schema<?> schema = parameter.getSchema();
+
+    if (schema == null || !"array".equals(schema.getType())) {
+      return false;
+    }
+
+    Schema<?> itemSchema = schema.getItems();
+    return itemSchema != null && "string".equals(itemSchema.getType());
   }
 
   private String getResponseModelName(MediaType responseSchema) {
@@ -166,7 +216,7 @@ public class EmbedParameterModifier implements ReaderListener {
 
       return new QueryParameter()
           .schema(new ArraySchema().items(new StringSchema()._enum(embeddableObjects)))
-          .name("embed")
+          .name(EMBED_PARAMETER_NAME)
           .description(
               "Select linked resources that should be resolved and embedded into the response");
     }

--- a/sda-commons-server-openapi/src/test/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifierTest.java
+++ b/sda-commons-server-openapi/src/test/java/org/sdase/commons/optional/server/openapi/parameter/embed/EmbedParameterModifierTest.java
@@ -1,13 +1,137 @@
 package org.sdase.commons.optional.server.openapi.parameter.embed;
 
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.BooleanSchema;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.ObjectSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import io.swagger.v3.oas.models.parameters.QueryParameter;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import org.junit.jupiter.api.Test;
 
 class EmbedParameterModifierTest {
 
+  private static final String RESOURCE_SCHEMA_NAME = "TestResource";
+  private static final String EMBEDDABLE_PROPERTY_NAME = "relatedResources";
+  private static final String TEST_PATH = "/resources/{id}";
+
   @Test
   void shouldReturnNullForNullSchemas() {
     assertThat(new EmbedParameterModifier().getOriginalRef(null)).isNull();
+  }
+
+  @Test
+  void shouldAddEmbedParameterWhenItDoesNotExist() {
+    Operation operation = new Operation();
+    OpenAPI openApi = createOpenApi(operation);
+
+    new EmbedParameterModifier().afterScan(null, openApi);
+
+    assertThat(operation.getParameters())
+        .singleElement()
+        .satisfies(
+            parameter -> {
+              assertThat(parameter.getName()).isEqualTo("embed");
+              assertThat(parameter.getIn()).isEqualTo("query");
+              assertThat(parameter.getSchema()).isInstanceOf(ArraySchema.class);
+
+              Schema<?> itemSchema = parameter.getSchema().getItems();
+
+              assertThat(itemSchema)
+                  .isInstanceOfSatisfying(
+                      StringSchema.class,
+                      stringSchema ->
+                          assertThat(stringSchema.getEnum())
+                              .containsExactly(EMBEDDABLE_PROPERTY_NAME));
+            });
+  }
+
+  @Test
+  void shouldKeepCompatibleExistingEmbedParameter() {
+    Parameter existingParameter =
+        new QueryParameter()
+            .name("embed")
+            .description("Parameter from imported specification")
+            .required(false)
+            .style(Parameter.StyleEnum.FORM)
+            .explode(true)
+            .schema(new ArraySchema().items(new StringSchema()));
+
+    Operation operation = new Operation().addParametersItem(existingParameter);
+    OpenAPI openApi = createOpenApi(operation);
+
+    new EmbedParameterModifier().afterScan(null, openApi);
+
+    assertThat(operation.getParameters()).containsExactly(existingParameter);
+  }
+
+  @Test
+  void shouldRejectIncompatibleExistingEmbedParameter() {
+    Parameter existingParameter = new QueryParameter().name("embed").schema(new BooleanSchema());
+
+    Operation operation = new Operation().addParametersItem(existingParameter);
+    OpenAPI openApi = createOpenApi(operation);
+
+    EmbedParameterModifier modifier = new EmbedParameterModifier();
+
+    assertThatThrownBy(() -> modifier.afterScan(null, openApi))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "The query parameter 'embed' conflicts with the generated embed parameter. "
+                + "It must be an array of strings or use a different name.");
+  }
+
+  @Test
+  void shouldRejectMultipleExistingEmbedParameters() {
+    Parameter firstEmbedParameter =
+        new QueryParameter().name("embed").schema(new ArraySchema().items(new StringSchema()));
+
+    Parameter secondEmbedParameter =
+        new QueryParameter().name("embed").schema(new ArraySchema().items(new StringSchema()));
+
+    Operation operation =
+        new Operation()
+            .addParametersItem(firstEmbedParameter)
+            .addParametersItem(secondEmbedParameter);
+
+    OpenAPI openApi = createOpenApi(operation);
+
+    EmbedParameterModifier modifier = new EmbedParameterModifier();
+
+    assertThatThrownBy(() -> modifier.afterScan(null, openApi))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("The operation contains multiple 'embed' query parameters already.");
+  }
+
+  private OpenAPI createOpenApi(Operation operation) {
+    Schema<?> embeddedSchema =
+        new ObjectSchema().addProperty(EMBEDDABLE_PROPERTY_NAME, new ArraySchema());
+
+    Schema<?> resourceSchema = new ObjectSchema().addProperty("_embedded", embeddedSchema);
+
+    MediaType responseMediaType =
+        new MediaType().schema(new Schema<>().$ref("#/components/schemas/" + RESOURCE_SCHEMA_NAME));
+
+    ApiResponse response =
+        new ApiResponse().content(new Content().addMediaType(APPLICATION_JSON, responseMediaType));
+
+    operation.setResponses(new ApiResponses().addApiResponse("200", response));
+
+    return new OpenAPI()
+        .components(new Components().addSchemas(RESOURCE_SCHEMA_NAME, resourceSchema))
+        .paths(new Paths().addPathItem(TEST_PATH, new PathItem().get(operation)));
   }
 }


### PR DESCRIPTION
## Problem

`EmbedParameterModifier` adds an `embed` query parameter even when one already exists, resulting in duplicate parameters in the generated OpenAPI document.

## Change

Check for an existing query parameter with `name = embed` before adding the generated parameter.

## Result

The modifier becomes idempotent and preserves explicitly configured parameter settings.


## Problem

`@EnableFieldFilter` is not inherited by subclasses. Abstract base resource classes must therefore repeat the annotation on every concrete implementation.

## Change

Add `@Inherited` to `EnableFieldFilter`.

## Result

Concrete subclasses automatically use the field-filter configuration declared on their base class and may still override it locally.
